### PR TITLE
docs: board - remove deprecated 'dataset' from simple board example

### DIFF
--- a/docs/resources/board.md
+++ b/docs/resources/board.md
@@ -30,7 +30,6 @@ resource "honeycombio_board" "board" {
   name        = "My Board"
 
   query {
-    dataset  = var.dataset
     query_id = honeycombio_query.query.id
   }
 }


### PR DESCRIPTION
Noticed this while validating a bug.
