### PR TITLE
column: deprecate 'key_name' in favor of 'name'

### DIFF
--- a/docs/resources/column.md
+++ b/docs/resources/column.md
@@ -12,7 +12,7 @@ variable "dataset" {
 }
 
 resource "honeycombio_column" "duration_ms" { 
-  key_name    = "duration_ms_log10"
+  name        = "duration_ms_log10"
   type        = "float"
   description = "Duration of the trace"
 
@@ -25,7 +25,8 @@ resource "honeycombio_column" "duration_ms" {
 The following arguments are supported:
 
 * `dataset` - (Required) The dataset this column is added to.
-* `key_name` - (Required) The name of the column. Must be unique per dataset.
+* `name` - (Required) The name of the column. Must be unique per dataset.
+* `key_name` - (Deprecated) Please use `name` instead. The name of the column. Must be unique per dataset. Conficts with `name`.
 * `type` - (Optional) The type of the column, allowed values are `string`, `float`, `integer` and `boolean`. Defaults to `string`.
 * `hidden` - (Optional) Whether this column should be hidden in the query builder and sample data. Defaults to false.
 * `description` - (Optional) A description that is shown in the UI.
@@ -41,7 +42,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-Columns can be imported using a combination of the dataset name and their key name, e.g.
+Columns can be imported using a combination of the dataset name and their name, e.g.
 
 ```
 $ terraform import honeycombio_column.my_column my-dataset/duration_ms

--- a/honeycombio/resource_column_test.go
+++ b/honeycombio/resource_column_test.go
@@ -21,7 +21,7 @@ func TestAccHoneycombioColumn_basic(t *testing.T) {
 			{
 				Config: testAccColumnConfig(keyName, dataset),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("honeycombio_column.test", "key_name", keyName),
+					resource.TestCheckResourceAttr("honeycombio_column.test", "name", keyName),
 					resource.TestCheckResourceAttr("honeycombio_column.test", "type", "float"),
 					resource.TestCheckResourceAttr("honeycombio_column.test", "hidden", "false"),
 					resource.TestCheckResourceAttr("honeycombio_column.test", "description", "Duration of the trace"),
@@ -40,7 +40,7 @@ func TestAccHoneycombioColumn_basic(t *testing.T) {
 func testAccColumnConfig(keyName, dataset string) string {
 	return fmt.Sprintf(`
 resource "honeycombio_column" "test" {
-  key_name    = "%s"
+  name        = "%s"
   type        = "float"
   hidden      = false
   description = "Duration of the trace"


### PR DESCRIPTION
Using 'key_name' felt like we were leaking an API abstraction into the resource needlessly.

This PR also removes a surprising behavior in the column resource where an existing column would silently be used on create instead of erroring.