### PR TITLE
Trigger recipient fixes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,8 +59,7 @@ jobs:
 
       - uses: hashicorp/setup-terraform@v2
         with:
-          # TODO: update to a TF version matrix test once testsuite won't generate conflicting resources
-          terraform_version: 1.0.6
+          terraform_version: 1.4.6
           terraform_wrapper: false
 
       - name: Run TF acceptance tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,7 +60,7 @@ jobs:
       - uses: hashicorp/setup-terraform@v2
         with:
           # TODO: update to a TF version matrix test once testsuite won't generate conflicting resources
-          terraform_version: 0.14
+          terraform_version: 0.15
           terraform_wrapper: false
 
       - name: Run TF acceptance tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,7 +59,7 @@ jobs:
 
       - uses: hashicorp/setup-terraform@v2
         with:
-          terraform_version: 1.4
+          terraform_version: 1.0
           terraform_wrapper: false
 
       - name: Run TF acceptance tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,7 +61,7 @@ jobs:
 
       - uses: hashicorp/setup-terraform@v2
         with:
-          terraform_version: $TERRAFORM_VERSION
+          terraform_version: ${{ env.TERRAFORM_VERSION }}
           terraform_wrapper: false
 
       - name: Run TF acceptance tests
@@ -70,7 +70,7 @@ jobs:
           HONEYCOMB_API_KEY: ${{ secrets.HONEYCOMB_API_KEY }}
           HONEYCOMB_DATASET: testacc
           TF_ACC: 1
-          TF_ACC_TERRAFORM_VERSION: $TERRAFORM_VERSION
+          TF_ACC_TERRAFORM_VERSION: ${{ env.TERRAFORM_VERSION }}
         run: go test -v -coverprofile=tf-coverage.txt -covermode=atomic ./internal/... ./honeycombio/...
 
       - name: Generate Coverage Report

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,7 +59,7 @@ jobs:
 
       - uses: hashicorp/setup-terraform@v2
         with:
-          terraform_version: 1.3
+          terraform_version: 1.4
           terraform_wrapper: false
 
       - name: Run TF acceptance tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,7 +60,7 @@ jobs:
       - uses: hashicorp/setup-terraform@v2
         with:
           # TODO: update to a TF version matrix test once testsuite won't generate conflicting resources
-          terraform_version: 0.15
+          terraform_version: 1.0.6
           terraform_wrapper: false
 
       - name: Run TF acceptance tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,6 +34,8 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    env:
+      TERRAFORM_VERSION: "1.0.11"
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -59,7 +61,7 @@ jobs:
 
       - uses: hashicorp/setup-terraform@v2
         with:
-          terraform_version: 1.0
+          terraform_version: $TERRAFORM_VERSION
           terraform_wrapper: false
 
       - name: Run TF acceptance tests
@@ -68,6 +70,7 @@ jobs:
           HONEYCOMB_API_KEY: ${{ secrets.HONEYCOMB_API_KEY }}
           HONEYCOMB_DATASET: testacc
           TF_ACC: 1
+          TF_ACC_TERRAFORM_VERSION: $TERRAFORM_VERSION
         run: go test -v -coverprofile=tf-coverage.txt -covermode=atomic ./internal/... ./honeycombio/...
 
       - name: Generate Coverage Report

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,7 +59,7 @@ jobs:
 
       - uses: hashicorp/setup-terraform@v2
         with:
-          terraform_version: 1.4.6
+          terraform_version: 1.2
           terraform_wrapper: false
 
       - name: Run TF acceptance tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,7 +59,7 @@ jobs:
 
       - uses: hashicorp/setup-terraform@v2
         with:
-          terraform_version: 1.2
+          terraform_version: 1.3
           terraform_wrapper: false
 
       - name: Run TF acceptance tests

