### PR TITLE
README: add missing OSS Lifecycle badge

### DIFF
--- a/OSSMETADATA
+++ b/OSSMETADATA
@@ -1,0 +1,1 @@
+osslifecycle=active

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Honeycomb.io Terraform Provider
 
+[![OSS Lifecycle](https://img.shields.io/osslifecycle/honeycombio/terraform-provider-honeycombio)](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md)
 [![CI](https://github.com/honeycombio/terraform-provider-honeycombio/workflows/CI/badge.svg)](https://github.com/honeycombio/terraform-provider-honeycombio/actions)
-[![Go Report Card](https://goreportcard.com/badge/github.com/honeycombio/terraform-provider-honeycombio)](https://goreportcard.com/report/github.com/honeycombio/terraform-provider-honeycombio)
 [![codecov](https://codecov.io/gh/honeycombio/terraform-provider-honeycombio/branch/main/graph/badge.svg)](https://codecov.io/gh/honeycombio/terraform-provider-honeycombio)
 [![Terraform Registry](https://img.shields.io/github/v/release/honeycombio/terraform-provider-honeycombio?color=5e4fe3&label=Terraform%20Registry&logo=terraform&sort=semver)](https://registry.terraform.io/providers/honeycombio/honeycombio/latest)
 


### PR DESCRIPTION
Noticed we didn't have the OSS lifecycle properly setup for this project.

Also removes the 'Go Report Card' badge 🤷🏻 