### PR TITLE
[ci] update workflow to work for pull_request_target

### DIFF
--- a/.github/workflows/gh-pr-to-asana.yaml
+++ b/.github/workflows/gh-pr-to-asana.yaml
@@ -1,6 +1,6 @@
 name: Sync Github Pull Request to Asana
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened]
 
 jobs:
@@ -9,7 +9,7 @@ jobs:
     name: Create pull request attachments on Asana tasks
     steps:
       - name: Create pull request attachments
-        uses: Asana/create-app-attachment-github-action@latest
+        uses: honeycombio/gha-create-pr-attachment@main
         id: postAttachment
         with:
           asana-secret: ${{ secrets.ASANA_SECRET }}


### PR DESCRIPTION
## Short description of the changes

This change updates the PR to Asana workflow to run on pull_request_target events so it can work on PRs from forks. This should subvert the need to approve the workflow to run and allow the workflow to access the necessary secrets.
