### PR TITLE
Add overlaid charts support

### DIFF
--- a/client/board.go
+++ b/client/board.go
@@ -113,11 +113,12 @@ const (
 
 // BoardGraphSettings represents the display settings for an individual graph in a board.
 type BoardGraphSettings struct {
-	OmitMissingValues bool `json:"omit_missing_values,omitempty"`
-	UseStackedGraphs  bool `json:"stacked_graphs,omitempty"`
-	UseLogScale       bool `json:"log_scale,omitempty"`
-	UseUTCXAxis       bool `json:"utc_xaxis,omitempty"`
-	HideMarkers       bool `json:"hide_markers,omitempty"`
+	OmitMissingValues    bool `json:"omit_missing_values,omitempty"`
+	UseStackedGraphs     bool `json:"stacked_graphs,omitempty"`
+	UseLogScale          bool `json:"log_scale,omitempty"`
+	UseUTCXAxis          bool `json:"utc_xaxis,omitempty"`
+	HideMarkers          bool `json:"hide_markers,omitempty"`
+	PreferOverlaidCharts bool `json:"overlaid_charts,omitempty"`
 }
 
 // BoardQueryStyles returns an exhaustive list of board query styles.

--- a/docs/resources/board.md
+++ b/docs/resources/board.md
@@ -96,36 +96,39 @@ resource "honeycombio_board" "overview" {
 
 The following arguments are supported:
 
-* `name` - (Required) Name of the board.
-* `description` - (Optional) Description of the board. Supports markdown.
-* `column_layout` - (Optional) the number of columns to layout on the board, either `multi` (the default) or `single`. Only `visual` style boards (see below) have a column layout.
-* `style` - (Optional) How the board should be displayed in the UI, either `list` (the default) or `visual`.
-* `query` - (Optional) Zero or more configurations blocks (described below) with the queries of the board.
+-   `name` - (Required) Name of the board.
+-   `description` - (Optional) Description of the board. Supports markdown.
+-   `column_layout` - (Optional) the number of columns to layout on the board, either `multi` (the default) or `single`. Only `visual` style boards (see below) have a column layout.
+-   `style` - (Optional) How the board should be displayed in the UI, either `list` (the default) or `visual`.
+-   `query` - (Optional) Zero or more configurations blocks (described below) with the queries of the board.
 
 Each board configuration may have zero or more `query` blocks, which accepts the following arguments:
 
-* `query_id` - (Required) The ID of the Query to run.
-* `query_annotation_id` - (Optional) The ID of the Query Annotation to associate with this query.
-* `dataset` - (Deprecated) The dataset this query is associated with.
-* `caption` - (Optional) A description of the query that will be displayed on the board. Supports markdown.
-* `graph_settings` - (Optional) A map of boolean toggles to manages the settings for this query's graph on the board.
-If a value is unspecified, it is assumed to be false.
-Currently supported toggles are:
-  * `hide_markers`
-  * `log_scale`
-  * `omit_missing_values`
-  * `stacked_graphs`
-  * `utc_xaxis`
+-   `query_id` - (Required) The ID of the Query to run.
+-   `query_annotation_id` - (Optional) The ID of the Query Annotation to associate with this query.
+-   `dataset` - (Deprecated) The dataset this query is associated with.
+-   `caption` - (Optional) A description of the query that will be displayed on the board. Supports markdown.
+-   `graph_settings` - (Optional) A map of boolean toggles to manages the settings for this query's graph on the board.
+    If a value is unspecified, it is assumed to be false.
+    Currently supported toggles are:
 
-  See [Graph Settings](https://docs.honeycomb.io/working-with-your-data/graph-settings/) in the documentation for more information on any individual setting.
-* `query_style` - (Optional) How the query should be displayed within the board, either `graph` (the default), `table` or `combo`.
+    -   `hide_markers`
+    -   `log_scale`
+    -   `omit_missing_values`
+    -   `stacked_graphs`
+    -   `utc_xaxis`
+    -   `overlaid_charts`
+
+    See [Graph Settings](https://docs.honeycomb.io/working-with-your-data/graph-settings/) in the documentation for more information on any individual setting.
+
+-   `query_style` - (Optional) How the query should be displayed within the board, either `graph` (the default), `table` or `combo`.
 
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - ID of the board.
-* `board_url` - The URL to the board in the Honeycomb UI.
+-   `id` - ID of the board.
+-   `board_url` - The URL to the board in the Honeycomb UI.
 
 ## Import
 

--- a/docs/resources/board.md
+++ b/docs/resources/board.md
@@ -96,39 +96,37 @@ resource "honeycombio_board" "overview" {
 
 The following arguments are supported:
 
--   `name` - (Required) Name of the board.
--   `description` - (Optional) Description of the board. Supports markdown.
--   `column_layout` - (Optional) the number of columns to layout on the board, either `multi` (the default) or `single`. Only `visual` style boards (see below) have a column layout.
--   `style` - (Optional) How the board should be displayed in the UI, either `list` (the default) or `visual`.
--   `query` - (Optional) Zero or more configurations blocks (described below) with the queries of the board.
+* `name` - (Required) Name of the board.
+* `description` - (Optional) Description of the board. Supports markdown.
+* `column_layout` - (Optional) the number of columns to layout on the board, either `multi` (the default) or `single`. Only `visual` style boards (see below) have a column layout.
+* `style` - (Optional) How the board should be displayed in the UI, either `list` (the default) or `visual`.
+* `query` - (Optional) Zero or more configurations blocks (described below) with the queries of the board.
 
 Each board configuration may have zero or more `query` blocks, which accepts the following arguments:
 
--   `query_id` - (Required) The ID of the Query to run.
--   `query_annotation_id` - (Optional) The ID of the Query Annotation to associate with this query.
--   `dataset` - (Deprecated) The dataset this query is associated with.
--   `caption` - (Optional) A description of the query that will be displayed on the board. Supports markdown.
--   `graph_settings` - (Optional) A map of boolean toggles to manages the settings for this query's graph on the board.
-    If a value is unspecified, it is assumed to be false.
-    Currently supported toggles are:
+* `query_id` - (Required) The ID of the Query to run.
+* `query_annotation_id` - (Optional) The ID of the Query Annotation to associate with this query.
+* `dataset` - (Deprecated) The dataset this query is associated with.
+* `caption` - (Optional) A description of the query that will be displayed on the board. Supports markdown.
+* `graph_settings` - (Optional) A map of boolean toggles to manages the settings for this query's graph on the board.
+If a value is unspecified, it is assumed to be false.
+Currently supported toggles are:
+  * `hide_markers`
+  * `log_scale`
+  * `omit_missing_values`
+  * `stacked_graphs`
+  * `utc_xaxis`
+  * `overlaid_charts`
 
-    -   `hide_markers`
-    -   `log_scale`
-    -   `omit_missing_values`
-    -   `stacked_graphs`
-    -   `utc_xaxis`
-    -   `overlaid_charts`
-
-    See [Graph Settings](https://docs.honeycomb.io/working-with-your-data/graph-settings/) in the documentation for more information on any individual setting.
-
--   `query_style` - (Optional) How the query should be displayed within the board, either `graph` (the default), `table` or `combo`.
+  See [Graph Settings](https://docs.honeycomb.io/working-with-your-data/graph-settings/) in the documentation for more information on any individual setting.
+* `query_style` - (Optional) How the query should be displayed within the board, either `graph` (the default), `table` or `combo`.
 
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
--   `id` - ID of the board.
--   `board_url` - The URL to the board in the Honeycomb UI.
+* `id` - ID of the board.
+* `board_url` - The URL to the board in the Honeycomb UI.
 
 ## Import
 

--- a/honeycombio/resource_board.go
+++ b/honeycombio/resource_board.go
@@ -105,6 +105,12 @@ See [Graph Settings](https://docs.honeycomb.io/working-with-your-data/graph-sett
 										Optional:    true,
 										Description: "Set the graph's X axis to UTC.",
 									},
+									"overlaid_charts": {
+										Type:        schema.TypeBool,
+										Computed:    true,
+										Optional:    true,
+										Description: "Allow charts to be overlaid when using supported Visualize operators",
+									},
 								},
 							},
 						},

--- a/honeycombio/resource_board.go
+++ b/honeycombio/resource_board.go
@@ -284,7 +284,6 @@ func expandBoardQueryGraphSettings(gs interface{}) (honeycombio.BoardGraphSettin
 	if v, ok := s["utc_xaxis"].(bool); ok && v {
 		graphSettings.UseUTCXAxis = true
 	}
-
 	if v, ok := s["overlaid_charts"].(bool); ok && v {
 		graphSettings.PreferOverlaidCharts = true
 	}

--- a/honeycombio/resource_board.go
+++ b/honeycombio/resource_board.go
@@ -109,7 +109,7 @@ See [Graph Settings](https://docs.honeycomb.io/working-with-your-data/graph-sett
 										Type:        schema.TypeBool,
 										Computed:    true,
 										Optional:    true,
-										Description: "Allow charts to be overlaid when using supported Visualize operators",
+										Description: "Allow charts to be overlaid when using supported Visualize operators.",
 									},
 								},
 							},

--- a/honeycombio/resource_board.go
+++ b/honeycombio/resource_board.go
@@ -279,6 +279,10 @@ func expandBoardQueryGraphSettings(gs interface{}) (honeycombio.BoardGraphSettin
 		graphSettings.UseUTCXAxis = true
 	}
 
+	if v, ok := s["overlaid_charts"].(bool); ok && v {
+		graphSettings.PreferOverlaidCharts = true
+	}
+
 	return graphSettings, nil
 }
 
@@ -291,6 +295,7 @@ func flattenBoardQueryGraphSettings(gs honeycombio.BoardGraphSettings) []map[str
 		"omit_missing_values": gs.OmitMissingValues,
 		"stacked_graphs":      gs.UseStackedGraphs,
 		"utc_xaxis":           gs.UseUTCXAxis,
+		"overlaid_charts":     gs.PreferOverlaidCharts,
 	})
 
 	return result


### PR DESCRIPTION
## Which problem is this PR solving?

You can't set a query to display with overlaid aggregates on a board without access to the right graph settings.

## Short description of the changes

Adds the overlaid_charts graph setting that is supported by the API

## How to verify that this has the expected result

Configure a board with the overlaid charts option and verify that that is reflected in Honeycomb