### PR TITLE
client - escape query string when listing burn alerts for an SLO

### DIFF
--- a/client/burn_alert.go
+++ b/client/burn_alert.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"time"
 )
 
@@ -52,7 +53,7 @@ type BurnAlert struct {
 
 func (s *burnalerts) ListForSLO(ctx context.Context, dataset string, sloId string) ([]BurnAlert, error) {
 	var b []BurnAlert
-	err := s.client.performRequest(ctx, "GET", fmt.Sprintf("/1/burn_alerts/%s?slo_id=%s", urlEncodeDataset(dataset), sloId), nil, &b)
+	err := s.client.performRequest(ctx, "GET", fmt.Sprintf("/1/burn_alerts/%s?slo_id=%s", urlEncodeDataset(dataset), url.QueryEscape(sloId)), nil, &b)
 	return b, err
 }
 


### PR DESCRIPTION
## Which problem is this PR solving?

- Closes #300 

## Short description of the changes

As reported in #297, blindly passing HCL inputs into the query can cause bad behaviour. This is the only other place in the codebase (after #297 is merged) which uses an unescaped query parameter.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204461304887421