### PR TITLE
Adds severity support for PagerDuty notifications

### DIFF
--- a/client/recipient.go
+++ b/client/recipient.go
@@ -46,9 +46,10 @@ type Recipient struct {
 
 // NotificationRecipient represents a recipient embedded in a Trigger or Burn Alert
 type NotificationRecipient struct {
-	ID     string        `json:"id,omitempty"`
-	Type   RecipientType `json:"type,omitempty"`
-	Target string        `json:"target,omitempty"`
+	ID      string                        `json:"id,omitempty"`
+	Type    RecipientType                 `json:"type"`
+	Details *NotificationRecipientDetails `json:"details,omitempty"`
+	Target  string                        `json:"target,omitempty"`
 }
 
 type RecipientDetails struct {
@@ -67,6 +68,10 @@ type RecipientDetails struct {
 	WebhookSecret string `json:"webhook_secret,omitempty"`
 }
 
+type NotificationRecipientDetails struct {
+	PDSeverity PagerDutySeverity `json:"pagerduty_severity,omitempty"`
+}
+
 // RecipientType holds all the possible recipient types.
 type RecipientType string
 
@@ -77,6 +82,16 @@ const (
 	RecipientTypeSlack     RecipientType = "slack"
 	RecipientTypeWebhook   RecipientType = "webhook"
 	RecipientTypeMarker    RecipientType = "marker"
+)
+
+// PagerDutySeverity holds all the possible PD Severity types
+type PagerDutySeverity string
+
+const (
+	PDSeverityCRITICAL PagerDutySeverity = "critical"
+	PDSeverityERROR    PagerDutySeverity = "error"
+	PDSeverityWARNING  PagerDutySeverity = "warning"
+	PDSeverityINFO     PagerDutySeverity = "info"
 )
 
 // TriggerRecipientTypes returns a list of recipient types compatible with Triggers

--- a/docs/resources/burn_alert.md
+++ b/docs/resources/burn_alert.md
@@ -4,6 +4,8 @@ Creates a burn alert. For more information about burn alerts, check out [Define 
 
 ## Example Usage
 
+### Basic Example
+
 ```hcl
 variable "dataset" {
   type = string
@@ -31,6 +33,41 @@ resource "honeycombio_burn_alert" "example_alert" {
 }
 ```
 
+### Example with PagerDuty Recipient and Severity
+```hcl
+variable "dataset" {
+  type = string
+}
+
+variable "slo_id" {
+  type = string
+}
+
+data "honeycombio_recipient" "pd-prod" {
+  type = "pagerduty"
+
+  detail_filter {
+    name  = "integration_name"
+    value = "Prod On-Call"
+  }
+}
+
+resource "honeycombio_burn_alert" "example_alert" {
+  dataset            = var.dataset
+  slo_id             = var.slo_id
+  exhaustion_minutes = 60
+
+  recipient {
+    id = data.honeycombio_recipient.pd-prod.id
+
+    notification_details {
+      pagerduty_severity = "critical"
+    }
+  }
+}
+```
+
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -45,6 +82,7 @@ Each burn alert configuration may have one or more `recipient` blocks, which eac
 * `type` - (Optional) The type of the recipient, allowed types are `email`, `pagerduty`, `slack` and `webhook`. Should not be used in combination with `id`.
 * `target` - (Optional) Target of the recipient, this has another meaning depending on the type of recipient (see the table below). Should not be used in combination with `id`.
 * `id` - (Optional) The ID of an already existing recipient. Should not be used in combination with `type` and `target`.
+* `notification_details` - (Optional) a block of additional details to send along with the notification. The only supported option currently is `pagerduty_severity` which can be set to one of `info`, `warn`, `error`, or `critical` and must be used in combination with a PagerDuty recipient.
 
 Type      | Target
 ----------|-------------------------

--- a/docs/resources/burn_alert.md
+++ b/docs/resources/burn_alert.md
@@ -82,7 +82,7 @@ Each burn alert configuration may have one or more `recipient` blocks, which eac
 * `type` - (Optional) The type of the recipient, allowed types are `email`, `pagerduty`, `slack` and `webhook`. Should not be used in combination with `id`.
 * `target` - (Optional) Target of the recipient, this has another meaning depending on the type of recipient (see the table below). Should not be used in combination with `id`.
 * `id` - (Optional) The ID of an already existing recipient. Should not be used in combination with `type` and `target`.
-* `notification_details` - (Optional) a block of additional details to send along with the notification. The only supported option currently is `pagerduty_severity` which can be set to one of `info`, `warn`, `error`, or `critical` and must be used in combination with a PagerDuty recipient.
+* `notification_details` - (Optional) a block of additional details to send along with the notification. The only supported option currently is `pagerduty_severity` which can be set to one of `info`, `warning`, `error`, or `critical` and must be used in combination with a PagerDuty recipient.
 
 Type      | Target
 ----------|-------------------------

--- a/docs/resources/trigger.md
+++ b/docs/resources/trigger.md
@@ -139,7 +139,7 @@ Each trigger configuration may have zero or more `recipient` blocks, which each 
 * `type` - (Optional) The type of the trigger recipient, allowed types are `email`, `marker`, `pagerduty`, `slack` and `webhook`. Should not be used in combination with `id`.
 * `target` - (Optional) Target of the trigger recipient, this has another meaning depending on the type of recipient (see the table below). Should not be used in combination with `id`.
 * `id` - (Optional) The ID of an already existing recipient. Should not be used in combination with `type` and `target`.
-* `notification_details` - (Optional) a block of additional details to send along with the notification. The only supported option currently is `pagerduty_severity` which can be set to one of `info`, `warn`, `error`, or `critical` and must be used in combination with a PagerDuty recipient.
+* `notification_details` - (Optional) a block of additional details to send along with the notification. The only supported option currently is `pagerduty_severity` which can be set to one of `info`, `warning`, `error`, or `critical` and must be used in combination with a PagerDuty recipient.
 
 Type      | Target
 ----------|-------------------------

--- a/honeycombio/resource_burn_alert.go
+++ b/honeycombio/resource_burn_alert.go
@@ -75,8 +75,9 @@ func newBurnAlert() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"pagerduty_severity": {
-										Type:         schema.TypeString,
-										Optional:     true,
+										Type: schema.TypeString,
+										// technically optional, but as its the only value supported for the moment we may as well require it
+										Required:     true,
 										ValidateFunc: validation.StringInSlice([]string{"info", "warning", "error", "critical"}, false),
 									},
 								},

--- a/honeycombio/resource_burn_alert.go
+++ b/honeycombio/resource_burn_alert.go
@@ -67,6 +67,21 @@ func newBurnAlert() *schema.Resource {
 							Computed:    true,
 							Description: "Target of the recipient, this has another meaning depending on the type of recipient. Should not be used in combination with `id`.",
 						},
+						"notification_details": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MinItems: 1,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"pagerduty_severity": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: validation.StringInSlice([]string{"info", "warning", "error", "critical"}, false),
+									},
+								},
+							},
+						},
 					},
 				},
 			},

