### PR TITLE
Update burn alert docs to match validation

### DIFF
--- a/docs/resources/burn_alert.md
+++ b/docs/resources/burn_alert.md
@@ -18,7 +18,7 @@ resource "honeycombio_burn_alert" "example_alert" {
   slo_id             = var.slo_id
   exhaustion_minutes = 480
 
-  # zero or more recipients
+  # one or more recipients
   recipient {
     type   = "email"
     target = "hello@example.com"
@@ -40,7 +40,7 @@ The following arguments are supported:
 * `exhaustion_minutes` - (Required) The amount of time, in minutes, remaining before the SLO's error budget will be exhausted and the alert will fire.
 * `recipient` - (Optional) Zero or more configuration blocks (described below) with the recipients to notify when the alert fires.
 
-Each burn alert configuration may have zero or more `recipient` blocks, which each accept the following arguments. A recipient block can either refer to an existing recipient (a recipient that is already present in another burn alert or trigger) or a new recipient. When specifying an existing recipient, only `id` may be set. If you pass in a recipient without its ID and only include the type and target, Honeycomb will make a best effort to match to an existing recipient. To retrieve the ID of an existing recipient, refer to the [`honeycombio_recipient`](../data-sources/recipient.md) data source.
+Each burn alert configuration may have one or more `recipient` blocks, which each accept the following arguments. A recipient block can either refer to an existing recipient (a recipient that is already present in another burn alert or trigger) or a new recipient. When specifying an existing recipient, only `id` may be set. If you pass in a recipient without its ID and only include the type and target, Honeycomb will make a best effort to match to an existing recipient. To retrieve the ID of an existing recipient, refer to the [`honeycombio_recipient`](../data-sources/recipient.md) data source.
 
 * `type` - (Optional) The type of the recipient, allowed types are `email`, `pagerduty`, `slack` and `webhook`. Should not be used in combination with `id`.
 * `target` - (Optional) Target of the recipient, this has another meaning depending on the type of recipient (see the table below). Should not be used in combination with `id`.


### PR DESCRIPTION
Burn alerts are required to have at least one recipient, but the docs mention having "zero or more."

The provider/api validation prevents zero recipients with `Error: Insufficient recipient blocks`.