### PR TITLE
Allow provider debugging

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,15 +1,29 @@
 package main
 
 import (
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"context"
+	"flag"
+	"log"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 	"github.com/honeycombio/terraform-provider-honeycombio/honeycombio"
 )
 
 func main() {
-	plugin.Serve(&plugin.ServeOpts{
-		ProviderFunc: func() *schema.Provider {
-			return honeycombio.Provider()
-		},
-	})
+	var debugMode bool
+
+	flag.BoolVar(&debugMode, "debug", false, "set to true to run the provider with support for debuggers like delve")
+	flag.Parse()
+
+	opts := &plugin.ServeOpts{ProviderFunc: honeycombio.Provider}
+
+	if debugMode {
+		err := plugin.Debug(context.Background(), "registry.terraform.io/honeycombio/honeycombio", opts)
+		if err != nil {
+			log.Fatalf(err.Error())
+		}
+		return
+	}
+
+	plugin.Serve(opts)
 }


### PR DESCRIPTION
Allow debugging with delve or an IDE's debugger by passing the `-debug` flag on start:

https://www.terraform.io/plugin/sdkv2/debugging#debugger-based-debugging