### PR TITLE
appease the linter gods

### DIFF
--- a/client/burn_alert_test.go
+++ b/client/burn_alert_test.go
@@ -33,6 +33,7 @@ func TestBurnAlerts(t *testing.T) {
 		t.Fatal(err)
 	}
 	// remove SLO and SLI at the end of the test run
+	//nolint:errcheck
 	t.Cleanup(func() {
 		c.SLOs.Delete(ctx, dataset, slo.ID)
 		c.DerivedColumns.Delete(ctx, dataset, sli.ID)

--- a/client/client.go
+++ b/client/client.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
@@ -207,7 +206,7 @@ func (e *honeycombioError) Error() string {
 }
 
 func attemptToExtractHoneycombioError(bodyReader io.Reader) string {
-	body, err := ioutil.ReadAll(bodyReader)
+	body, err := io.ReadAll(bodyReader)
 	if err != nil {
 		return ""
 	}

--- a/client/dataset_definitions_test.go
+++ b/client/dataset_definitions_test.go
@@ -21,6 +21,7 @@ func TestDatasetDefinitions(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	// reset all defs and remove test helpers at end of test run
+	//nolint:errcheck
 	t.Cleanup(func() {
 		c.DatasetDefinitions.ResetAll(ctx, dataset)
 		c.Columns.Delete(ctx, dataset, col.ID)

--- a/client/dataset_test.go
+++ b/client/dataset_test.go
@@ -83,6 +83,7 @@ func TestDatasets(t *testing.T) {
 		}
 		t.Cleanup(func() {
 			// revert updated fields to defaults after the test run
+			//nolint:errcheck
 			c.Datasets.Update(ctx, &Dataset{Name: datasetName})
 		})
 		d, err := c.Datasets.Update(ctx, updateDataset)

--- a/client/slo_test.go
+++ b/client/slo_test.go
@@ -25,6 +25,7 @@ func TestSLOs(t *testing.T) {
 	}
 	// remove SLI DC at end of test run
 	t.Cleanup(func() {
+		//nolint:errcheck
 		c.DerivedColumns.Delete(ctx, dataset, sli.ID)
 	})
 


### PR DESCRIPTION
There were a handful of linter warnings and this fixes or suppresses them all to allow any new ones to be more obvious.