### PR TITLE
docs: fix README.md markdown rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,11 @@
 A Terraform provider for Honeycomb.io.
 
 📄 Check out [the documentation](https://registry.terraform.io/providers/honeycombio/honeycombio/latest/docs)
+
 🏗️ Examples can be found in [example/](example/)
+
 ❓ Questions? Feel free to create a new issue or find us on the **Honeycomb Pollinators** Slack, channel [**#terraform-provider**](https://honeycombpollinators.slack.com/archives/C017T9FFT0D) (you can find a link to request an invite [here](https://www.honeycomb.io/blog/spread-the-love-appreciating-our-pollinators-community/))
+
 🔧 Want to contribute? Check out [CONTRIBUTING.md](./CONTRIBUTING.md)
 
 ## Using the provider


### PR DESCRIPTION
## Which problem is this PR solving?

The general description includes multiple sections which were rendering in a single line instead of multiple lines because of the missing line in-between

## How to verify that this has the expected result

before
<img width="1043" alt="Screenshot 2022-12-14 at 16 47 13" src="https://user-images.githubusercontent.com/1898225/207642824-3cf7c012-a279-4238-8125-8d72309e31dd.png">

after
<img width="1058" alt="Screenshot 2022-12-14 at 16 47 01" src="https://user-images.githubusercontent.com/1898225/207642844-3c66968f-c058-4559-b3fa-9127b63fe7f1.png">
