### PR TITLE
docs: add missing import section to new recipient resources

### DIFF
--- a/docs/resources/email_recipient.md
+++ b/docs/resources/email_recipient.md
@@ -21,3 +21,11 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the recipient.
+
+## Import
+
+Email Recipients can be imported by their ID, e.g.
+
+```
+$ terraform import honeycombio_email_recipient.my_recipient nx2zsegA0dZ
+```

--- a/docs/resources/pagerduty_recipient.md
+++ b/docs/resources/pagerduty_recipient.md
@@ -23,3 +23,11 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the recipient.
+
+## Import
+
+PagerDuty Recipients can be imported by their ID, e.g.
+
+```
+$ terraform import honeycombio_pagerduty_recipient.my_recipient nx2zsegA0dZ
+```

--- a/docs/resources/slack_recipient.md
+++ b/docs/resources/slack_recipient.md
@@ -21,3 +21,11 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the recipient.
+
+## Import
+
+Slack Recipients can be imported by their ID, e.g.
+
+```
+$ terraform import honeycombio_slack_recipient.my_recipient nx2zsegA0dZ
+```

--- a/docs/resources/webhook_recipient.md
+++ b/docs/resources/webhook_recipient.md
@@ -25,3 +25,11 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the recipient.
+
+## Import
+
+Webhook Recipients can be imported by their ID, e.g.
+
+```
+$ terraform import honeycombio_webhook_recipient.my_recipient nx2zsegA0dZ
+```


### PR DESCRIPTION
Noticed I forgot to add the `Import` section to the new email recipient docs