--- a/honeycombio/resource_burn_alert_test.go
+++ b/honeycombio/resource_burn_alert_test.go
@@ -63,7 +63,6 @@ resource "honeycombio_burn_alert" "test" {
 	})
 }
 
-// add a recipient by ID to verify the diff is stable
 func TestAccHoneycombioBurnAlert_RecipientById(t *testing.T) {
 	ctx := context.Background()
 	c := testAccClient(t)
@@ -89,29 +88,59 @@ func TestAccHoneycombioBurnAlert_RecipientById(t *testing.T) {
 		c.DerivedColumns.Delete(ctx, dataset, sli.ID)
 	})
 
-	trigger, deleteFn := createTriggerWithRecipient(t, dataset, honeycombio.NotificationRecipient{
-		Type:   honeycombio.RecipientTypeEmail,
-		Target: "acctest@example.com",
-	})
-	defer deleteFn()
-
+	// add a recipient by ID to verify the diff is stable
 	resource.Test(t, resource.TestCase{
 		PreCheck:          testAccPreCheck(t),
 		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`
-				resource "honeycombio_burn_alert" "test" {
-				  dataset            = "%s"
-				  slo_id             = "%s"
-				  exhaustion_minutes = 240 # 4 hours
-				
-				  recipient {
-					id   = "%s"
-				  }
-				
-				}
-				`, dataset, slo.ID, trigger.Recipients[0].ID),
+resource "honeycombio_email_recipient" "test" {
+  address = "ba-acctest@example.com"
+}
+
+resource "honeycombio_burn_alert" "test" {
+  dataset            = "%s"
+  slo_id             = "%s"
+  exhaustion_minutes = 240 # 4 hours
+
+  recipient {
+    id = honeycombio_email_recipient.test.id
+  }
+}
+`, dataset, slo.ID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBurnAlertExists(t, dataset, "honeycombio_burn_alert.test"),
+				),
+			},
+		},
+	})
+
+	// test PD Recipient with Severity
+	resource.Test(t, resource.TestCase{
+		PreCheck:          testAccPreCheck(t),
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "honeycombio_pagerduty_recipient" "test" {
+  integration_key  = "09c9d4cacd68933151a1ef1048b67dd5"
+  integration_name = "BA acctest"
+}
+
+resource "honeycombio_burn_alert" "test" {
+  dataset            = "%s"
+  slo_id             = "%s"
+  exhaustion_minutes = 0 # budget burnt
+
+  recipient {
+    id = honeycombio_pagerduty_recipient.test.id
+
+    notification_details {
+      pagerduty_severity = "critical"
+    }
+  }
+}`, dataset, slo.ID),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBurnAlertExists(t, dataset, "honeycombio_burn_alert.test"),
 				),

