### PR TITLE
docs/resources/derived_column: multiline expressions

### DIFF
--- a/docs/resources/derived_column.md
+++ b/docs/resources/derived_column.md
@@ -16,6 +16,28 @@ resource "honeycombio_derived_column" "duration_ms_log" {
 
   dataset = var.dataset
 }
+
+resource "honeycombio_derived_column" "example_multiline_expr" { 
+  alias       = "example_multiline_expr"
+  description = "Example of multiline expression"
+ 
+  expression  = trimspace(<<EOT
+  IF(
+    REG_MATCH($request, `PATCH https://www.foo.[a-z]+:443/gw/api/[0-9]+/bar?`),
+    AND(
+      OR(
+        STARTS_WITH($backend_status_code, "2"), 
+        STARTS_WITH($backend_status_code, "3"), 
+        STARTS_WITH($backend_status_code, "4")
+      ),
+      LTE($backend_processing_time, 2)
+    )
+  )
+  EOT
+  )
+
+  dataset = var.dataset
+}
 ```
 
 ## Argument Reference
@@ -24,8 +46,10 @@ The following arguments are supported:
 
 * `dataset` - (Required) The dataset this derived column is added to.
 * `alias` - (Required) The name of the derived column. Must be unique per dataset.
-* `expression` - (Required) The function of the derived column. See [Derived Column Syntax](https://docs-ismith.honeycomb.io/working-with-your-data/customizing-your-query/derived-columns/#derived-column-syntax).
+* `expression` - (Required) The function of the derived column. See [Derived Column Syntax](https://docs.honeycomb.io/working-with-your-data/customizing-your-query/derived-columns/#derived-column-syntax).
 * `description` - (Optional) A description that is shown in the UI.
+
+~> **Note** Use `trimline()` for multiline values of `expression`.
 
 ## Attribute Reference
 


### PR DESCRIPTION
Added an information regarding the multiline expressions in derived columns. 

- added an example of multiline expression
- added an advise to use `trimline()`
- fixed a broken link

Tested in [doc_preview](https://registry.terraform.io/tools/doc-preview) and spellchecked.

Related issue: #81 