### PR TITLE
datasource/query_result - take query JSON directly

### DIFF
--- a/docs/data-sources/query_result.md
+++ b/docs/data-sources/query_result.md
@@ -16,14 +16,9 @@ data "honeycombio_query_specification" "example" {
   }
 }
 
-resource "honeycombio_query" "example" {
+data "honeycombio_query_result" "example" {
   dataset    = var.dataset
   query_json = data.honeycombio_query_specification.example.json
-}
-
-data "honeycombio_query_result" "example" {
-  dataset  = var.dataset
-  query_id = honeycombio_query.example.id
 }
 
 output "event_count" {
@@ -42,12 +37,13 @@ output "event_count" {
 The following arguments are supported:
 
 * `dataset` - (Required) The dataset this query is associated with.
-* `query_id` - (Required) The ID of the query that will be executed to obtain the result.
+* `query_json` - (Required) A JSON object describing the query according to the Query Specification. While the JSON can be constructed manually, it is easiest to use the honeycombio_query_specification data source.
 
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
+* `query_id` - The ID of the Query created and executed to obtain the result.
 * `query_url` - The permalink to the executed query's results.
 * `query_image_url` - The permalink to the visualization of the executed query's results.
 * `results` - The results of the executed query. This will be a list of maps, with each map's keys set to the breakdowns and calculations of the query. Due to a limitation of the Terraform Plugin SDK, all values are transformed into strings.

--- a/example/board_via_query_result/main.tf
+++ b/example/board_via_query_result/main.tf
@@ -1,0 +1,42 @@
+terraform {
+  required_providers {
+    honeycombio = {
+      source = "honeycombio/honeycombio"
+    }
+  }
+}
+
+variable "dataset" {
+  type = string
+}
+
+data "honeycombio_query_specification" "example" {
+  time_range = 7 * 86400 # last 7 days
+
+  calculation {
+    op = "COUNT"
+  }
+
+  breakdowns = ["service.name"]
+}
+
+
+data "honeycombio_query_result" "example" {
+  dataset    = var.dataset
+  query_json = data.honeycombio_query_specification.example.json
+}
+
+locals {
+  active_services = flatten(
+    [
+      for result in data.honeycombio_query_result.example.results : result["service.name"]
+    ]
+  )
+}
+
+# generate a board for each service seen in the last 7 days
+resource "honeycombio_board" "services" {
+  for_each = toset(local.active_services)
+
+  name = format("%s board", each.key)
+}

--- a/honeycombio/data_source_query_result_test.go
+++ b/honeycombio/data_source_query_result_test.go
@@ -40,8 +40,8 @@ resource "honeycombio_query" "test" {
 }
 
 data "honeycombio_query_result" "test" {
-  dataset  = "%s"
-  query_id = honeycombio_query.test.id
+  dataset    = "%s"
+  query_json = data.honeycombio_query_specification.test.json
 }
 
 output "results" {


### PR DESCRIPTION
By taking a Query ID it was not possible to use the results of the data source without first generating an output (or similar) making use of the results.

By switching to taking Query JSON directly, Terraform is able to use the results later in the same plan as no resources need to be created first.

Note: this is a breaking change