### PR TITLE
correct time_range in honeycombio_trigger example

### DIFF
--- a/docs/resources/trigger.md
+++ b/docs/resources/trigger.md
@@ -21,6 +21,8 @@ data "honeycombio_query_specification" "example" {
     column = "trace.parent_id"
     op     = "does-not-exist"
   }
+
+  time_range = 1800
 }
 
 resource "honeycombio_query" "example" {


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Closes #271 

## Short description of the changes

When you use the example code in `honeycombio_trigger`'s documentation,
it will fail at time of `terraform apply`.

The error returned from the Honeycomb API says that the query duration
can't be more than 4x greater than the trigger's frequency.

The default time_range on `honeycombio_query_specification` is 7200
which is 12x larger than the `frequency` on `honeycombio_trigger`.

An alternative fix would be to change the `frequency` setting, instead.
I'd be willing to go that route, and produce another PR! It felt like
maybe it's worth mentioning the `time_range` value explicitly here, but
I'm not convinced on that.

Another possible change would be to change the default `time_range`, but
that would be a breaking change. Not only because of user expectations
but also because the provider's current trigger API requires passing
query ids from immutable query objects. If the `time_range` was updated,
it would cause the `honeycombio_query` resources to attempt to update
themselves which would then fail because queries are immutable in the
Honeycomb API.

## How to verify that this has the expected result

Trying out the example code in a new terraform configuration