--- a/client/recipient.go
+++ b/client/recipient.go
@@ -17,13 +17,13 @@ type Recipients interface {
 	// the given ID
 	Get(ctx context.Context, id string) (*Recipient, error)
 
-	// Create a new Recipient. When creating a new Recipient ID ma not be set.
+	// Create a new Recipient. When creating a new Recipient ID must not be set.
 	Create(ctx context.Context, r *Recipient) (*Recipient, error)
 
 	// Update an existing Recipient.
 	Update(ctx context.Context, r *Recipient) (*Recipient, error)
 
-	// Delete a Recipient from the dataset.
+	// Delete a Recipient
 	Delete(ctx context.Context, id string) error
 }
 
@@ -92,6 +92,7 @@ const (
 	PDSeverityERROR    PagerDutySeverity = "error"
 	PDSeverityWARNING  PagerDutySeverity = "warning"
 	PDSeverityINFO     PagerDutySeverity = "info"
+	PDDefaultSeverity                    = PDSeverityCRITICAL
 )
 
 // TriggerRecipientTypes returns a list of recipient types compatible with Triggers

--- a/honeycombio/data_source_column_test.go
+++ b/honeycombio/data_source_column_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+
 	honeycombio "github.com/honeycombio/terraform-provider-honeycombio/client"
 )
 
@@ -18,7 +20,7 @@ func TestAccDataSourceHoneycombioColumn_basic(t *testing.T) {
 
 	testColumns := []honeycombio.Column{
 		{
-			KeyName:     "test_column3",
+			KeyName:     acctest.RandString(4) + "_test_column3",
 			Description: "test column3",
 			Type:        honeycombio.ToPtr(honeycombio.ColumnType("float")),
 		},
@@ -45,7 +47,7 @@ func TestAccDataSourceHoneycombioColumn_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			// match by name and return a single column with the right type
 			{
-				Config: testAccDataSourceColumnConfig([]string{"dataset = \"" + testAccDataset() + "\"", "name = \"test_column3\""}),
+				Config: testAccDataSourceColumnConfig([]string{"dataset = \"" + testAccDataset() + "\"", "name = \"" + testColumns[0].KeyName + "\""}),
 				Check:  resource.TestCheckResourceAttr("data.honeycombio_column.test", "type", "float"),
 			},
 			// test a failed match

--- a/honeycombio/data_source_columns_test.go
+++ b/honeycombio/data_source_columns_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+
 	honeycombio "github.com/honeycombio/terraform-provider-honeycombio/client"
 )
 
@@ -15,13 +17,15 @@ func TestAccDataSourceHoneycombioColumns_basic(t *testing.T) {
 	c := testAccClient(t)
 	dataset := testAccDataset()
 
+	testprefix := acctest.RandString(4)
+
 	testColumns := []honeycombio.Column{
 		{
-			KeyName:     "test_column1",
+			KeyName:     testprefix + "_test_column1",
 			Description: "test column1",
 		},
 		{
-			KeyName:     "test_column2",
+			KeyName:     testprefix + "_test_column2",
 			Description: "test column2",
 		},
 	}
@@ -52,7 +56,7 @@ func TestAccDataSourceHoneycombioColumns_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDataSourceColumnsConfig([]string{"dataset = \"" + testAccDataset() + "\"", "starts_with = \"test_column\""}),
+				Config: testAccDataSourceColumnsConfig([]string{"dataset = \"" + testAccDataset() + "\"", "starts_with = \"" + testprefix + "\""}),
 				Check:  resource.TestCheckResourceAttr("data.honeycombio_columns.test", "names.#", "2"),
 			},
 			{

--- a/internal/helper/modifiers/notification_recipients.go
+++ b/internal/helper/modifiers/notification_recipients.go
@@ -1,0 +1,70 @@
+package modifiers
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/honeycombio/terraform-provider-honeycombio/client"
+	"github.com/honeycombio/terraform-provider-honeycombio/internal/models"
+)
+
+type notificationRecipientsModifier struct{}
+
+var _ planmodifier.Set = &notificationRecipientsModifier{}
+
+func (m notificationRecipientsModifier) Description(_ context.Context) string {
+	return "Handles the default states and value manipulations for notificiation recipients."
+}
+
+func (m notificationRecipientsModifier) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m notificationRecipientsModifier) PlanModifySet(ctx context.Context, req planmodifier.SetRequest, resp *planmodifier.SetResponse) {
+	// Do nothing on resource destroy.
+	if req.Plan.Raw.IsNull() {
+		return
+	}
+
+	var plan models.TriggerResourceModel
+	req.Plan.Get(ctx, &plan)
+
+	var rcpts []models.NotificationRecipientModel
+	req.Plan.GetAttribute(ctx, path.Root("recipient"), &rcpts)
+
+	// manage null values properly based on the type of recipient
+	if !req.StateValue.IsNull() {
+		for i, r := range rcpts {
+			if r.ID.IsUnknown() && r.Type.IsUnknown() {
+				// likely dependant on creation of another resource
+				continue
+			}
+			if r.ID.IsUnknown() && !r.Type.IsUnknown() {
+				// specified by type and target
+				r.ID = types.StringNull()
+				if r.Type.ValueString() == string(client.RecipientTypePagerDuty) {
+					// PagerDuty recipients do not have a target
+					r.Target = types.StringNull()
+				}
+			}
+			if !r.ID.IsUnknown() && r.Type.IsUnknown() {
+				// specified by ID
+				r.Type = types.StringNull()
+				r.Target = types.StringNull()
+			}
+
+			rcpts[i] = r
+		}
+
+		updated, diag := types.SetValueFrom(ctx, req.PlanValue.ElementType(ctx), rcpts)
+		resp.Diagnostics.Append(diag...)
+		resp.PlanValue = updated
+	}
+}
+
+func NotificationRecipients() planmodifier.Set {
+	return notificationRecipientsModifier{}
+}

