### PR TITLE
Do not update an existing derived column with creation of new TF resource

### DIFF
--- a/client/derived_column_test.go
+++ b/client/derived_column_test.go
@@ -30,6 +30,18 @@ func TestDerivedColumns(t *testing.T) {
 		assert.Equal(t, data, derivedColumn)
 	})
 
+	t.Run("Create_DuplicateErr", func(t *testing.T) {
+		data := &DerivedColumn{
+			Alias:       "derived_column_test",
+			Expression:  "LOG10($duration_ms)",
+			Description: "This is a derived column with the same name as an existing one",
+		}
+		_, err = c.DerivedColumns.Create(ctx, dataset, data)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "chosen alias is the same as an existing derived column")
+	})
+
 	t.Run("List", func(t *testing.T) {
 		derivedColumns, err := c.DerivedColumns.List(ctx, dataset)
 

--- a/honeycombio/resource_derived_column.go
+++ b/honeycombio/resource_derived_column.go
@@ -65,12 +65,7 @@ func resourceDerivedColumnCreate(ctx context.Context, d *schema.ResourceData, me
 	dataset := d.Get("dataset").(string)
 	derivedColumn := readDerivedColumn(d)
 
-	existing, err := client.DerivedColumns.GetByAlias(ctx, dataset, derivedColumn.Alias)
-	if err == nil {
-		d.SetId(existing.ID)
-		return resourceDerivedColumnUpdate(ctx, d, meta)
-	}
-
+	var err error
 	derivedColumn, err = client.DerivedColumns.Create(ctx, dataset, derivedColumn)
 	if err != nil {
 		return diag.FromErr(err)


### PR DESCRIPTION
Today, we broke a whole slew of triggers because we inadvertently changed the definition of a derived column by creating a new `honeycombio_derived_column` resource with an already in-use alias.

This should not be possible according to the Honeycomb API:
```
❯ curl https://api.honeycomb.io/1/derived_columns/test-dataset \
          -X POST \
          -H "X-Honeycomb-Team: REDACTED" \
          -d '{"alias": "liz-test", "expression": "MAX(1)", "description": "liz testing if you can unintentionally overwrite derived columns"}'
{"id":"123456","expression":"MAX(1)","alias":"liz-test","description":"liz testing if you can unintentionally overwrite derived columns"}
~
❯ curl https://api.honeycomb.io/1/derived_columns/test-dataset \
          -X POST \
          -H "X-Honeycomb-Team: REDACTED" \
          -d '{"alias": "liz-test", "expression": "MAX(1)", "description": "liz testing if you can unintentionally overwrite derived columns"}'
{"error":"Your chosen alias is the same as an existing derived column. Please choose a different alias."}
```

However, the Terraform provider accepts overwriting of the existing derived column because a `PUT` is performed _if_ a column with the same alias already exists. This is unexpected behavior. Instead, we'd expect the apply to fail with the above message returned by the API.