### PR TITLE
Add board_url link to the board resource output

### DIFF
--- a/client/board.go
+++ b/client/board.go
@@ -53,6 +53,8 @@ type Board struct {
 	ColumnLayout BoardColumnStyle `json:"column_layout,omitempty"`
 	// How the board should be displayed in the UI, defaults to "list".
 	Style BoardStyle `json:"style,omitempty"`
+	// Links returned by the board API for the Board
+	Links BoardLinks `json:"links,omitempty"`
 	// A list of queries displayed on the board, in order of appearance.
 	Queries []BoardQuery `json:"queries"`
 }
@@ -77,6 +79,12 @@ const (
 	BoardColumnStyleMulti  BoardColumnStyle = "multi"
 	BoardColumnStyleSingle BoardColumnStyle = "single"
 )
+
+// BoardLinks represents links returned by the board API.
+type BoardLinks struct {
+	// URL For accessing the board
+	BoardURL string `json:"board_url,omitempty"`
+}
 
 // BoardQuery represents a query that is part of a board.
 type BoardQuery struct {

--- a/client/board_test.go
+++ b/client/board_test.go
@@ -54,6 +54,10 @@ func TestBoards(t *testing.T) {
 		data.ID = b.ID
 		data.Queries[0].QueryID = b.Queries[0].QueryID
 
+		// ensure the board URL got populated
+		assert.NotEqual(t, b.Links.BoardURL, "")
+		data.Links.BoardURL = b.Links.BoardURL
+
 		assert.Equal(t, data, b)
 	})
 

--- a/docs/resources/board.md
+++ b/docs/resources/board.md
@@ -125,12 +125,13 @@ Currently supported toggles are:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - ID of the board.
+* `board_url` - The URL to the board in the Honeycomb UI.
 
 ## Import
 
 Boards can be imported using their ID, e.g.
 
-```
+```shell
 $ terraform import honeycombio_board.my_board AobW9oAZX71
 ```
 

--- a/honeycombio/resource_board.go
+++ b/honeycombio/resource_board.go
@@ -44,10 +44,10 @@ func newBoard() *schema.Resource {
 				ValidateFunc: validation.StringInSlice(boardStyleStrings(), false),
 			},
 			"board_url": {
-				Type:       schema.TypeString,
-				Required:   false,
-				Optional:   false,
-				Computed:   true,
+				Type:     schema.TypeString,
+				Required: false,
+				Optional: false,
+				Computed: true,
 			},
 			"query": {
 				Type:     schema.TypeList,

--- a/honeycombio/resource_board.go
+++ b/honeycombio/resource_board.go
@@ -43,6 +43,12 @@ func newBoard() *schema.Resource {
 				Default:      "list",
 				ValidateFunc: validation.StringInSlice(boardStyleStrings(), false),
 			},
+			"board_url": {
+				Type:       schema.TypeString,
+				Required:   false,
+				Optional:   false,
+				Computed:   true,
+			},
 			"query": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -156,6 +162,7 @@ func resourceBoardRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	d.Set("description", b.Description)
 	d.Set("style", b.Style)
 	d.Set("column_layout", b.ColumnLayout)
+	d.Set("board_url", b.Links.BoardURL)
 
 	queries := make([]map[string]interface{}, len(b.Queries))
 


### PR DESCRIPTION
Co-authored-by: Jason Harley <jason@honeycomb.io>
Signed-off-by: Davin Taddeo <davin@honeycomb.io>

<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->


## Short description of the changes
Adds the new `board_url` output from the Boards API when returning a board create or get action

## How to verify that this has the expected result
