### PR TITLE
fix - marker client test flake

### DIFF
--- a/client/marker_test.go
+++ b/client/marker_test.go
@@ -58,6 +58,7 @@ func TestMarkers(t *testing.T) {
 		result, err := c.Markers.Update(ctx, dataset, m)
 
 		assert.NoError(t, err)
+		assert.Equal(t, m.ID, result.ID)
 		assert.Equal(t, m.Message, result.Message)
 		assert.Equal(t, m.Type, result.Type)
 		assert.Equal(t, m.URL, result.URL)

--- a/client/marker_test.go
+++ b/client/marker_test.go
@@ -61,7 +61,7 @@ func TestMarkers(t *testing.T) {
 		assert.Equal(t, m.Message, result.Message)
 		assert.Equal(t, m.Type, result.Type)
 		assert.Equal(t, m.URL, result.URL)
-		assert.WithinDuration(t, time.UnixMilli(m.StartTime), time.UnixMilli(m.StartTime), 5*time.Second)
+		assert.WithinDuration(t, time.UnixMilli(m.StartTime), time.UnixMilli(result.StartTime), 5*time.Second)
 		assert.WithinDuration(t, time.UnixMilli(m.EndTime), time.UnixMilli(result.EndTime), 5*time.Second)
 	})
 

--- a/client/marker_test.go
+++ b/client/marker_test.go
@@ -34,8 +34,8 @@ func TestMarkers(t *testing.T) {
 		assert.Equal(t, data.Message, m.Message)
 		assert.Equal(t, data.Type, m.Type)
 		assert.Equal(t, data.URL, m.URL)
-		assert.Equal(t, data.StartTime, m.StartTime)
-		assert.Equal(t, data.EndTime, m.EndTime)
+		assert.WithinDuration(t, time.UnixMilli(data.StartTime), time.UnixMilli(m.StartTime), 5*time.Second)
+		assert.WithinDuration(t, time.UnixMilli(data.EndTime), time.UnixMilli(m.EndTime), 5*time.Second)
 	})
 
 	t.Run("List", func(t *testing.T) {
@@ -58,7 +58,7 @@ func TestMarkers(t *testing.T) {
 		result, err := c.Markers.Update(ctx, dataset, m)
 
 		assert.NoError(t, err)
-		assert.Equal(t, m, result)
+		assert.WithinDuration(t, time.UnixMilli(m.EndTime), time.UnixMilli(result.EndTime), 5*time.Second)
 	})
 
 	t.Run("Delete", func(t *testing.T) {

--- a/client/marker_test.go
+++ b/client/marker_test.go
@@ -58,6 +58,10 @@ func TestMarkers(t *testing.T) {
 		result, err := c.Markers.Update(ctx, dataset, m)
 
 		assert.NoError(t, err)
+		assert.Equal(t, m.Message, result.Message)
+		assert.Equal(t, m.Type, result.Type)
+		assert.Equal(t, m.URL, result.URL)
+		assert.WithinDuration(t, time.UnixMilli(m.StartTime), time.UnixMilli(m.StartTime), 5*time.Second)
 		assert.WithinDuration(t, time.UnixMilli(m.EndTime), time.UnixMilli(result.EndTime), 5*time.Second)
 	})
 


### PR DESCRIPTION
The client's Marker test suite has failed a few times on a time comparison test ([most recent example](https://github.com/honeycombio/terraform-provider-honeycombio/actions/runs/4458036388/jobs/7829506246)).

This fixes that up ✨ 