--- a/internal/provider/derived_column_data_source_test.go
+++ b/internal/provider/derived_column_data_source_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
 	"github.com/honeycombio/terraform-provider-honeycombio/client"
 )
 

--- a/internal/provider/trigger_resource.go
+++ b/internal/provider/trigger_resource.go
@@ -256,9 +256,8 @@ func (r *triggerResource) Create(ctx context.Context, req resource.CreateRequest
 		idx := slices.IndexFunc(plan.Recipients, func(s models.NotificationRecipientModel) bool {
 			if !s.ID.IsUnknown() {
 				return s.ID.ValueString() == r.ID
-			} else {
-				return s.Type.ValueString() == string(r.Type) && (s.Target.IsNull() || s.Target.ValueString() == r.Target)
 			}
+			return s.Type.ValueString() == string(r.Type) && (s.Target.IsNull() || s.Target.ValueString() == r.Target)
 		})
 		if idx < 0 {
 			resp.Diagnostics.AddError(
@@ -332,9 +331,8 @@ func (r *triggerResource) Read(ctx context.Context, req resource.ReadRequest, re
 			idx := slices.IndexFunc(state.Recipients, func(s models.NotificationRecipientModel) bool {
 				if !s.ID.IsNull() {
 					return s.ID.ValueString() == r.ID
-				} else {
-					return s.Type.ValueString() == string(r.Type) && (s.Target.IsNull() || s.Target.ValueString() == r.Target)
 				}
+				return s.Type.ValueString() == string(r.Type) && (s.Target.IsNull() || s.Target.ValueString() == r.Target)
 			})
 			if idx < 0 {
 				resp.Diagnostics.AddError(
@@ -405,9 +403,8 @@ func (r *triggerResource) Update(ctx context.Context, req resource.UpdateRequest
 		idx := slices.IndexFunc(plan.Recipients, func(s models.NotificationRecipientModel) bool {
 			if !s.ID.IsNull() {
 				return s.ID.ValueString() == r.ID
-			} else {
-				return s.Type.ValueString() == string(r.Type) && (s.Target.IsNull() || s.Target.ValueString() == r.Target)
 			}
+			return s.Type.ValueString() == string(r.Type) && (s.Target.IsNull() || s.Target.ValueString() == r.Target)
 		})
 		if idx < 0 {
 			resp.Diagnostics.AddError(

--- a/internal/provider/trigger_resource.go
+++ b/internal/provider/trigger_resource.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"strings"
 
+	"golang.org/x/exp/slices"
+
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/objectvalidator"
@@ -14,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -22,6 +25,7 @@ import (
 
 	"github.com/honeycombio/terraform-provider-honeycombio/client"
 	"github.com/honeycombio/terraform-provider-honeycombio/internal/helper"
+	"github.com/honeycombio/terraform-provider-honeycombio/internal/helper/modifiers"
 	"github.com/honeycombio/terraform-provider-honeycombio/internal/helper/validation"
 	"github.com/honeycombio/terraform-provider-honeycombio/internal/models"
 )
@@ -138,7 +142,8 @@ func (r *triggerResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				},
 			},
 			"recipient": schema.SetNestedBlock{
-				Description: "Zero or more recipients to notify when the Trigger fires.",
+				Description:   "Zero or more recipients to notify when the Trigger fires.",
+				PlanModifiers: []planmodifier.Set{modifiers.NotificationRecipients()},
 				NestedObject: schema.NestedBlockObject{
 					Validators: []validator.Object{
 						objectvalidator.AtLeastOneOf(
@@ -179,12 +184,13 @@ func (r *triggerResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 							Validators: []validator.List{
 								listvalidator.SizeAtMost(1),
 							},
+							PlanModifiers: []planmodifier.List{listplanmodifier.UseStateForUnknown()},
 							NestedObject: schema.NestedBlockObject{
 								Attributes: map[string]schema.Attribute{
 									"pagerduty_severity": schema.StringAttribute{
 										Optional:      true,
 										Computed:      true,
-										Description:   "The severity to set with the PagerDuty notification. If no serverity is provided, 'critical' is assumed.",
+										Description:   "The severity to set with the PagerDuty notification. If no severity is provided, 'critical' is assumed.",
 										PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 										Validators: []validator.String{
 											stringvalidator.All(
@@ -208,13 +214,12 @@ func (r *triggerResource) Configure(_ context.Context, req resource.ConfigureReq
 
 func (r *triggerResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var plan models.TriggerResourceModel
-	diags := req.Plan.Get(ctx, &plan)
-	resp.Diagnostics.Append(diags...)
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	newTrigger := &client.Trigger{
+	trigger, err := r.client.Triggers.Create(ctx, plan.Dataset.ValueString(), &client.Trigger{
 		Name:        plan.Name.ValueString(),
 		Description: plan.Description.ValueString(),
 		Disabled:    plan.Disabled.ValueBool(),
@@ -223,8 +228,7 @@ func (r *triggerResource) Create(ctx context.Context, req resource.CreateRequest
 		Threshold:   expandTriggerThreshold(plan.Threshold),
 		Frequency:   int(plan.Frequency.ValueInt64()),
 		Recipients:  expandNotificationRecipients(plan.Recipients),
-	}
-	trigger, err := r.client.Triggers.Create(ctx, plan.Dataset.ValueString(), newTrigger)
+	})
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Creating Honeycomb Trigger",
@@ -233,24 +237,69 @@ func (r *triggerResource) Create(ctx context.Context, req resource.CreateRequest
 		return
 	}
 
-	plan.ID = types.StringValue(trigger.ID)
-	plan.Name = types.StringValue(trigger.Name)
-	plan.Description = types.StringValue(trigger.Description)
-	plan.Disabled = types.BoolValue(trigger.Disabled)
-	plan.QueryID = types.StringValue(trigger.QueryID)
-	plan.AlertType = types.StringValue(trigger.AlertType)
-	plan.Threshold = flattenTriggerThreshold(trigger.Threshold)
-	plan.Frequency = types.Int64Value(int64(trigger.Frequency))
-	plan.Recipients = flattenNotificationRecipients(trigger.Recipients)
+	var state models.TriggerResourceModel
+	state.Dataset = plan.Dataset
+	state.ID = types.StringValue(trigger.ID)
+	state.Name = types.StringValue(trigger.Name)
+	state.Description = types.StringValue(trigger.Description)
+	state.Disabled = types.BoolValue(trigger.Disabled)
+	state.QueryID = types.StringValue(trigger.QueryID)
+	state.AlertType = types.StringValue(trigger.AlertType)
+	state.Threshold = flattenTriggerThreshold(trigger.Threshold)
+	state.Frequency = types.Int64Value(int64(trigger.Frequency))
 
-	diags = resp.State.Set(ctx, plan)
-	resp.Diagnostics.Append(diags...)
+	recipients := make([]models.NotificationRecipientModel, len(trigger.Recipients))
+	for i, r := range trigger.Recipients {
+		var rcpt models.NotificationRecipientModel
+
+		// match the trigger's recipient to that in the plan
+		idx := slices.IndexFunc(plan.Recipients, func(s models.NotificationRecipientModel) bool {
+			if !s.ID.IsUnknown() {
+				return s.ID.ValueString() == r.ID
+			} else {
+				return s.Type.ValueString() == string(r.Type) && (s.Target.IsNull() || s.Target.ValueString() == r.Target)
+			}
+		})
+		if idx < 0 {
+			resp.Diagnostics.AddError(
+				"Error Creating Honeycomb Trigger",
+				"Could not find Recipient "+r.ID+" in plan",
+			)
+		}
+		rcpt = plan.Recipients[idx]
+
+		// TODO: can we move this to the planmodifier by adding a create state?
+		if !rcpt.ID.IsUnknown() {
+			// recipient provided by ID
+			rcpt.ID = types.StringValue(r.ID)
+			rcpt.Type = types.StringNull()
+			rcpt.Target = types.StringNull()
+		} else {
+			// recipient provided by type+target
+			rcpt.ID = types.StringNull()
+			rcpt.Type = types.StringValue(string(r.Type))
+			if rcpt.Type.ValueString() == string(client.RecipientTypePagerDuty) {
+				// PagerDuty recipients don't have a target
+				rcpt.Target = types.StringNull()
+			} else {
+				rcpt.Target = types.StringValue(r.Target)
+			}
+		}
+
+		if r.Type == client.RecipientTypePagerDuty && r.Details != nil {
+			rcpt.Details = make([]models.NotificationRecipientDetailsModel, 1)
+			rcpt.Details[0].PDSeverity = types.StringValue(string(r.Details.PDSeverity))
+		}
+		recipients[i] = rcpt
+	}
+	state.Recipients = recipients
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }
 
 func (r *triggerResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state models.TriggerResourceModel
-	diags := req.State.Get(ctx, &state)
-	resp.Diagnostics.Append(diags...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -275,21 +324,43 @@ func (r *triggerResource) Read(ctx context.Context, req resource.ReadRequest, re
 	state.AlertType = types.StringValue(trigger.AlertType)
 	state.Threshold = flattenTriggerThreshold(trigger.Threshold)
 	state.Frequency = types.Int64Value(int64(trigger.Frequency))
-	state.Recipients = flattenNotificationRecipients(trigger.Recipients)
 
-	diags = resp.State.Set(ctx, &state)
-	resp.Diagnostics.Append(diags...)
+	recipients := make([]models.NotificationRecipientModel, len(trigger.Recipients))
+	if state.Recipients != nil {
+		for i, r := range trigger.Recipients {
+			// match the Trigger's recipient to that in state
+			idx := slices.IndexFunc(state.Recipients, func(s models.NotificationRecipientModel) bool {
+				if !s.ID.IsNull() {
+					return s.ID.ValueString() == r.ID
+				} else {
+					return s.Type.ValueString() == string(r.Type) && (s.Target.IsNull() || s.Target.ValueString() == r.Target)
+				}
+			})
+			if idx < 0 {
+				resp.Diagnostics.AddError(
+					"Error Reading Honeycomb Trigger",
+					"Could not find Recipient "+r.ID+" in state",
+				)
+			}
+
+			recipients[i] = state.Recipients[idx]
+		}
+	} else {
+		recipients = flattenNotificationRecipients(trigger.Recipients)
+	}
+	state.Recipients = recipients
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }
 
 func (r *triggerResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var plan models.TriggerResourceModel
-	diags := req.Plan.Get(ctx, &plan)
-	resp.Diagnostics.Append(diags...)
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	newTrigger := &client.Trigger{
+	_, err := r.client.Triggers.Update(ctx, plan.Dataset.ValueString(), &client.Trigger{
 		ID:          plan.ID.ValueString(),
 		Name:        plan.Name.ValueString(),
 		Description: plan.Description.ValueString(),
@@ -299,9 +370,7 @@ func (r *triggerResource) Update(ctx context.Context, req resource.UpdateRequest
 		Frequency:   int(plan.Frequency.ValueInt64()),
 		Threshold:   expandTriggerThreshold(plan.Threshold),
 		Recipients:  expandNotificationRecipients(plan.Recipients),
-	}
-
-	_, err := r.client.Triggers.Update(ctx, plan.Dataset.ValueString(), newTrigger)
+	})
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Updating Honeycomb Trigger",
@@ -319,27 +388,43 @@ func (r *triggerResource) Update(ctx context.Context, req resource.UpdateRequest
 		return
 	}
 
-	plan.ID = types.StringValue(trigger.ID)
-	plan.Name = types.StringValue(trigger.Name)
-	plan.Description = types.StringValue(trigger.Description)
-	plan.Disabled = types.BoolValue(trigger.Disabled)
-	plan.QueryID = types.StringValue(trigger.QueryID)
-	plan.AlertType = types.StringValue(trigger.AlertType)
-	plan.Frequency = types.Int64Value(int64(trigger.Frequency))
-	plan.Threshold = flattenTriggerThreshold(trigger.Threshold)
-	plan.Recipients = flattenNotificationRecipients(trigger.Recipients)
+	var state models.TriggerResourceModel
+	state.Dataset = plan.Dataset
+	state.ID = types.StringValue(trigger.ID)
+	state.Name = types.StringValue(trigger.Name)
+	state.Description = types.StringValue(trigger.Description)
+	state.Disabled = types.BoolValue(trigger.Disabled)
+	state.QueryID = types.StringValue(trigger.QueryID)
+	state.AlertType = types.StringValue(trigger.AlertType)
+	state.Frequency = types.Int64Value(int64(trigger.Frequency))
+	state.Threshold = flattenTriggerThreshold(trigger.Threshold)
 
-	diags = resp.State.Set(ctx, plan)
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
+	recipients := make([]models.NotificationRecipientModel, len(trigger.Recipients))
+	for i, r := range trigger.Recipients {
+		// match the Trigger's recipient to that in the plan
+		idx := slices.IndexFunc(plan.Recipients, func(s models.NotificationRecipientModel) bool {
+			if !s.ID.IsNull() {
+				return s.ID.ValueString() == r.ID
+			} else {
+				return s.Type.ValueString() == string(r.Type) && (s.Target.IsNull() || s.Target.ValueString() == r.Target)
+			}
+		})
+		if idx < 0 {
+			resp.Diagnostics.AddError(
+				"Error Updating Honeycomb Trigger",
+				"Could not find Recipient "+r.ID+" in plan",
+			)
+		}
+		recipients[i] = plan.Recipients[idx]
 	}
+	state.Recipients = recipients
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }
 
 func (r *triggerResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	var state models.TriggerResourceModel
-	diags := req.State.Get(ctx, &state)
-	resp.Diagnostics.Append(diags...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/trigger_resource_test.go
+++ b/internal/provider/trigger_resource_test.go
@@ -5,8 +5,11 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+
+	"github.com/honeycombio/terraform-provider-honeycombio/client"
 )
 
 func TestAcc_TriggerResource(t *testing.T) {
@@ -17,7 +20,7 @@ func TestAcc_TriggerResource(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5MuxServerFactory,
 		Steps: []resource.TestStep{
 			{
-				Config: basicTriggerTestConfig(dataset),
+				Config: testAccConfigBasicTriggerTest(dataset, "info"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccEnsureTriggerExists(t, "honeycombio_trigger.test"),
 					resource.TestCheckResourceAttr("honeycombio_trigger.test", "name", "Test trigger from terraform-provider-honeycombio"),
@@ -25,6 +28,10 @@ func TestAcc_TriggerResource(t *testing.T) {
 					resource.TestCheckResourceAttr("honeycombio_trigger.test", "recipient.#", "2"),
 					resource.TestCheckResourceAttrPair("honeycombio_trigger.test", "query_id", "honeycombio_query.test", "id"),
 				),
+			},
+			// then update the PD Severity from info -> critical (the default)
+			{
+				Config: testAccConfigBasicTriggerTest(dataset, "critical"),
 			},
 			{
 				ResourceName:        "honeycombio_trigger.test",
@@ -47,6 +54,8 @@ func TestAcc_TriggerResource(t *testing.T) {
 func TestAcc_TriggerResourceUpgradeFromVersion014(t *testing.T) {
 	dataset := testAccDataset()
 
+	config := testAccConfigBasicTriggerTest(dataset, "info")
+
 	resource.Test(t, resource.TestCase{
 		Steps: []resource.TestStep{
 			{
@@ -56,22 +65,149 @@ func TestAcc_TriggerResourceUpgradeFromVersion014(t *testing.T) {
 						Source:            "honeycombio/honeycombio",
 					},
 				},
-				Config: basicTriggerTestConfig(dataset),
+				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testAccEnsureTriggerExists(t, "honeycombio_trigger.test"),
 				),
 			},
 			{
 				ProtoV5ProviderFactories: testAccProtoV5MuxServerFactory,
-				Config:                   basicTriggerTestConfig(dataset),
+				Config:                   config,
 				PlanOnly:                 true,
 			},
 		},
 	})
 }
 
-func basicTriggerTestConfig(dataset string) string {
-	return fmt.Sprintf(`
+func TestAcc_TriggerResourceUpdateRecipientByID(t *testing.T) {
+	ctx := context.Background()
+	c := testAccClient(t)
+	dataset := testAccDataset()
+
+	testRecipients := []client.Recipient{
+		{
+			Type: client.RecipientTypeEmail,
+			Details: client.RecipientDetails{
+				EmailAddress: acctest.RandString(8) + "@example.com",
+			},
+		},
+		{
+			Type: client.RecipientTypeSlack,
+			Details: client.RecipientDetails{
+				SlackChannel: "#" + acctest.RandString(8),
+			},
+		},
+	}
+
+	for i, r := range testRecipients {
+		rcpt, err := c.Recipients.Create(ctx, &r)
+		if err != nil {
+			t.Error(err)
+		}
+		// update ID for removal later
+		testRecipients[i].ID = rcpt.ID
+	}
+	t.Cleanup(func() {
+		// remove recipients at the of the test run
+		for _, col := range testRecipients {
+			//nolint:errcheck
+			c.DerivedColumns.Delete(ctx, dataset, col.ID)
+		}
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 testAccPreCheck(t),
+		ProtoV5ProviderFactories: testAccProtoV5MuxServerFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfigTriggerRecipientByID(dataset, testRecipients[0].ID),
+				Check:  resource.TestCheckResourceAttr("honeycombio_trigger.test", "recipient.0.id", testRecipients[0].ID),
+			},
+			{
+				Config: testAccConfigTriggerRecipientByID(dataset, testRecipients[1].ID),
+				Check:  resource.TestCheckResourceAttr("honeycombio_trigger.test", "recipient.0.id", testRecipients[1].ID),
+			},
+		},
+	})
+}
+
+func TestAcc_TriggerResourceRecipientOrderingStable(t *testing.T) {
+	dataset := testAccDataset()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 testAccPreCheck(t),
+		ProtoV5ProviderFactories: testAccProtoV5MuxServerFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+data "honeycombio_query_specification" "test" {
+  calculation {
+    op     = "COUNT"
+  }
+
+  time_range = 1200
+}
+
+resource "honeycombio_query" "test" {
+  dataset    = "%[1]s"
+  query_json = data.honeycombio_query_specification.test.json
+}
+
+resource "honeycombio_trigger" "test" {
+  name = "Ensure mixed order recipients don't cause infinite diffs"
+
+  query_id = honeycombio_query.test.id
+  dataset  = "%[1]s"
+
+  threshold {
+    op    = ">"
+    value = 1000
+  }
+
+  alert_type = "on_change"
+
+  recipient {
+    type   = "slack"
+    target = "#test2"
+  }
+
+  recipient {
+    type   = "slack"
+    target = "#test"
+  }
+
+  recipient {
+    type   = "email"
+    target = "bob@example.com"
+  }
+
+  recipient {
+    type   = "email"
+    target = "alice@example.com"
+  }
+
+  recipient {
+    type   = "marker"
+    target = "trigger fired"
+  }
+}
+`, dataset),
+			},
+		},
+	})
+}
+
+func TestAcc_TriggerResourcePagerDutyUnsetSeverity(t *testing.T) {
+	t.Skip("known issue: see https://github.com/honeycombio/terraform-provider-honeycombio/issues/309")
+
+	dataset := testAccDataset()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 testAccPreCheck(t),
+		ProtoV5ProviderFactories: testAccProtoV5MuxServerFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
 data "honeycombio_query_specification" "test" {
   calculation {
     op     = "AVG"
@@ -87,7 +223,52 @@ resource "honeycombio_query" "test" {
 
 resource "honeycombio_pagerduty_recipient" "test" {
   integration_key  = "09c9d4cacd68933151a1ef1048b67dd5"
-  integration_name = "acctest"
+  integration_name = "severity-test"
+}
+
+resource "honeycombio_trigger" "test" {
+  name    = "Test trigger from terraform-provider-honeycombio"
+  dataset = "%[1]s"
+
+  description = "My nice description"
+
+  query_id = honeycombio_query.test.id
+
+  threshold {
+    op    = ">"
+    value = 100
+  }
+
+  frequency = data.honeycombio_query_specification.test.time_range / 2
+
+  recipient {
+    id = honeycombio_pagerduty_recipient.test.id
+    // default severity is 'critical'
+  }
+}`, dataset),
+			},
+		},
+	})
+}
+
+func testAccConfigBasicTriggerTest(dataset, pdseverity string) string {
+	return fmt.Sprintf(`
+data "honeycombio_query_specification" "test" {
+  calculation {
+    op     = "AVG"
+    column = "duration_ms"
+  }
+  time_range = 1200
+}
+
+resource "honeycombio_query" "test" {
+  dataset    = "%[1]s"
+  query_json = data.honeycombio_query_specification.test.json
+}
+
+resource "honeycombio_pagerduty_recipient" "test" {
+  integration_key  = "08b9d4cacd68933151a1ef1028b67da2"
+  integration_name = "testacc-basic"
 }
 
 resource "honeycombio_trigger" "test" {
@@ -114,10 +295,41 @@ resource "honeycombio_trigger" "test" {
     id = honeycombio_pagerduty_recipient.test.id
 
     notification_details {
-      pagerduty_severity = "info"
+      pagerduty_severity = "%[2]s"
     }
   }
-}`, dataset)
+}`, dataset, pdseverity)
+}
+
+func testAccConfigTriggerRecipientByID(dataset, recipientID string) string {
+	return fmt.Sprintf(`
+data "honeycombio_query_specification" "test" {
+  calculation {
+    op     = "AVG"
+    column = "duration_ms"
+  }
+
+  time_range = 1800
+}
+
+resource "honeycombio_query" "test" {
+  dataset    = "%[1]s"
+  query_json = data.honeycombio_query_specification.test.json
+}
+
+resource "honeycombio_trigger" "test" {
+  name    = "Test trigger with changing recipient id"
+  dataset = "%[1]s"
+  query_id = honeycombio_query.test.id
+  threshold {
+    op    = ">"
+    value = 100
+  }
+
+  recipient {
+    id = "%[2]s"
+  }
+}`, dataset, recipientID)
 }
 
 func testAccEnsureTriggerExists(t *testing.T, name string) resource.TestCheckFunc {


### PR DESCRIPTION
This completes the move of the `honeycombio_trigger` resource to the Terraform Plugin Framework (started in #306).

In order to support versions of Terraform core older than 1.4.0 (which, is rather "fresh") there is a bit of logic to handle `Null` or `Unknown` values of these awkwardly-shaped notification recipients.

This also 'bumps' the version of Terraform core used in CI to 1.0.11 (from the old 0.14.x series).

- Closes #303, #267, #200

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204716790924151