### PR TITLE
[triggers] Add alert_type field for Triggers

### DIFF
--- a/client/trigger.go
+++ b/client/trigger.go
@@ -58,7 +58,7 @@ type Trigger struct {
 	// be greater than 4 times the frequency.
 	Query   *QuerySpec `json:"query,omitempty"`
 	QueryID string     `json:"query_id,omitempty"`
-	// Alert Type. contain types of trigger schedule to use. This field is required
+	// Alert Frequency. Describes scheduling behavior for triggers. By default alert type per change. This field is required
 	AlertFrequency string `json:"alert_frequency,omitempty"`
 	// Threshold. This fild is required.
 	Threshold *TriggerThreshold `json:"threshold"`

--- a/client/trigger.go
+++ b/client/trigger.go
@@ -97,14 +97,6 @@ func TriggerThresholdOps() []TriggerThresholdOp {
 	}
 }
 
-// Representation of the Triggers Alert Type.
-type TriggerAlertType struct {
-	Type TriggerAlertTypeValue `json:"alert_type"`
-}
-
-// TriggerAlertTypeValue, the current setting type for the trigger.
-type TriggerAlertTypeValue string
-
 // Allowed values for alert_type. | on_change is default
 const (
 	TriggerAlertTypeValueOnChange string = "on_change"

--- a/client/trigger.go
+++ b/client/trigger.go
@@ -59,7 +59,7 @@ type Trigger struct {
 	Query   *QuerySpec `json:"query,omitempty"`
 	QueryID string     `json:"query_id,omitempty"`
 	// Alert Frequency. Describes scheduling behavior for triggers. By default alert type per change. This field is required
-	AlertFrequency string `json:"alert_frequency,omitempty"`
+	AlertType string `json:"alert_type,omitempty"`
 	// Threshold. This fild is required.
 	Threshold *TriggerThreshold `json:"threshold"`
 	// Frequency describes how often the trigger should run. Frequency is an
@@ -97,10 +97,18 @@ func TriggerThresholdOps() []TriggerThresholdOp {
 	}
 }
 
-// Alert Frequency values - alert_on_change is default
+// Representation of the Triggers Alert Type.
+type TriggerAlertType struct {
+	Type TriggerAlertTypeValue `json:"alert_type"`
+}
+
+// TriggerAlertTypeValue, the current setting type for the trigger.
+type TriggerAlertTypeValue string
+
+// Allowed values for alert_type. | on_change is default
 const (
-	AlertFrequencyOnChange string = "alert_on_change"
-	AlertFrequencyOnTrue   string = "alert_on_true"
+	TriggerAlertTypeValueOnChange string = "on_change"
+	TriggerAlertTypeValueOnTrue   string = "on_true"
 )
 
 // TriggerRecipient represents a recipient that will receive a notification
@@ -182,15 +190,15 @@ func (t *Trigger) MarshalJSON() ([]byte, error) {
 		// this doesn't work in the general case, but this
 		// client is now purpose-built for the Terraform provider
 		a := &ATrigger{
-			ID:             t.ID,
-			Name:           t.Name,
-			Description:    t.Description,
-			Disabled:       t.Disabled,
-			QueryID:        t.QueryID,
-			AlertFrequency: t.AlertFrequency,
-			Threshold:      t.Threshold,
-			Frequency:      t.Frequency,
-			Recipients:     t.Recipients,
+			ID:          t.ID,
+			Name:        t.Name,
+			Description: t.Description,
+			Disabled:    t.Disabled,
+			QueryID:     t.QueryID,
+			AlertType:   t.AlertType,
+			Threshold:   t.Threshold,
+			Frequency:   t.Frequency,
+			Recipients:  t.Recipients,
 		}
 		return json.Marshal(&struct{ *ATrigger }{ATrigger: (*ATrigger)(a)})
 	}

--- a/client/trigger.go
+++ b/client/trigger.go
@@ -58,8 +58,8 @@ type Trigger struct {
 	// be greater than 4 times the frequency.
 	Query   *QuerySpec `json:"query,omitempty"`
 	QueryID string     `json:"query_id,omitempty"`
-	// Alert Type. contain types of trigger schedule to use
-	AlertType string `json:"alert_type,omitempty"`
+	// Alert Type. contain types of trigger schedule to use. This field is required
+	AlertFrequency string `json:"alert_frequency,omitempty"`
 	// Threshold. This fild is required.
 	Threshold *TriggerThreshold `json:"threshold"`
 	// Frequency describes how often the trigger should run. Frequency is an
@@ -96,6 +96,12 @@ func TriggerThresholdOps() []TriggerThresholdOp {
 		TriggerThresholdOpLessThanOrEqual,
 	}
 }
+
+// Alert Frequency values - alert_on_change is default
+const (
+	AlertFrequencyOnChange string = "alert_on_change"
+	AlertFrequencyOnTrue   string = "alert_on_true"
+)
 
 // TriggerRecipient represents a recipient that will receive a notification
 // when the trigger fires.
@@ -176,15 +182,15 @@ func (t *Trigger) MarshalJSON() ([]byte, error) {
 		// this doesn't work in the general case, but this
 		// client is now purpose-built for the Terraform provider
 		a := &ATrigger{
-			ID:          t.ID,
-			Name:        t.Name,
-			Description: t.Description,
-			Disabled:    t.Disabled,
-			QueryID:     t.QueryID,
-			AlertType:   t.AlertType,
-			Threshold:   t.Threshold,
-			Frequency:   t.Frequency,
-			Recipients:  t.Recipients,
+			ID:             t.ID,
+			Name:           t.Name,
+			Description:    t.Description,
+			Disabled:       t.Disabled,
+			QueryID:        t.QueryID,
+			AlertFrequency: t.AlertFrequency,
+			Threshold:      t.Threshold,
+			Frequency:      t.Frequency,
+			Recipients:     t.Recipients,
 		}
 		return json.Marshal(&struct{ *ATrigger }{ATrigger: (*ATrigger)(a)})
 	}

--- a/client/trigger.go
+++ b/client/trigger.go
@@ -58,7 +58,7 @@ type Trigger struct {
 	// be greater than 4 times the frequency.
 	Query   *QuerySpec `json:"query,omitempty"`
 	QueryID string     `json:"query_id,omitempty"`
-	// Alert Frequency. Describes scheduling behavior for triggers. By default alert type per change. This field is required
+	// Alert Type. Describes scheduling behavior for triggers.
 	AlertType string `json:"alert_type,omitempty"`
 	// Threshold. This fild is required.
 	Threshold *TriggerThreshold `json:"threshold"`

--- a/client/trigger.go
+++ b/client/trigger.go
@@ -58,6 +58,8 @@ type Trigger struct {
 	// be greater than 4 times the frequency.
 	Query   *QuerySpec `json:"query,omitempty"`
 	QueryID string     `json:"query_id,omitempty"`
+	// Alert Type. contain types of trigger schedule to use
+	AlertType string `json:"alert_type,omitempty"`
 	// Threshold. This fild is required.
 	Threshold *TriggerThreshold `json:"threshold"`
 	// Frequency describes how often the trigger should run. Frequency is an
@@ -179,6 +181,7 @@ func (t *Trigger) MarshalJSON() ([]byte, error) {
 			Description: t.Description,
 			Disabled:    t.Disabled,
 			QueryID:     t.QueryID,
+			AlertType:   t.AlertType,
 			Threshold:   t.Threshold,
 			Frequency:   t.Frequency,
 			Recipients:  t.Recipients,

--- a/client/trigger_test.go
+++ b/client/trigger_test.go
@@ -50,6 +50,7 @@ func TestTriggers(t *testing.T) {
 				Op:    TriggerThresholdOpGreaterThan,
 				Value: 10000,
 			},
+			AlertType: "on_change",
 			Recipients: []TriggerRecipient{
 				{
 					Type:   TriggerRecipientTypeEmail,
@@ -71,11 +72,15 @@ func TestTriggers(t *testing.T) {
 		// copy IDs before asserting equality
 		data.ID = trigger.ID
 		data.QueryID = trigger.QueryID
+		data.AlertType = trigger.AlertType
 		for i := range trigger.Recipients {
 			data.Recipients[i].ID = trigger.Recipients[i].ID
 		}
 		// set default time range
 		data.Query.TimeRange = IntPtr(300)
+
+		// set the default alert type
+		data.AlertType = TriggerAlertTypeValueOnChange
 
 		assert.Equal(t, data, trigger)
 	})
@@ -97,11 +102,14 @@ func TestTriggers(t *testing.T) {
 	t.Run("Update", func(t *testing.T) {
 		trigger.Description = "A new description"
 
+		// update the alert_type to on_true / this is a simple validation that this field works
+		trigger.AlertType = TriggerAlertTypeValueOnTrue
+
 		result, err := c.Triggers.Update(ctx, dataset, trigger)
 
 		// copy IDs before asserting equality
 		trigger.QueryID = result.QueryID
-
+		trigger.AlertType = result.AlertType
 		assert.NoError(t, err)
 		assert.Equal(t, trigger, result)
 	})

--- a/docs/resources/trigger.md
+++ b/docs/resources/trigger.md
@@ -66,7 +66,7 @@ The following arguments are supported:
 * `description` - (Optional) Description of the trigger.
 * `disabled` - (Optional) The state of the trigger. If true, the trigger will not be run. Defaults to false.
 * `frequency` - (Optional) The interval (in seconds) in which to check the results of the query’s calculation against the threshold. Value must be divisible by 60 and between 60 and 86400 (between 1 minute and 1 day). Defaults to 900 (15 minutes).
-* `alert_type` - (Optional) The frequency for the alert to trigger. (on_change is the default behavior, on_true can also be selected)
+* `alert_type` - (Optional) The frequency for the alert to trigger. (`on_change` is the default behavior, `on_true` can also be selected)
 * `recipient` - (Optional) Zero or more configuration blocks (described below) with the recipients to notify when the trigger fires.
 
 -> **NOTE** The query used in a Trigger must follow a strict subset: a query must contain exactly one calcuation and may only contain `calculation`, `filter`, `filter_combination` and `breakdowns` fields. The query's duration cannot be more than four times the trigger's frequency.

--- a/docs/resources/trigger.md
+++ b/docs/resources/trigger.md
@@ -62,11 +62,11 @@ The following arguments are supported:
 * `name` - (Required) Name of the trigger.
 * `dataset` - (Required) The dataset this trigger is associated with.
 * `query_id` - (Required) The ID of the Query that the Trigger will execute.
-* `alert_type` - (Required) The frequency for the alert to trigger. (on_change is our default behavior, on_true can be optionally selected)
 * `threshold` - (Required) A configuration block (described below) describing the threshold of the trigger.
 * `description` - (Optional) Description of the trigger.
 * `disabled` - (Optional) The state of the trigger. If true, the trigger will not be run. Defaults to false.
 * `frequency` - (Optional) The interval (in seconds) in which to check the results of the query’s calculation against the threshold. Value must be divisible by 60 and between 60 and 86400 (between 1 minute and 1 day). Defaults to 900 (15 minutes).
+* `alert_type` - (Optional) The frequency for the alert to trigger. (on_change is the default behavior, on_true can also be selected)
 * `recipient` - (Optional) Zero or more configuration blocks (described below) with the recipients to notify when the trigger fires.
 
 -> **NOTE** The query used in a Trigger must follow a strict subset: a query must contain exactly one calcuation and may only contain `calculation`, `filter`, `filter_combination` and `breakdowns` fields. The query's duration cannot be more than four times the trigger's frequency.

--- a/docs/resources/trigger.md
+++ b/docs/resources/trigger.md
@@ -35,6 +35,8 @@ resource "honeycombio_trigger" "example" {
 
   frequency = 600 // in seconds, 10 minutes
 
+  alert_type = "on_change" // on_change is default, on_true can refers to the "Alert on True" checkbox in the UI
+
   threshold {
     op    = ">"
     value = 1000
@@ -60,6 +62,7 @@ The following arguments are supported:
 * `name` - (Required) Name of the trigger.
 * `dataset` - (Required) The dataset this trigger is associated with.
 * `query_id` - (Required) The ID of the Query that the Trigger will execute.
+* `alert_type` - (Required) The frequency for the alert to trigger. (on_change is our default behavior, on_true can be optionally selected)
 * `threshold` - (Required) A configuration block (described below) describing the threshold of the trigger.
 * `description` - (Optional) Description of the trigger.
 * `disabled` - (Optional) The state of the trigger. If true, the trigger will not be run. Defaults to false.

--- a/honeycombio/resource_trigger.go
+++ b/honeycombio/resource_trigger.go
@@ -47,7 +47,8 @@ func newTrigger() *schema.Resource {
 			},
 			"alert_type": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
+				Default:  "on_change",
 			},
 			"threshold": {
 				Type:     schema.TypeList,

--- a/honeycombio/resource_trigger.go
+++ b/honeycombio/resource_trigger.go
@@ -45,6 +45,10 @@ func newTrigger() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"alert_type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
 			"threshold": {
 				Type:     schema.TypeList,
 				Required: true,
@@ -156,6 +160,7 @@ func resourceTriggerRead(ctx context.Context, d *schema.ResourceData, meta inter
 	d.Set("description", t.Description)
 	d.Set("disabled", t.Disabled)
 	d.Set("query_id", t.QueryID)
+	d.Set("alert_type", t.AlertType)
 
 	err = d.Set("threshold", flattenTriggerThreshold(t.Threshold))
 	if err != nil {
@@ -213,6 +218,7 @@ func expandTrigger(d *schema.ResourceData) (*honeycombio.Trigger, error) {
 		Description: d.Get("description").(string),
 		Disabled:    d.Get("disabled").(bool),
 		QueryID:     d.Get("query_id").(string),
+		AlertType:   d.Get("alert_type").(string),
 		Threshold:   expandTriggerThreshold(d.Get("threshold").([]interface{})),
 		Frequency:   d.Get("frequency").(int),
 		Recipients:  expandTriggerRecipients(d.Get("recipient").([]interface{})),

--- a/honeycombio/resource_trigger.go
+++ b/honeycombio/resource_trigger.go
@@ -46,9 +46,10 @@ func newTrigger() *schema.Resource {
 				Required: true,
 			},
 			"alert_type": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  "on_change",
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "on_change",
+				ValidateFunc: validation.StringInSlice([]string{"on_change", "on_true"}, false),
 			},
 			"threshold": {
 				Type:     schema.TypeList,

--- a/honeycombio/resource_trigger.go
+++ b/honeycombio/resource_trigger.go
@@ -45,7 +45,7 @@ func newTrigger() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			"alert_type": {
+			"alert_frequency": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
@@ -160,7 +160,7 @@ func resourceTriggerRead(ctx context.Context, d *schema.ResourceData, meta inter
 	d.Set("description", t.Description)
 	d.Set("disabled", t.Disabled)
 	d.Set("query_id", t.QueryID)
-	d.Set("alert_type", t.AlertType)
+	d.Set("alert_type", t.AlertFrequency)
 
 	err = d.Set("threshold", flattenTriggerThreshold(t.Threshold))
 	if err != nil {
@@ -213,15 +213,15 @@ func resourceTriggerDelete(ctx context.Context, d *schema.ResourceData, meta int
 
 func expandTrigger(d *schema.ResourceData) (*honeycombio.Trigger, error) {
 	trigger := &honeycombio.Trigger{
-		ID:          d.Id(),
-		Name:        d.Get("name").(string),
-		Description: d.Get("description").(string),
-		Disabled:    d.Get("disabled").(bool),
-		QueryID:     d.Get("query_id").(string),
-		AlertType:   d.Get("alert_type").(string),
-		Threshold:   expandTriggerThreshold(d.Get("threshold").([]interface{})),
-		Frequency:   d.Get("frequency").(int),
-		Recipients:  expandTriggerRecipients(d.Get("recipient").([]interface{})),
+		ID:             d.Id(),
+		Name:           d.Get("name").(string),
+		Description:    d.Get("description").(string),
+		Disabled:       d.Get("disabled").(bool),
+		QueryID:        d.Get("query_id").(string),
+		AlertFrequency: d.Get("alert_frequency").(string),
+		Threshold:      expandTriggerThreshold(d.Get("threshold").([]interface{})),
+		Frequency:      d.Get("frequency").(int),
+		Recipients:     expandTriggerRecipients(d.Get("recipient").([]interface{})),
 	}
 	return trigger, nil
 }

--- a/honeycombio/resource_trigger.go
+++ b/honeycombio/resource_trigger.go
@@ -160,7 +160,7 @@ func resourceTriggerRead(ctx context.Context, d *schema.ResourceData, meta inter
 	d.Set("description", t.Description)
 	d.Set("disabled", t.Disabled)
 	d.Set("query_id", t.QueryID)
-	d.Set("alert_type", t.AlertFrequency)
+	d.Set("alert_frequency", t.AlertFrequency)
 
 	err = d.Set("threshold", flattenTriggerThreshold(t.Threshold))
 	if err != nil {

--- a/honeycombio/resource_trigger.go
+++ b/honeycombio/resource_trigger.go
@@ -45,7 +45,7 @@ func newTrigger() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			"alert_frequency": {
+			"alert_type": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
@@ -160,7 +160,7 @@ func resourceTriggerRead(ctx context.Context, d *schema.ResourceData, meta inter
 	d.Set("description", t.Description)
 	d.Set("disabled", t.Disabled)
 	d.Set("query_id", t.QueryID)
-	d.Set("alert_frequency", t.AlertFrequency)
+	d.Set("alert_type", t.AlertType)
 
 	err = d.Set("threshold", flattenTriggerThreshold(t.Threshold))
 	if err != nil {
@@ -213,15 +213,15 @@ func resourceTriggerDelete(ctx context.Context, d *schema.ResourceData, meta int
 
 func expandTrigger(d *schema.ResourceData) (*honeycombio.Trigger, error) {
 	trigger := &honeycombio.Trigger{
-		ID:             d.Id(),
-		Name:           d.Get("name").(string),
-		Description:    d.Get("description").(string),
-		Disabled:       d.Get("disabled").(bool),
-		QueryID:        d.Get("query_id").(string),
-		AlertFrequency: d.Get("alert_frequency").(string),
-		Threshold:      expandTriggerThreshold(d.Get("threshold").([]interface{})),
-		Frequency:      d.Get("frequency").(int),
-		Recipients:     expandTriggerRecipients(d.Get("recipient").([]interface{})),
+		ID:          d.Id(),
+		Name:        d.Get("name").(string),
+		Description: d.Get("description").(string),
+		Disabled:    d.Get("disabled").(bool),
+		QueryID:     d.Get("query_id").(string),
+		AlertType:   d.Get("alert_type").(string),
+		Threshold:   expandTriggerThreshold(d.Get("threshold").([]interface{})),
+		Frequency:   d.Get("frequency").(int),
+		Recipients:  expandTriggerRecipients(d.Get("recipient").([]interface{})),
 	}
 	return trigger, nil
 }

--- a/honeycombio/resource_trigger_test.go
+++ b/honeycombio/resource_trigger_test.go
@@ -218,48 +218,6 @@ resource "honeycombio_trigger" "test" {
 }`, dataset, dataset, frequency)
 }
 
-func testAccTriggerConfigWithAlertType(dataset string, alertType string) string {
-	return fmt.Sprintf(`
-data "honeycombio_query_specification" "test" {
-  calculation {
-    op     = "AVG"
-    column = "duration_ms"
-  }
-  time_range = 1200
-}
-
-resource "honeycombio_query" "test" {
-  dataset    = "%s"
-  query_json = data.honeycombio_query_specification.test.json
-}
-
-resource "honeycombio_trigger" "test" {
-  name    = "Test trigger from terraform-provider-honeycombio"
-  dataset = "%s"
-
-  query_id = honeycombio_query.test.id
-
-  alert_type = "%s"
-  
-  threshold {
-    op    = ">"
-    value = 100
-  }
-
-  frequency = d
-
-  recipient {
-    type   = "email"
-    target = "hello@example.com"
-  }
-
-  recipient {
-    type   = "email"
-    target = "bye@example.com"
-  }
-}`, dataset, dataset, alertType)
-}
-
 func testAccTriggerConfigWithCount(dataset string) string {
 	return fmt.Sprintf(`
 data "honeycombio_query_specification" "test" {

--- a/honeycombio/resource_trigger_test.go
+++ b/honeycombio/resource_trigger_test.go
@@ -150,9 +150,7 @@ resource "honeycombio_trigger" "test" {
     value = 1000
   }
 
-  alert_type {
-    type = "on_change"
-  }
+  alert_type = "on_change"
 
   recipient {
     type   = "slack"
@@ -207,9 +205,8 @@ resource "honeycombio_trigger" "test" {
 
   query_id = honeycombio_query.test.id
 
-  alert_type {
-    type = "on_change"
-  }
+  alert_type = "on_change"
+  
   threshold {
     op    = ">"
     value = 100
@@ -263,6 +260,8 @@ resource "honeycombio_trigger" "test" {
 
   query_id = honeycombio_query.test.id
 
+  alert_type = "on_change"
+
   threshold {
     op    = ">"
     value = 100
@@ -290,6 +289,8 @@ resource "honeycombio_trigger" "test" {
   dataset = "%s"
 
   query_id = honeycombio_query.test.id
+
+  alert_type = "on_change"
 
   threshold {
     op    = ">"

--- a/honeycombio/resource_trigger_test.go
+++ b/honeycombio/resource_trigger_test.go
@@ -89,16 +89,6 @@ func testAccCheckTriggerAttributes(t *honeycombio.Trigger) resource.TestCheckFun
 	}
 }
 
-func testAccCheckTriggerAlertType(t *honeycombio.Trigger) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if t.AlertType != honeycombio.TriggerAlertTypeValueOnChange && t.AlertType != honeycombio.TriggerAlertTypeValueOnTrue {
-			return fmt.Errorf("bad alert_type: %s - must be on_change or on_true", t.AlertType)
-		}
-
-		return nil
-	}
-}
-
 // add a trigger recipient by ID to verify the diff is stable
 func TestAccHoneycombioTrigger_triggerRecipientById(t *testing.T) {
 	dataset := testAccDataset()

--- a/honeycombio/resource_trigger_test.go
+++ b/honeycombio/resource_trigger_test.go
@@ -207,6 +207,9 @@ resource "honeycombio_trigger" "test" {
 
   query_id = honeycombio_query.test.id
 
+  alert_type {
+    type = "on_change"
+  }
   threshold {
     op    = ">"
     value = 100


### PR DESCRIPTION
Adding a new attribute to Triggers, it will include the following changes:
- adding a new alert frequency to the Trigger structure

The current behaviors of triggers is an alert is sent on change. We are adding a the feature for the provider set alert on true for our triggers.

Read more about alert frequency here:
https://docs.honeycomb.io/working-with-your-data/triggers/#configuration

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202136190006122