### PR TITLE
bugfix: query equivalence for time_range, filter ops, and calculations

### DIFF
--- a/client/board_test.go
+++ b/client/board_test.go
@@ -82,7 +82,7 @@ func TestBoards(t *testing.T) {
 					Op: CalculationOpCount,
 				},
 			},
-			TimeRange: ToPtr(7200), // 2 hours
+			TimeRange: ToPtr(DefaultQueryTimeRange),
 		})
 		assert.NoError(t, err)
 		b.ColumnLayout = BoardColumnStyleMulti

--- a/client/query_spec_test.go
+++ b/client/query_spec_test.go
@@ -88,7 +88,7 @@ func TestQuerySpec_EquivalentTo(t *testing.T) {
 					},
 				},
 				FilterCombination: "AND",
-				TimeRange:         ToPtr(7200),
+				TimeRange:         ToPtr(DefaultQueryTimeRange),
 			},
 			QuerySpec{},
 			true,
@@ -123,7 +123,7 @@ func TestQuerySpec_EquivalentTo(t *testing.T) {
 					},
 				},
 				Breakdowns: []string{"colB", "colA"},
-				TimeRange:  ToPtr(7200),
+				TimeRange:  ToPtr(DefaultQueryTimeRange),
 			},
 			QuerySpec{
 				Calculations: []CalculationSpec{

--- a/client/query_spec_test.go
+++ b/client/query_spec_test.go
@@ -183,12 +183,93 @@ func TestQuerySpec_EquivalentTo(t *testing.T) {
 			},
 			false,
 		},
+		{
+			"Different time ranges",
+			QuerySpec{
+				Calculations: []CalculationSpec{
+					{
+						Op: "COUNT",
+					},
+				},
+				TimeRange: ToPtr(1800),
+			},
+			QuerySpec{
+				Calculations: []CalculationSpec{
+					{
+						Op: "COUNT",
+					},
+				},
+			},
+			false,
+		},
+		{
+			"Different FilterCombinations",
+			QuerySpec{
+				FilterCombination: "OR",
+			},
+			QuerySpec{},
+			false,
+		},
+		{
+			"Calculation different from DefaultCalc",
+			QuerySpec{
+				Calculations: []CalculationSpec{
+					{
+						Op:     "MIN",
+						Column: ToPtr("metrics.cpu.utilization"),
+					},
+				},
+			},
+			QuerySpec{},
+			false,
+		},
+		{
+			"Different Calculations",
+			QuerySpec{
+				Calculations: []CalculationSpec{
+					{
+						Op:     "MIN",
+						Column: ToPtr("metrics.cpu.utilization"),
+					},
+				},
+			},
+			QuerySpec{
+				Calculations: []CalculationSpec{
+					{
+						Op:     "MAX",
+						Column: ToPtr("metrics.cpu.utilization"),
+					},
+				},
+			},
+			false,
+		},
+		{
+			"Different Number of Calculations",
+			QuerySpec{
+				Calculations: []CalculationSpec{
+					{
+						Op:     "MIN",
+						Column: ToPtr("metrics.cpu.utilization"),
+					},
+				},
+			},
+			QuerySpec{
+				Calculations: []CalculationSpec{
+					{
+						Op: "COUNT_DISTINCT",
+					},
+					{
+						Op:     "MAX",
+						Column: ToPtr("metrics.cpu.utilization"),
+					},
+				},
+			},
+			false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.a.EquivalentTo(tt.b); got != tt.want {
-				t.Errorf("QuerySpec.EquivalentTo() = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.want, tt.a.EquivalentTo(tt.b))
 		})
 	}
 }

--- a/client/type_helpers.go
+++ b/client/type_helpers.go
@@ -52,17 +52,15 @@ func IsZero[T comparable](v T) bool {
 }
 
 func PtrValueOrDefault[T any](v *T, d T) T {
-	var result = d
 	if v != nil {
-		result = *v
+		return *v
 	}
-	return result
+	return d
 }
 
 func ValueOrDefault[T comparable](v, d T) T {
-	var result = d
 	if !IsZero(v) {
-		result = v
+		return v
 	}
-	return result
+	return d
 }

--- a/client/type_helpers.go
+++ b/client/type_helpers.go
@@ -46,3 +46,23 @@ func Equivalent[T any](a, b []T) bool {
 
 	return true
 }
+
+func IsZero[T comparable](v T) bool {
+	return v == *new(T)
+}
+
+func PtrValueOrDefault[T any](v *T, d T) T {
+	var result = d
+	if v != nil {
+		result = *v
+	}
+	return result
+}
+
+func ValueOrDefault[T comparable](v, d T) T {
+	var result = d
+	if !IsZero(v) {
+		result = v
+	}
+	return result
+}

--- a/honeycombio/data_source_query_specification.go
+++ b/honeycombio/data_source_query_specification.go
@@ -113,8 +113,8 @@ func dataSourceHoneycombioQuerySpec() *schema.Resource {
 			"filter_combination": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				Default:      "AND",
-				ValidateFunc: validation.StringInSlice([]string{"AND", "OR"}, false),
+				Default:      honeycombio.DefaultFilterCombination,
+				ValidateFunc: validation.StringInSlice([]string{string(honeycombio.FilterCombinationAnd), string(honeycombio.FilterCombinationOr)}, false),
 			},
 			"breakdowns": {
 				Type:     schema.TypeList,
@@ -158,7 +158,7 @@ func dataSourceHoneycombioQuerySpec() *schema.Resource {
 				// Terraform isn't able to set the computed value causing a
 				// constant diff. By using a default value instead, we don't
 				// need the feedback from the API.
-				Default: 7200,
+				Default: honeycombio.DefaultQueryTimeRange,
 			},
 			"start_time": {
 				Type:     schema.TypeInt,
@@ -213,10 +213,10 @@ func dataSourceHoneycombioQuerySpecRead(ctx context.Context, d *schema.ResourceD
 		}
 	}
 
-	// The API doesn't return filter_combination if it is 'AND' (the default)
+	// The API doesn't return filter_combination if it's the default
 	var filterCombination honeycombio.FilterCombination
 	filterString := d.Get("filter_combination").(string)
-	if filterString != "" && filterString != "AND" {
+	if filterString != "" && filterString != string(honeycombio.DefaultFilterCombination) {
 		// doing it this way to support possible different filter types in future
 		// and having one less place to update them
 		filterCombination = honeycombio.FilterCombination(filterString)

--- a/honeycombio/resource_query_test.go
+++ b/honeycombio/resource_query_test.go
@@ -94,7 +94,7 @@ func testAccCheckQueryExists(t *testing.T, dataset string, name string, duration
 					Value:  float64(duration),
 				},
 			},
-			TimeRange: honeycombio.ToPtr(7200),
+			TimeRange: honeycombio.ToPtr(honeycombio.DefaultQueryTimeRange),
 		}
 
 		ok = assert.Equal(t, expectedQuery, createdQuery)


### PR DESCRIPTION
## Which problem is this PR solving?

- Closes #275

## Short description of the changes

The QuerySpec 'equivalence' functionality introduced in #236 to suppress diffs failed to detect changes in `time_range`, `filter_combination`, and `calculation`.
