### PR TITLE
rename query datasource to query_specification

### DIFF
--- a/docs/data-sources/query_specification.md
+++ b/docs/data-sources/query_specification.md
@@ -1,4 +1,4 @@
-# Data Source: honeycombio_query
+# Data Source: honeycombio_query_specification
 
 Construct a query that can be used in triggers and boards. For more information about the query specification, check out [Query Specification](https://docs.honeycomb.io/api/query-specification/).
 
@@ -7,7 +7,7 @@ The `json` attribute contains a serialized JSON representation which can be pass
 ## Example Usage
 
 ```hcl
-data "honeycombio_query" "example" {
+data "honeycombio_query_specification" "example" {
   # zero or more calculation blocks
   calculation {
     op     = "AVG"
@@ -34,7 +34,7 @@ data "honeycombio_query" "example" {
 }
 
 output "json_query" {
-    value = data.honeycombio_query.example.json
+    value = data.honeycombio_query_specification.example.json
 }
 ```
 

--- a/docs/data-sources/trigger_recipient.md
+++ b/docs/data-sources/trigger_recipient.md
@@ -16,7 +16,7 @@ data "honeycombio_trigger_recipient" "slack" {
   target  = "honeycomb-triggers"
 }
 
-data "honeycombio_query" "example" {
+data "honeycombio_query_specification" "example" {
   calculation {
     op     = "AVG"
     column = "duration_ms"
@@ -26,7 +26,7 @@ data "honeycombio_query" "example" {
 resource "honeycombio_trigger" "example" {
   name        = "Requests are slower than usuals"
 
-  query_json = data.honeycombio_query.example.json
+  query_json = data.honeycombio_query_specification.example.json
   dataset    = var.dataset
 
   threshold {

--- a/docs/resources/board.md
+++ b/docs/resources/board.md
@@ -13,7 +13,7 @@ locals {
   percentiles = ["P50", "P75", "P90", "P95"]
 }
 
-data "honeycombio_query" "query" {
+data "honeycombio_query_specification" "query" {
   count = length(local.percentiles)
 
   calculation {
@@ -46,7 +46,7 @@ resource "honeycombio_board" "board" {
       caption     = query.value
       query_style = "combo"
       dataset     = var.dataset
-      query_json  = data.honeycombio_query.query[query.key].json
+      query_json  = data.honeycombio_query_specification.query[query.key].json
     }
   }
 }
@@ -63,7 +63,7 @@ The following arguments are supported:
 
 Each board configuration may have zero or more `query` blocks, which accepts the following arguments:
 
-* `query_json` - (Required) A JSON object describing the query according to the [Query Specification](https://docs.honeycomb.io/api/query-specification/#fields-on-a-query-specification). While the JSON can be constructed manually, it is easiest to use the [`honeycombio_query`](../data-sources/query.md) data source.
+* `query_json` - (Required) A JSON object describing the query according to the [Query Specification](https://docs.honeycomb.io/api/query-specification/#fields-on-a-query-specification). While the JSON can be constructed manually, it is easiest to use the [`honeycombio_query_specification`](../data-sources/query_specification.md) data source.
 * `dataset` - (Required) The dataset this query is associated with.
 * `caption` - (Optional) A description of the query that will be displayed on the board. Supports markdown.
 * `query_style` - (Optional) How the query should be displayed within the board, either `graph` (the default), `table` or `combo`.

--- a/docs/resources/query.md
+++ b/docs/resources/query.md
@@ -11,7 +11,7 @@ variable "dataset" {
   type = string
 }
 
-data "honeycombio_query" "test_query" {
+data "honeycombio_query_specification" "test_query" {
   calculation {
     op     = "AVG"
     column = "duration_ms"
@@ -26,7 +26,7 @@ data "honeycombio_query" "test_query" {
 
 resource "honeycombio_query" "test_query" {
   dataset = "%s"
-  query_json = data.honeycombio_query.test_query.json
+  query_json = data.honeycombio_query_specification.test_query.json
 }
 ```
 
@@ -35,7 +35,7 @@ resource "honeycombio_query" "test_query" {
 The following arguments are supported:
 
 * `dataset` - (Required) The dataset this query is added to.
-* `query_json` - (Required) A JSON object describing the query according to the [Query Specification](https://docs.honeycomb.io/api/query-specification/#fields-on-a-query-specification). While the JSON can be constructed manually, it is easiest to use the [`honeycombio_query`](../data-sources/query.md) data source.
+* `query_json` - (Required) A JSON object describing the query according to the [Query Specification](https://docs.honeycomb.io/api/query-specification/#fields-on-a-query-specification). While the JSON can be constructed manually, it is easiest to use the [`honeycombio_query_specification`](../data-sources/query_specification.md) data source.
 
 ## Attribute Reference
 

--- a/docs/resources/query_annotation.md
+++ b/docs/resources/query_annotation.md
@@ -3,7 +3,7 @@
 Creates a query annotation in a dataset.
 
 -> **Note** A query annotation points to a specific query. Any change to the query will result in a new query ID and the annotation will no longer apply.
-If you use the "honeycombio_query" to determine the `query_id` parameter (as in the example below), Terraform will destroy the old query annotation and create a new one.
+If you use the "honeycombio_query_specification" to determine the `query_id` parameter (as in the example below), Terraform will destroy the old query annotation and create a new one.
 If this is wrong for your use case, please open an issue in [kvrhdn/terraform-provider-honeycombio](https://github.com/kvrhdn/terraform-provider-honeycombio).
 
 ## Example Usage
@@ -13,7 +13,7 @@ variable "dataset" {
   type = string
 }
 
-data "honeycombio_query" "test_query" {
+data "honeycombio_query_specification" "test_query" {
   calculation {
     op     = "AVG"
     column = "duration_ms"
@@ -28,7 +28,7 @@ data "honeycombio_query" "test_query" {
 
 resource "honeycombio_query" "test_query" {
   dataset    = var.dataset
-  query_json = data.honeycombio_query.test_query.json
+  query_json = data.honeycombio_query_specification.test_query.json
 }
 
 resource "honeycombio_query_annotation" "test_annotation" {

--- a/docs/resources/trigger.md
+++ b/docs/resources/trigger.md
@@ -9,7 +9,7 @@ variable "dataset" {
   type = string
 }
 
-data "honeycombio_query" "example" {
+data "honeycombio_query_specification" "example" {
   calculation {
     op     = "AVG"
     column = "duration_ms"
@@ -25,7 +25,7 @@ resource "honeycombio_trigger" "example" {
   name        = "Requests are slower than usuals"
   description = "Average duration of all requests for the last 10 minutes."
 
-  query_json = data.honeycombio_query.example.json
+  query_json = data.honeycombio_query_specification.example.json
   dataset    = var.dataset
 
   frequency = 600 // in seconds, 10 minutes
@@ -54,7 +54,7 @@ The following arguments are supported:
 
 * `name` - (Required) Name of the trigger.
 * `dataset` - (Required) The dataset this trigger is associated with.
-* `query_json` - (Required) A JSON object describng the query according to the [Query Specification](https://docs.honeycomb.io/api/query-specification/#fields-on-a-query-specification). While the JSON can be constructed manually, it is easiest to use the [`honeycombio_query`](../data-sources/query.md) data source.
+* `query_json` - (Required) A JSON object describng the query according to the [Query Specification](https://docs.honeycomb.io/api/query-specification/#fields-on-a-query-specification). While the JSON can be constructed manually, it is easiest to use the [`honeycombio_query_specification`](../data-sources/query_specification.md) data source.
 * `threshold` - (Required) A configuration block (described below) describing the threshold of the trigger.
 * `description` - (Optional) Description of the trigger.
 * `disabled` - (Optional) The state of the trigger. If true, the trigger will not be run. Defaults to false.

--- a/example/board/main.tf
+++ b/example/board/main.tf
@@ -14,7 +14,7 @@ locals {
   percentiles = ["P50", "P75", "P90", "P95"]
 }
 
-data "honeycombio_query" "query" {
+data "honeycombio_query_specification" "query" {
   count = length(local.percentiles)
 
   calculation {
@@ -45,7 +45,7 @@ resource "honeycombio_board" "board" {
     content {
       caption    = query.value
       dataset    = var.dataset
-      query_json = data.honeycombio_query.query[query.key].json
+      query_json = data.honeycombio_query_specification.query[query.key].json
     }
   }
 }

--- a/example/trigger/main.tf
+++ b/example/trigger/main.tf
@@ -10,7 +10,7 @@ variable "dataset" {
   type = string
 }
 
-data "honeycombio_query" "query" {
+data "honeycombio_query_specification" "query" {
   calculation {
     op     = "AVG"
     column = "duration_ms"
@@ -35,7 +35,7 @@ resource "honeycombio_trigger" "trigger" {
 
   disabled = false
 
-  query_json = data.honeycombio_query.query.json
+  query_json = data.honeycombio_query_specification.query.json
   dataset    = var.dataset
 
   frequency = 900 // in seconds, 15 minutes

--- a/example/trigger_with_slack_recipient/main.tf
+++ b/example/trigger_with_slack_recipient/main.tf
@@ -10,7 +10,7 @@ variable "dataset" {
   type = string
 }
 
-data "honeycombio_query" "query" {
+data "honeycombio_query_specification" "query" {
   calculation {
     op     = "AVG"
     column = "duration_ms"
@@ -29,7 +29,7 @@ data "honeycombio_trigger_recipient" "slack" {
 resource "honeycombio_trigger" "trigger" {
   name = "Requests are slower than usual"
 
-  query_json = data.honeycombio_query.query.json
+  query_json = data.honeycombio_query_specification.query.json
   dataset    = var.dataset
 
   threshold {

--- a/honeycombio/data_source_query_specification.go
+++ b/honeycombio/data_source_query_specification.go
@@ -13,9 +13,9 @@ import (
 	"github.com/honeycombio/terraform-provider-honeycombio/honeycombio/internal/hashcode"
 )
 
-func dataSourceHoneycombioQuery() *schema.Resource {
+func dataSourceHoneycombioQuerySpec() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourceHoneycombioQueryRead,
+		ReadContext: dataSourceHoneycombioQuerySpecRead,
 
 		Schema: map[string]*schema.Schema{
 			"calculation": {
@@ -148,7 +148,7 @@ func dataSourceHoneycombioQuery() *schema.Resource {
 	}
 }
 
-func dataSourceHoneycombioQueryRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceHoneycombioQuerySpecRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	calculations, err := extractCalculations(d)
 	if err != nil {
 		return diag.FromErr(err)

--- a/honeycombio/data_source_query_specification_test.go
+++ b/honeycombio/data_source_query_specification_test.go
@@ -24,7 +24,7 @@ func TestAccDataSourceHoneycombioQuery_basic(t *testing.T) {
 }
 
 const testAccQueryConfig = `
-data "honeycombio_query" "test" {
+data "honeycombio_query_specification" "test" {
     calculation {
         op     = "AVG"
         column = "duration_ms"
@@ -63,7 +63,7 @@ data "honeycombio_query" "test" {
 }
 
 output "query_json" {
-    value = data.honeycombio_query.test.json
+    value = data.honeycombio_query_specification.test.json
 }`
 
 //Note: By default go encodes `<` and `>` for html, hence the `\u003e`
@@ -126,7 +126,7 @@ func TestAccDataSourceHoneycombioQuery_validationChecks(t *testing.T) {
 var testStepsQueryValidationChecks_calculation = []resource.TestStep{
 	{
 		Config: `
-data "honeycombio_query" "test" {
+data "honeycombio_query_specification" "test" {
   calculation {
     op     = "COUNT"
     column = "we-should-not-specify-a-column-with-COUNT"
@@ -137,7 +137,7 @@ data "honeycombio_query" "test" {
 	},
 	{
 		Config: `
-data "honeycombio_query" "test" {
+data "honeycombio_query_specification" "test" {
   calculation {
     op     = "AVG"
   }
@@ -150,7 +150,7 @@ data "honeycombio_query" "test" {
 var testStepsQueryValidationChecks_filter = []resource.TestStep{
 	{
 		Config: `
-data "honeycombio_query" "test" {
+data "honeycombio_query_specification" "test" {
   filter {
     column = "column"
     op     = "exists"
@@ -162,7 +162,7 @@ data "honeycombio_query" "test" {
 	},
 	{
 		Config: `
-data "honeycombio_query" "test" {
+data "honeycombio_query_specification" "test" {
   filter {
     column = "column"
     op     = ">"
@@ -173,7 +173,7 @@ data "honeycombio_query" "test" {
 	},
 	{
 		Config: `
-data "honeycombio_query" "test" {
+data "honeycombio_query_specification" "test" {
   filter {
     column        = "column"
     op            = ">"
@@ -186,7 +186,7 @@ data "honeycombio_query" "test" {
 	},
 	{
 		Config: `
-data "honeycombio_query" "test" {
+data "honeycombio_query_specification" "test" {
   filter {
     column        = "column"
     op            = "in"
@@ -200,7 +200,7 @@ data "honeycombio_query" "test" {
 
 func testStepsQueryValidationChecks_limit() []resource.TestStep {
 	var queryLimitFmt = `
-data "honeycombio_query" "test" {
+data "honeycombio_query_specification" "test" {
   limit = %d
 }`
 	return []resource.TestStep{
@@ -222,7 +222,7 @@ data "honeycombio_query" "test" {
 var testStepsQueryValidationChecks_time = []resource.TestStep{
 	{
 		Config: `
-data "honeycombio_query" "test" {
+data "honeycombio_query_specification" "test" {
   time_range = 7200
   start_time = 1577836800
   end_time   = 1577844000
@@ -232,7 +232,7 @@ data "honeycombio_query" "test" {
 	},
 	{
 		Config: `
-data "honeycombio_query" "test" {
+data "honeycombio_query_specification" "test" {
   time_range  = 120
   granularity = 13
 }
@@ -241,7 +241,7 @@ data "honeycombio_query" "test" {
 	},
 	{
 		Config: `
-data "honeycombio_query" "test" {
+data "honeycombio_query_specification" "test" {
   time_range  = 60000
   granularity = 59
 }
@@ -267,7 +267,7 @@ func TestAccDataSourceHoneycombioQuery_filterOpInAndNotIn(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`
-data "honeycombio_query" "test" {
+data "honeycombio_query_specification" "test" {
   calculation {
     op = "COUNT"
   }
@@ -288,7 +288,7 @@ resource "honeycombio_board" "test" {
   name = "terraform-provider-honeycombio - Test honeycombio-query - filter ops in/not-in"
   query {
     dataset    = "%v"
-    query_json = data.honeycombio_query.test.json
+    query_json = data.honeycombio_query_specification.test.json
   }
 }`, dataset),
 			},

--- a/honeycombio/provider.go
+++ b/honeycombio/provider.go
@@ -44,9 +44,9 @@ func Provider() *schema.Provider {
 			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{
-			"honeycombio_datasets":          dataSourceHoneycombioDatasets(),
-			"honeycombio_query":             dataSourceHoneycombioQuery(),
-			"honeycombio_trigger_recipient": dataSourceHoneycombioSlackRecipient(),
+			"honeycombio_datasets":            dataSourceHoneycombioDatasets(),
+			"honeycombio_query_specification": dataSourceHoneycombioQuerySpec(),
+			"honeycombio_trigger_recipient":   dataSourceHoneycombioSlackRecipient(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"honeycombio_board":            newBoard(),

--- a/honeycombio/resource_board_test.go
+++ b/honeycombio/resource_board_test.go
@@ -36,7 +36,7 @@ func TestAccHoneycombioBoard_basic(t *testing.T) {
 
 func testAccBoardConfig(dataset string) string {
 	return fmt.Sprintf(`
-data "honeycombio_query" "test" {
+data "honeycombio_query_specification" "test" {
   count = 2
 
   calculation {
@@ -58,13 +58,13 @@ resource "honeycombio_board" "test" {
   query {
     caption = "test query 0"
     dataset = "%s"
-    query_json = data.honeycombio_query.test[0].json
+    query_json = data.honeycombio_query_specification.test[0].json
   }
   query {
     caption     = "test query 1"
     query_style = "combo"
     dataset     = "%s"
-    query_json  = data.honeycombio_query.test[1].json
+    query_json  = data.honeycombio_query_specification.test[1].json
   }
 }`, dataset, dataset)
 }

--- a/honeycombio/resource_query_annotation_test.go
+++ b/honeycombio/resource_query_annotation_test.go
@@ -37,7 +37,7 @@ func TestAccHoneycombioQueryAnnotation_update(t *testing.T) {
 
 func testAccResourceQueryAnnotationConfig(dataset string, name string) string {
 	return fmt.Sprintf(`
-data "honeycombio_query" "test" {
+data "honeycombio_query_specification" "test" {
   calculation {
     op     = "AVG"
     column = "duration_ms"
@@ -52,7 +52,7 @@ data "honeycombio_query" "test" {
 
 resource "honeycombio_query" "test" {
   dataset = "%s"
-  query_json = data.honeycombio_query.test.json
+  query_json = data.honeycombio_query_specification.test.json
 }
 
 resource "honeycombio_query_annotation" "test" {

--- a/honeycombio/resource_query_test.go
+++ b/honeycombio/resource_query_test.go
@@ -40,7 +40,7 @@ func TestAccHoneycombioQuery_update(t *testing.T) {
 
 func testAccResourceQueryConfig(dataset string, duration int) string {
 	return fmt.Sprintf(`
-data "honeycombio_query" "test" {
+data "honeycombio_query_specification" "test" {
   calculation {
     op     = "AVG"
     column = "duration_ms"
@@ -55,7 +55,7 @@ data "honeycombio_query" "test" {
 
 resource "honeycombio_query" "test" {
   dataset = "%s"
-  query_json = data.honeycombio_query.test.json
+  query_json = data.honeycombio_query_specification.test.json
 }
 `, duration, dataset)
 }

--- a/honeycombio/resource_trigger_test.go
+++ b/honeycombio/resource_trigger_test.go
@@ -175,7 +175,7 @@ func TestAccHoneycombioTrigger_validationErrors(t *testing.T) {
 
 func testAccTriggerConfigWithFrequency(dataset string, frequency int) string {
 	return fmt.Sprintf(`
-data "honeycombio_query" "test" {
+data "honeycombio_query_specification" "test" {
   calculation {
     op     = "AVG"
     column = "duration_ms"
@@ -187,7 +187,7 @@ resource "honeycombio_trigger" "test" {
   name    = "Test trigger from terraform-provider-honeycombio"
   dataset = "%s"
 
-  query_json = data.honeycombio_query.test.json
+  query_json = data.honeycombio_query_specification.test.json
 
   threshold {
     op    = ">"
@@ -210,7 +210,7 @@ resource "honeycombio_trigger" "test" {
 
 func testAccTriggerConfigWithCount(dataset string) string {
 	return fmt.Sprintf(`
-data "honeycombio_query" "test" {
+data "honeycombio_query_specification" "test" {
   calculation {
     op     = "COUNT"
   }
@@ -221,7 +221,7 @@ resource "honeycombio_trigger" "test" {
   name    = "Test trigger from terraform-provider-honeycombio"
   dataset = "%s"
 
-  query_json = data.honeycombio_query.test.json
+  query_json = data.honeycombio_query_specification.test.json
 
   threshold {
     op    = ">"
@@ -249,7 +249,7 @@ EOF
 
 func testAccTriggerConfigWithRecipientID(dataset, recipientID string) string {
 	return fmt.Sprintf(`
-data "honeycombio_query" "test" {
+data "honeycombio_query_specification" "test" {
   calculation {
     op     = "AVG"
     column = "duration_ms"
@@ -261,7 +261,7 @@ resource "honeycombio_trigger" "test" {
   name    = "Test trigger from terraform-provider-honeycombio"
   dataset = "%s"
 
-  query_json = data.honeycombio_query.test.json
+  query_json = data.honeycombio_query_specification.test.json
         
   threshold {
     op    = ">"


### PR DESCRIPTION
The new name more accurately reflects what the data source is used for.

Breaking change as outlined in #96
Resolves #65 