--- a/honeycombio/resource_trigger.go
+++ b/honeycombio/resource_trigger.go
@@ -109,8 +109,9 @@ func newTrigger() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"pagerduty_severity": {
-										Type:         schema.TypeString,
-										Optional:     true,
+										Type: schema.TypeString,
+										// technically optional, but as its the only value supported for the moment we may as well require it
+										Required:     true,
 										ValidateFunc: validation.StringInSlice([]string{"info", "warning", "error", "critical"}, false),
 									},
 								},

--- a/honeycombio/resource_trigger.go
+++ b/honeycombio/resource_trigger.go
@@ -101,6 +101,21 @@ func newTrigger() *schema.Resource {
 							Optional: true,
 							Computed: true,
 						},
+						"notification_details": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MinItems: 1,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"pagerduty_severity": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: validation.StringInSlice([]string{"info", "warning", "error", "critical"}, false),
+									},
+								},
+							},
+						},
 					},
 				},
 			},

--- a/honeycombio/type_helpers.go
+++ b/honeycombio/type_helpers.go
@@ -164,6 +164,15 @@ func flattenNotificationRecipients(rs []honeycombio.NotificationRecipient) []map
 			"type":   string(r.Type),
 			"target": r.Target,
 		}
+		if r.Details != nil {
+			// notification details have been provided
+			details := make([]map[string]interface{}, 1)
+			details[0] = map[string]interface{}{}
+			if r.Details.PDSeverity != "" {
+				details[0]["pagerduty_severity"] = string(r.Details.PDSeverity)
+			}
+			result[i]["notification_details"] = details
+		}
 	}
 
 	return result
@@ -179,6 +188,15 @@ func expandNotificationRecipients(s []interface{}) []honeycombio.NotificationRec
 			ID:     rMap["id"].(string),
 			Type:   honeycombio.RecipientType(rMap["type"].(string)),
 			Target: rMap["target"].(string),
+		}
+		if v, ok := rMap["notification_details"].([]interface{}); ok && len(v) > 0 {
+			// notification details have been provided
+			details := v[0].(map[string]interface{})
+			if s, ok := details["pagerduty_severity"]; ok {
+				recipients[i].Details = &honeycombio.NotificationRecipientDetails{
+					PDSeverity: honeycombio.PagerDutySeverity(s.(string)),
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
BurnAlerts and Triggers will now be able to optionally pass a severity level to PagerDuty when a notification is sent.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202483433776325