### PR TITLE
Restore CI functionality after project transfer

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
       - uses: kvrhdn/gha-buildevents@v1
         with:
           apikey: ${{ secrets.HONEYCOMBIO_APIKEY }}
-          dataset: ${{ secrets.HONEYCOMBIO_DATASET_URL_ENCODED }}
+          dataset: ${{ secrets.HONEYCOMBIO_DATASET }}
           job-status: ${{ job.status }}
 
       - uses: actions/setup-go@v2
@@ -35,7 +35,9 @@ jobs:
           HONEYCOMBIO_APIKEY: ${{ secrets.HONEYCOMBIO_APIKEY }}
           HONEYCOMBIO_DATASET: ${{ secrets.HONEYCOMBIO_DATASET }}
           TF_ACC: 1
-        run: go test -v -coverprofile=coverage.txt -covermode=atomic ./...
+        run: |
+          ./scripts/setup-testsuite-dataset
+          go test -v -coverprofile=coverage.txt -covermode=atomic ./...
 
       - uses: codecov/codecov-action@v2.1.0
         with:
@@ -49,7 +51,7 @@ jobs:
       - uses: kvrhdn/gha-buildevents@v1
         with:
           apikey: ${{ secrets.HONEYCOMBIO_APIKEY }}
-          dataset: ${{ secrets.HONEYCOMBIO_DATASET_URL_ENCODED }}
+          dataset: ${{ secrets.HONEYCOMBIO_DATASET }}
           job-status: ${{ job.status }}
 
       - uses: actions/setup-go@v2

--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -3,10 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - '*'
-
-env:
-  HONEYCOMBIO_DATASET: kvrhdn-terraform-provider-honeycombio
+      - "v*"
 
 jobs:
   goreleaser:
@@ -14,29 +11,33 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: kvrhdn/gha-buildevents@v1
+      - name: setup Honeycomb BuildEvents
+        uses: kvrhdn/gha-buildevents@v1
         with:
           apikey: ${{ secrets.HONEYCOMBIO_APIKEY }}
           dataset: ${{ env.HONEYCOMBIO_DATASET }}
           job-status: ${{ job.status }}
-
-      - uses: actions/setup-go@v2
+      - name: Checkout
+        uses: actions/checkout@v2.4.0
+      - name: Unshallow
+        run: git fetch --prune --unshallow
+      - name: Set up Go
+        uses: actions/setup-go@v2
         with:
           go-version: 1.16
-
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-
-      - uses: crazy-max/ghaction-import-gpg@v4
-        with:
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.PASSPHRASE }}
+      - name: Import GPG key
         id: import_gpg
-
-      - uses: goreleaser/goreleaser-action@v2
+        uses: hashicorp/ghaction-import-gpg@v2.1.0
+        env:
+          # These secrets will need to be configured for the repository:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          PASSPHRASE: ${{ secrets.PASSPHRASE }}
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2.8.0
         with:
