### PR TITLE
Mention the example directory from the main docs page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -36,6 +36,8 @@ resource "honeycombio_marker" "hello" {
 }
 ```
 
+More advanced examples may be found in the [example directory](/example/).
+
 ## Authentication
 
 The Honeycomb provider requires an API key to communicate with the Honeycomb API. API keys and their permissions can be managed in _Team settings_.


### PR DESCRIPTION
## Short description of the changes
The examples in the [example directory](/example/) are so good, and I didn't even know about them!   Let's make it a tiny bit more visible

## How to verify that this has the expected result
Go to [the rendered markdown for the docs index page](https://github.com/honeycombio/terraform-provider-honeycombio/blob/a4b6ab2c112fca063e7a3bae99ed39407b0b661d/docs/index.md) and hit the example link.