### PR TITLE
A fix in the docs about trigger resource

### DIFF
--- a/docs/resources/trigger.md
+++ b/docs/resources/trigger.md
@@ -30,7 +30,7 @@ resource "honeycombio_trigger" "example" {
   name        = "Requests are slower than usuals"
   description = "Average duration of all requests for the last 10 minutes."
 
-  query_json = honeycombio_query.example.id
+  query_id   = honeycombio_query.example.id
   dataset    = var.dataset
 
   frequency = 600 // in seconds, 10 minutes


### PR DESCRIPTION
This a small fix in [trigger docs](https://registry.terraform.io/providers/honeycombio/honeycombio/latest/docs/resources/trigger). It should say `query_id` instead of `query_json`