### PR TITLE
bugfix: missing 'type' in column resource can cause infinite diff

### DIFF
--- a/honeycombio/resource_column.go
+++ b/honeycombio/resource_column.go
@@ -41,6 +41,7 @@ func newColumn() *schema.Resource {
 			"type": {
 				Type:         schema.TypeString,
 				Optional:     true,
+				Default:      "string",
 				ValidateFunc: validation.StringInSlice(columnTypeStrings(), false),
 			},
 			"dataset": {


### PR DESCRIPTION
Omitting the optional `type` argument in the `honeycombio_column` resource will cause infinite diff.

Discovered while validating another bug 🙃 