### PR TITLE
provider: fix crash on startup when HONEYCOMB_API_KEY env var isn't present

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.17
 
 require (
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
-	github.com/hashicorp/terraform-plugin-log v0.7.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.20.0
 	github.com/joho/godotenv v1.4.0
 	github.com/stretchr/testify v1.8.0
@@ -32,6 +31,7 @@ require (
 	github.com/hashicorp/terraform-exec v0.17.2 // indirect
 	github.com/hashicorp/terraform-json v0.14.0 // indirect
 	github.com/hashicorp/terraform-plugin-go v0.12.0 // indirect
+	github.com/hashicorp/terraform-plugin-log v0.7.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.0.0-20220623143253-7d51757b572c // indirect
 	github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 // indirect
 	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect

--- a/honeycombio/provider.go
+++ b/honeycombio/provider.go
@@ -2,9 +2,7 @@ package honeycombio
 
 import (
 	"context"
-	"os"
 
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -21,25 +19,14 @@ func init() {
 // overwritten during the release process.
 var providerVersion = "dev"
 
-func deprecatedEnvCheck() schema.SchemaDefaultFunc {
-	if _, ok := os.LookupEnv("HONEYCOMBIO_APIKEY"); ok {
-		ctx := context.Background()
-		tflog.Warn(ctx, "HONEYCOMBIO_APIKEY has been deprecated, please use HONEYCOMB_API_KEY instead")
-	}
-	return schema.EnvDefaultFunc("HONEYCOMBIO_APIKEY", nil)
-}
-
 func Provider() *schema.Provider {
 	provider := &schema.Provider{
 		Schema: map[string]*schema.Schema{
 			"api_key": {
-				Type:     schema.TypeString,
-				Required: true,
-				// Tiering goes HONEYCOMB_API_KEY > HONEYCOMBIO_APIKEY > nil
-				DefaultFunc: schema.EnvDefaultFunc(
-					"HONEYCOMB_API_KEY",
-					deprecatedEnvCheck()),
-				Sensitive: true,
+				Type:        schema.TypeString,
+				Required:    true,
+				DefaultFunc: schema.MultiEnvDefaultFunc([]string{"HONEYCOMB_API_KEY", "HONEYCOMBIO_APIKEY"}, nil),
+				Sensitive:   true,
 			},
 			"api_url": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
This removes the attempt at logging a warning, but I couldn't get tflog to play nicely anyway