### PR TITLE
[dataset] introducing `created_at` and `last_written_at`

### DIFF
--- a/client/dataset.go
+++ b/client/dataset.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"time"
 )
 
 // Datasets describes all the dataset-related methods that the Honeycomb API
@@ -35,6 +36,10 @@ var _ Datasets = (*datasets)(nil)
 type Dataset struct {
 	Name string `json:"name"`
 	Slug string `json:"slug,omitempty"`
+
+	// Read only
+	LastWrittenAt time.Time `json:"last_written_at,omitempty"`
+	CreatedAt     time.Time `json:"created_at,omitempty"`
 }
 
 func (s datasets) List(ctx context.Context) ([]Dataset, error) {

--- a/client/dataset_test.go
+++ b/client/dataset_test.go
@@ -22,6 +22,16 @@ func TestDatasets(t *testing.T) {
 		d, err := c.Datasets.List(ctx)
 
 		assert.NoError(t, err)
+
+		for _, dataset := range d {
+			assert.NotNil(t, dataset.LastWrittenAt, "last written at is empty")
+			assert.NotNil(t, dataset.CreatedAt, "created at is empty")
+			// copy dynamic fields before asserting - will be skipped if expected dataset not found
+			if dataset.Name == currentDataset.Name {
+				currentDataset.LastWrittenAt = dataset.LastWrittenAt
+				currentDataset.CreatedAt = dataset.CreatedAt
+			}
+		}
 		assert.Contains(t, d, *currentDataset, "could not find current dataset with List")
 	})
 
@@ -29,6 +39,13 @@ func TestDatasets(t *testing.T) {
 		d, err := c.Datasets.Get(ctx, currentDataset.Slug)
 
 		assert.NoError(t, err)
+
+		assert.NotNil(t, d.LastWrittenAt, "last written at is empty")
+		assert.NotNil(t, d.CreatedAt, "created at is empty")
+		// copy dynamic fields before asserting equality
+		d.LastWrittenAt = currentDataset.LastWrittenAt
+		d.CreatedAt = currentDataset.CreatedAt
+
 		assert.Equal(t, *currentDataset, *d)
 	})
 
@@ -45,6 +62,13 @@ func TestDatasets(t *testing.T) {
 		d, err := c.Datasets.Create(ctx, createDataset)
 
 		assert.NoError(t, err)
+
+		assert.NotNil(t, d.LastWrittenAt, "last written at is empty")
+		assert.NotNil(t, d.CreatedAt, "created at is empty")
+		// copy dynamic fields before asserting equality
+		d.LastWrittenAt = currentDataset.LastWrittenAt
+		d.CreatedAt = currentDataset.CreatedAt
+
 		assert.Equal(t, currentDataset, d)
 	})
 }

--- a/docs/resources/dataset.md
+++ b/docs/resources/dataset.md
@@ -25,3 +25,5 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `slug` - The slug of the dataset.
+* `created_at` - ISO8601 formatted time the column was created
+* `last_written_at` - ISO8601 formatted time the column was last written to (received event data)

--- a/honeycombio/resource_dataset.go
+++ b/honeycombio/resource_dataset.go
@@ -2,6 +2,7 @@ package honeycombio
 
 import (
 	"context"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -26,6 +27,18 @@ func newDataset() *schema.Resource {
 			"slug": {
 				Type:     schema.TypeString,
 				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Required: false,
+				Optional: false,
+			},
+			"last_written_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Required: false,
+				Optional: false,
 			},
 		},
 	}
@@ -60,5 +73,7 @@ func resourceDatasetRead(ctx context.Context, d *schema.ResourceData, meta inter
 	d.SetId(dataset.Slug)
 	d.Set("name", dataset.Name)
 	d.Set("slug", dataset.Slug)
+	d.Set("created_at", dataset.CreatedAt.UTC().Format(time.RFC3339))
+	d.Set("last_written_at", dataset.CreatedAt.UTC().Format(time.RFC3339))
 	return nil
 }


### PR DESCRIPTION
Adds additional fields available when working with a Honeycomb Dataset