### PR TITLE
Fix Trigger recipient ordering resulting in infinite diffs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug Terraform Provider",
+      "type": "go",
+      "request": "launch",
+      "mode": "debug",
+      // this assumes your workspace is the root of the repo
+      "program": "${workspaceFolder}",
+      "env": {},
+      "args": [
+        "-debug",
+      ]
+    }
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,11 +6,10 @@
       "type": "go",
       "request": "launch",
       "mode": "debug",
-      // this assumes your workspace is the root of the repo
       "program": "${workspaceFolder}",
       "env": {},
       "args": [
-        "-debug",
+        "-debug"
       ]
     }
   ]

--- a/honeycombio/resource_trigger.go
+++ b/honeycombio/resource_trigger.go
@@ -292,11 +292,13 @@ func matchRecipientsWithSchema(readRecipients []honeycombio.TriggerRecipient, de
 		} else {
 			// group result recipients by type
 			for key, rcpt := range rMap {
-				if string(rcpt.Type) == declaredRcpt["type"] {
-					result[i] = rcpt
-					delete(rMap, key)
-					break
+				if string(rcpt.Type) != declaredRcpt["type"] || rcpt.Target != declaredRcpt["target"] {
+					continue
 				}
+
+				result[i] = rcpt
+				delete(rMap, key)
+				break
 			}
 		}
 	}


### PR DESCRIPTION
This addresses unstable recipient ordering which cannot be mitigated using a DiffSupressFunc (see: https://github.com/hashicorp/terraform-plugin-sdk/issues/477).

Fix inspired by https://github.com/linode/terraform-provider-linode/pull/386

Should resolve #123