### PR TITLE
honeycombio_dataset: add import support

### DIFF
--- a/docs/resources/dataset.md
+++ b/docs/resources/dataset.md
@@ -30,3 +30,13 @@ In addition to all arguments above, the following attributes are exported:
 * `slug` - The slug of the dataset.
 * `created_at` - ISO8601 formatted time the column was created
 * `last_written_at` - ISO8601 formatted time the column was last written to (received event data)
+
+## Import
+
+Datasets can be imported by their slug, e.g.
+
+```shell
+$ terraform import honeycombio_column.my_dataset my-dataset
+```
+
+You can find the slug in the URL bar when visiting the Dataset from the UI.

--- a/docs/resources/dataset.md
+++ b/docs/resources/dataset.md
@@ -36,7 +36,7 @@ In addition to all arguments above, the following attributes are exported:
 Datasets can be imported by their slug, e.g.
 
 ```shell
-$ terraform import honeycombio_column.my_dataset my-dataset
+$ terraform import honeycombio_dataset.my_dataset my-dataset
 ```
 
 You can find the slug in the URL bar when visiting the Dataset from the UI.

--- a/honeycombio/resource_dataset.go
+++ b/honeycombio/resource_dataset.go
@@ -16,6 +16,9 @@ func newDataset() *schema.Resource {
 		ReadContext:   resourceDatasetRead,
 		UpdateContext: resourceDatasetUpdate,
 		DeleteContext: schema.NoopContext,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/honeycombio/resource_dataset_test.go
+++ b/honeycombio/resource_dataset_test.go
@@ -25,6 +25,12 @@ func TestAccHoneycombioDataset_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("honeycombio_dataset.test", "expand_json_depth", "3"),
 				),
 			},
+			{
+				ResourceName:      "honeycombio_dataset.test",
+				ImportStateId:     testDatasetName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }


### PR DESCRIPTION
## Which problem is this PR solving?

- Closes #290 

## Short description of the changes

Adds import support for `honeycombio_dataset`. Now that the resource supports managing `description` and `expand_json_depth` this feels like a more natural Terraform experience.
