### PR TITLE
honeycombio_column: delete column on destroy

### DIFF
--- a/docs/resources/column.md
+++ b/docs/resources/column.md
@@ -1,8 +1,9 @@
 # Resource: honeycombio_column
 
-Creates a column in a dataset.
+Provides a Honeycomb Column resource.
+This can be used to create, update, and delete columns in a dataset.
 
--> **Note** Destroying or replacing this resource will not delete the previously created column. This is intentional to preserve the column and its data. The API supports deleting columns, so if this is required for your use case please open an issue in [honeycombio/terraform-provider-honeycombio](https://github.com/honeycombio/terraform-provider-honeycombio).
+-> **Note**: prior to version 0.13.0 of the provider, columns were *not* deleted on destroy but left in place and only removed from state.
 
 ## Example Usage
 
@@ -11,7 +12,7 @@ variable "dataset" {
   type = string
 }
 
-resource "honeycombio_column" "duration_ms" { 
+resource "honeycombio_column" "duration_ms" {
   name        = "duration_ms_log10"
   type        = "float"
   description = "Duration of the trace"

--- a/docs/resources/column.md
+++ b/docs/resources/column.md
@@ -3,6 +3,8 @@
 Provides a Honeycomb Column resource.
 This can be used to create, update, and delete columns in a dataset.
 
+-> **Note**: deleting a column is a destructive and irreversible operation which also removes the data in the column.
+
 -> **Note**: prior to version 0.13.0 of the provider, columns were *not* deleted on destroy but left in place and only removed from state.
 
 ## Example Usage

--- a/honeycombio/resource_column.go
+++ b/honeycombio/resource_column.go
@@ -17,7 +17,7 @@ func newColumn() *schema.Resource {
 		CreateContext: resourceColumnCreate,
 		ReadContext:   resourceColumnRead,
 		UpdateContext: resourceColumnUpdate,
-		DeleteContext: schema.NoopContext,
+		DeleteContext: resourceColumnDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceColumnImport,
 		},
@@ -157,6 +157,18 @@ func resourceColumnUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 
 	d.SetId(column.ID)
 	return resourceColumnRead(ctx, d, meta)
+}
+
+func resourceColumnDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*honeycombio.Client)
+
+	dataset := d.Get("dataset").(string)
+
+	err := client.Columns.Delete(ctx, dataset, d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
 }
 
 func expandColumn(d *schema.ResourceData) *honeycombio.Column {

--- a/honeycombio/resource_column_test.go
+++ b/honeycombio/resource_column_test.go
@@ -1,12 +1,14 @@
 package honeycombio
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccHoneycombioColumn_basic(t *testing.T) {
@@ -34,6 +36,17 @@ func TestAccHoneycombioColumn_basic(t *testing.T) {
 				ImportStateVerify: true,
 			},
 		},
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			func(s *terraform.State) error {
+				// ensure column is removed on destroy
+				client := testAccClient(t)
+				_, err := client.Columns.GetByKeyName(context.Background(), dataset, keyName)
+				if err == nil {
+					return fmt.Errorf("column %q was not deleted on destroy", keyName)
+				}
+				return nil
+			},
+		),
 	})
 }
 


### PR DESCRIPTION
Since the provider's inception this resource treated deletes as a 'noop' -- simply removing the column from state.

In 0.12.0 we removed the silent import of an existing column on create which has forced this gap into the light.

Given that column deletes are fully supported in the API, it felt proper to enable them here as it is assumed that the operator understands that there is removal.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203644387911130