### PR TITLE
bugfix: missing 'calculation' in Query Specification can cause infinite diff

### DIFF
--- a/honeycombio/data_source_query_specification.go
+++ b/honeycombio/data_source_query_specification.go
@@ -174,6 +174,8 @@ func dataSourceHoneycombioQuerySpec() *schema.Resource {
 			},
 			"json": {
 				Type:     schema.TypeString,
+				Required: false,
+				Optional: false,
 				Computed: true,
 			},
 		},

--- a/honeycombio/data_source_query_specification.go
+++ b/honeycombio/data_source_query_specification.go
@@ -278,6 +278,13 @@ func extractCalculations(d *schema.ResourceData) ([]honeycombio.CalculationSpec,
 			return nil, fmt.Errorf("calculation op %s is missing an accompanying column", calculation.Op)
 		}
 	}
+	// 'COUNT' is the default calculation and will be returned by the API `calculations`
+	// is not in the QuerySpec
+	if len(calculationSchemas) == 0 {
+		calculations = append(calculations, honeycombio.CalculationSpec{
+			Op: honeycombio.CalculationOpCount,
+		})
+	}
 
 	return calculations, nil
 }

--- a/honeycombio/data_source_query_specification.go
+++ b/honeycombio/data_source_query_specification.go
@@ -281,8 +281,9 @@ func extractCalculations(d *schema.ResourceData) ([]honeycombio.CalculationSpec,
 		}
 	}
 	// 'COUNT' is the default calculation and will be returned by the API if
-	// `calculations` is not in the QuerySpec
-	if len(calculationSchemas) == 0 {
+	// none have been provided. As this can potentially cause an infinite diff
+	// we'll set the default here if we haven't parsed any
+	if len(calculations) == 0 {
 		calculations = append(calculations, honeycombio.CalculationSpec{
 			Op: honeycombio.CalculationOpCount,
 		})

--- a/honeycombio/data_source_query_specification.go
+++ b/honeycombio/data_source_query_specification.go
@@ -280,8 +280,8 @@ func extractCalculations(d *schema.ResourceData) ([]honeycombio.CalculationSpec,
 			return nil, fmt.Errorf("calculation op %s is missing an accompanying column", calculation.Op)
 		}
 	}
-	// 'COUNT' is the default calculation and will be returned by the API `calculations`
-	// is not in the QuerySpec
+	// 'COUNT' is the default calculation and will be returned by the API if
+	// `calculations` is not in the QuerySpec
 	if len(calculationSchemas) == 0 {
 		calculations = append(calculations, honeycombio.CalculationSpec{
 			Op: honeycombio.CalculationOpCount,

--- a/honeycombio/data_source_query_specification_test.go
+++ b/honeycombio/data_source_query_specification_test.go
@@ -112,7 +112,7 @@ output "query_json" {
     value = data.honeycombio_query_specification.test.json
 }`
 
-//Note: By default go encodes `<` and `>` for html, hence the `\u003e`
+// Note: By default go encodes `<` and `>` for html, hence the `\u003e`
 const expectedJSON string = `{
   "calculations": [
     {

--- a/honeycombio/data_source_query_specification_test.go
+++ b/honeycombio/data_source_query_specification_test.go
@@ -8,6 +8,34 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
+func TestAccDataSourceHoneycombioQuery_EmptyDefaults(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          testAccPreCheck(t),
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+data "honeycombio_query_specification" "test" {}
+
+output "query_json" {
+  value = data.honeycombio_query_specification.test.json
+}
+`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckOutput("query_json", `{
+  "calculations": [
+    {
+      "op": "COUNT"
+    }
+  ],
+  "time_range": 7200
+}`),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDataSourceHoneycombioQuery_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          testAccPreCheck(t),


### PR DESCRIPTION
A `honeycombio_query_specification` without a `calculation` will get the default calculation (`COUNT`) returned by the API but cause an infinite diff for resources relying on the JSON input (e.g. `honeycombio_query`).

This resolves this issue, while also marking the `json` attribute of the data source read-only as indicated by the Terraform Plugin SDK documentation.