### PR TITLE
correct dataset in honeycombio_query example

### DIFF
--- a/docs/resources/query.md
+++ b/docs/resources/query.md
@@ -27,7 +27,7 @@ data "honeycombio_query_specification" "test_query" {
 }
 
 resource "honeycombio_query" "test_query" {
-  dataset    = "%s"
+  dataset    = var.dataset
   query_json = data.honeycombio_query_specification.test_query.json
 }
 ```


### PR DESCRIPTION
The `dataset = %s` was a typo.