+          version: latest
           args: release --rm-dist
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+          # GitHub sets this automatically
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,13 +16,13 @@ We use [go-honeycombio](https://github.com/kvrhdn/go-honeycombio) to call the va
 
 ### What's in progress and what's next?
 
-We maintain [an activity board](https://github.com/kvrhdn/terraform-provider-honeycombio/projects/1) with all the work that is currently being worked on and/or considered. Hopefully this can give a sense of what is next to come. The board is intended to create overview across the project, it's not a strict plan of action.
+We maintain [an activity board](https://github.com/honeycombio/terraform-provider-honeycombio/projects/1) with all the work that is currently being worked on and/or considered. Hopefully this can give a sense of what is next to come. The board is intended to create overview across the project, it's not a strict plan of action.
 
 ## Contributing changes
 
 ### Preview document changes
 
-Hashicorp has a tool to preview documentation. Visit [registry.terraform.io/tools/doc-preview](https://registry.terraform.io/tools/doc-preview). 
+Hashicorp has a tool to preview documentation. Visit [registry.terraform.io/tools/doc-preview](https://registry.terraform.io/tools/doc-preview).
 
 ### Running the test
 
@@ -30,17 +30,7 @@ Most of the tests are acceptance tests, which will call real APIs. To run the te
 
 First, **create an API key**. Initially you'll have to check all permissions, but _Send Events_ and _Create Datasets_ can be disabled once setup is done.
 
-Next, **initialize the dataset by sending a test event**. This will 1) create the dataset and 2) create columns that are used in the tests.  We need the following columns to exist: `duration_ms`, `trace.parent_id` and `app.tenant`.
-
-The easiest way to send an event is with [honeyvent](https://github.com/honeycombio/honeyvent):
-
-```sh
-# install honeyvent - you can also clone the repository and build it
-go get github.com/honeycombio/honeyvent
-
-# use honeyvent to send an event with dummy values
-honeyvent -k <your API key> -d <dataset> -n duration_ms -v 100 -n trace.parent_id -v abc -n app.tenant -v def
-```
+Next, **initialize the dataset**. The helper script [setup-testsuite-dataset](scripts/setup-testsuite-dataset) will create the dataset and required columns that are used in the tests.
 
 Finally, **run the acceptance tests** by passing the API key and dataset as environment variables:
 
@@ -99,20 +89,21 @@ To properly setup the GitHub Actions, add the following secrets:
 
 - `HONEYCOMBIO_APIKEY`: an API key for Honeycombio
 - `HONEYCOMBIO_DATASET`: name of the test dataset
-- `HONEYCOMBIO_DATASET_URL_ENCODED`: the same as `HONEYCOMBIO_DATASET`, but replace `/` with `-`. I.e. `foo/bar` becomes `foo-bar`.
 
 ## Release procedure
 
 To release a new version of the Terraform provider a binary has to be built for a list of platforms ([more information](https://www.terraform.io/docs/registry/providers/publishing.html#creating-a-github-release)). This process is automated with GoReleaser and GitHub Actions.
 
-- Create [a new release](https://github.com/kvrhdn/terraform-provider-honeycombio/releases/new)
+- Create [a new release](https://github.com/honeycombio/terraform-provider-honeycombio/releases/new)
 - The tag and release title should be a semantic version
 - To follow convention of other Terraform providers the description has the following sections (each section can be omitted if empty):
-```
+
+```text
 NOTES:
 FEATURES:
 ENHANCEMENTS:
 BUG FIXES:
 ```
+
 - After that tag has been created a GitHub Actions workflow Release will run and add binaries to the release (this workflow can run over 5 minutes)
-- Once the tag is created, the [Terraform Registry](https://registry.terraform.io/providers/kvrhdn/honeycombio/latest) should also list the new version
+- Once the tag is created, the [Terraform Registry](https://registry.terraform.io/providers/honeycombio/honeycombio/latest) should also list the new version

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Honeycomb.io Terraform Provider
 
-[![CI](https://github.com/kvrhdn/terraform-provider-honeycombio/workflows/CI/badge.svg)](https://github.com/kvrhdn/terraform-provider-honeycombio/actions)
-[![Go Report Card](https://goreportcard.com/badge/github.com/kvrhdn/terraform-provider-honeycombio)](https://goreportcard.com/report/github.com/kvrhdn/terraform-provider-honeycombio)
-[![codecov](https://codecov.io/gh/kvrhdn/terraform-provider-honeycombio/branch/main/graph/badge.svg)](https://codecov.io/gh/kvrhdn/terraform-provider-honeycombio)
+[![CI](https://github.com/honeycombio/terraform-provider-honeycombio/workflows/CI/badge.svg)](https://github.com/honeycombio/terraform-provider-honeycombio/actions)
+[![Go Report Card](https://goreportcard.com/badge/github.com/honeycombio/terraform-provider-honeycombio)](https://goreportcard.com/report/github.com/honeycombio/terraform-provider-honeycombio)
+[![codecov](https://codecov.io/gh/honeycombio/terraform-provider-honeycombio/branch/main/graph/badge.svg)](https://codecov.io/gh/honeycombio/terraform-provider-honeycombio)
 [![Terraform Registry](https://img.shields.io/github/v/release/kvrhdn/terraform-provider-honeycombio?color=5e4fe3&label=Terraform%20Registry&logo=terraform&sort=semver)](https://registry.terraform.io/providers/kvrhdn/honeycombio/latest)
 
 A Terraform provider for Honeycomb.io.

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -11,7 +11,7 @@ import (
 
 func init() {
 	// load environment values from a .env, if available
-	_ = godotenv.Load()
+	_ = godotenv.Load("../.env")
 }
 
 func newTestClient(t *testing.T) *Client {

--- a/client/dataset_test.go
+++ b/client/dataset_test.go
@@ -40,7 +40,7 @@ func TestDatasets(t *testing.T) {
 
 	t.Run("Create", func(t *testing.T) {
 		createDataset := &Dataset{
-			Name: "kvrhdn/go-honeycombio",
+			Name: datasetName,
 		}
 		d, err := c.Datasets.Create(ctx, createDataset)
 

--- a/honeycombio/data_source_datasets_test.go
+++ b/honeycombio/data_source_datasets_test.go
@@ -22,7 +22,7 @@ func TestAccDataSourceHoneycombioDataset_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDataSourceDatasetConfig([]string{"starts_with = \"kvrhdn/terraform-\""}),
+				Config: testAccDataSourceDatasetConfig([]string{"starts_with = \"" + string(dataset[0:2]) + "\""}),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckOutputContains("names", dataset),
 				),

--- a/honeycombio/resource_board_test.go
+++ b/honeycombio/resource_board_test.go
@@ -92,6 +92,7 @@ func testAccCheckBoardExists(t *testing.T, name string) resource.TestCheckFunc {
 					Caption:    "test query 0",
 					QueryStyle: honeycombio.BoardQueryStyleGraph,
 					Dataset:    testAccDataset(),
+					QueryID:    createdBoard.Queries[0].QueryID,
 					Query: &honeycombio.QuerySpec{
 						Calculations: []honeycombio.CalculationSpec{
 							{
@@ -113,6 +114,7 @@ func testAccCheckBoardExists(t *testing.T, name string) resource.TestCheckFunc {
 					Caption:    "test query 1",
 					QueryStyle: honeycombio.BoardQueryStyleCombo,
 					Dataset:    testAccDataset(),
+					QueryID:    createdBoard.Queries[1].QueryID,
 					Query: &honeycombio.QuerySpec{
 						Calculations: []honeycombio.CalculationSpec{
 							{

--- a/scripts/setup-testsuite-dataset
+++ b/scripts/setup-testsuite-dataset
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+
+# the integration testsuite requires that a dataset and particular columns already exist
+# this little script handles that bit of bootstrapping in an idempotent fashion
+
+HONEYCOMB_API="${HONEYCOMB_API:=https://api.honeycomb.io}"
+COLUMNS_API="${HONEYCOMB_API}/1/columns"
+DATASETS_API="${HONEYCOMB_API}/1/datasets"
+
+# a map of required columns for the integration tests and their types
+declare -A REQUIRED_COLUMNS=(
+  [trace.parent_id]=string
+  [trace.trace_id]=string
+  [app.tenant]=string
+  [column_1]=string
+  [column_2]=string
+  [duration_ms]=float
+)
+
+log () {
+  echo "$(date +"%Y-%m-%dT%H:%M:%S%z") $1"
+}
+
+dataset_exists() {
+  local name="$1"
+
+  curl -sf -H "x-honeycomb-team: $HONEYCOMBIO_APIKEY" \
+    -X GET "${DATASETS_API}/${HONEYCOMBIO_DATASET}" >/dev/null
+}
+
+create_dataset_if_missing () {
+  local name="$1"
+
+  if ! dataset_exists "$name"; then
+    curl -sf -H "x-honeycomb-team: $HONEYCOMBIO_APIKEY" \
+      -X POST "${DATASETS_API}" \
+      -d '{"name": "'"$name"'"}' >/dev/null
+    status_code=$?
+    if [[ $status_code -ne 0 ]]; then
+      log "error creating dataset \"$name\""
+    fi
+
+    log "created dataset \"$name}\""
+  fi
+}
+
+column_exists () {
+  local name="$1"
+
+  curl -sf -H "x-honeycomb-team: $HONEYCOMBIO_APIKEY" \
+    -X GET "${COLUMNS_API}/${HONEYCOMBIO_DATASET}?key_name=${name}" >/dev/null
+}
+
+create_column_if_missing () {
+  local name="$1"
+  local type="$2"
+
+  if ! column_exists "$name"; then
+    curl -sf -H "x-honeycomb-team: $HONEYCOMBIO_APIKEY" \
+      -X POST "${COLUMNS_API}/${HONEYCOMBIO_DATASET}" \
+      -d '{"key_name": "'"$name"'", "type": "'"$type"'"}' >/dev/null
+    status_code=$?
+    if [[ $status_code -ne 0 ]]; then
+      log "error creating column \"$name\""
+    fi
+
+    log "created column \"$name\" in \"${HONEYCOMBIO_DATASET}\""
+  fi
+}
+
+if [ -z "${HONEYCOMBIO_APIKEY+x}" ]; then
+  echo "HONEYCOMBIO_APIKEY is not set"
+  exit 255
+fi
+
+if [ -z "${HONEYCOMBIO_DATASET+x}" ]; then
+  echo "HONEYCOMBIO_DATASET is not set"
+  exit 255
+fi
+
+if ! create_dataset_if_missing "${HONEYCOMBIO_DATASET}"; then
+  exit 255
+fi
+
+err=0
+for col in "${!REQUIRED_COLUMNS[@]}"; do
+  if ! create_column_if_missing "$col" "${REQUIRED_COLUMNS[$col]}"; then
+    (( err++ ))
+  fi
+done
+
+if [[ $err -ne 0 ]]; then
+  # failed to create some columns: fail out
+  exit 255
+fi


### PR DESCRIPTION
Test suite is now decoupled from original dataset used for testing, keys updated to use an Internal test team, and initial pass on the markdown files done to update `kvrhdn/terraform-provider-honeycombio` -> `honeycombio/terraform-provider-honeycombio`