### PR TITLE
recipient datasource - fix bug where only supplying 'type' would error

### DIFF
--- a/honeycombio/data_source_recipient.go
+++ b/honeycombio/data_source_recipient.go
@@ -140,11 +140,11 @@ func dataSourceHoneycombioRecipientRead(ctx context.Context, d *schema.ResourceD
 	}
 	matchType := honeycombio.RecipientType(d.Get("type").(string))
 
-	var rcptFilter *recipientFilter
+	rcptFilter := &recipientFilter{Type: matchType}
 	if v, ok := d.GetOk("target"); ok {
 		// deprecated argument to be removed in future
 		target := v.(string)
-		rcptFilter = &recipientFilter{Type: matchType, Value: &target}
+		rcptFilter.Value = &target
 	}
 	if v, ok := d.GetOk("detail_filter"); ok {
 		rcptFilter = expandRecipientFilter(v.([]interface{}))


### PR DESCRIPTION
Fixes a bug in the `honeycombio_recipient` data source where only supplying `type` will error even if there was _only_ one Recipient of that type in the Team.

Example:

```hcl
data "honeycombio_recipient" "test" {
  type = "email"
}

output "value" {
  value = data.honeycombio_recipient.test.id
}
```

The above will error with the current version of the provider even with exactly one Recipient of type email existing in the Team.