### PR TITLE
Additional field length validation tests

### DIFF
--- a/honeycombio/resource_board.go
+++ b/honeycombio/resource_board.go
@@ -21,12 +21,14 @@ func newBoard() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringLenBetween(1, 255),
 			},
 			"description": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(1, 1023),
 			},
 			"style": {
 				Type:         schema.TypeString,
@@ -40,8 +42,9 @@ func newBoard() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"caption": {
-							Type:     schema.TypeString,
-							Optional: true,
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringLenBetween(1, 1023),
 						},
 						"query_style": {
 							Type:         schema.TypeString,

--- a/honeycombio/resource_column.go
+++ b/honeycombio/resource_column.go
@@ -23,17 +23,19 @@ func newColumn() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"key_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringLenBetween(1, 255),
 			},
 			"hidden": {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
 			"description": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(1, 255),
 			},
 			"type": {
 				Type:         schema.TypeString,

--- a/honeycombio/resource_dataset.go
+++ b/honeycombio/resource_dataset.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	honeycombio "github.com/honeycombio/terraform-provider-honeycombio/client"
 )
 
@@ -17,9 +18,10 @@ func newDataset() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringLenBetween(1, 255),
 			},
 			"slug": {
 				Type:     schema.TypeString,

--- a/honeycombio/resource_query_annotation.go
+++ b/honeycombio/resource_query_annotation.go
@@ -31,7 +31,7 @@ func newQueryAnnotation() *schema.Resource {
 			"name": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: validation.StringLenBetween(1, 120),
+				ValidateFunc: validation.StringLenBetween(1, 80),
 			},
 			"description": {
 				Type:         schema.TypeString,


### PR DESCRIPTION
Fix Query Annotation name max. length (had misread it to be equal to a Trigger), and add additional checks for some Board, Column, and Dataset fields.