### PR TITLE
honeycombio_trigger - add evaluation schedule support

### DIFF
--- a/client/trigger_test.go
+++ b/client/trigger_test.go
@@ -73,7 +73,9 @@ func TestTriggers(t *testing.T) {
 		data.Query.TimeRange = ToPtr(300)
 
 		// set the default alert type
-		data.AlertType = TriggerAlertTypeValueOnChange
+		data.AlertType = TriggerAlertTypeOnChange
+		// set the default evaluation window type
+		data.EvaluationScheduleType = TriggerEvaluationScheduleFrequency
 
 		assert.Equal(t, data, trigger)
 	})
@@ -95,14 +97,22 @@ func TestTriggers(t *testing.T) {
 	t.Run("Update", func(t *testing.T) {
 		trigger.Description = "A new description"
 
-		// update the alert_type to on_true / this is a simple validation that this field works
-		trigger.AlertType = TriggerAlertTypeValueOnTrue
+		// update the alert type to on true
+		trigger.AlertType = TriggerAlertTypeOnTrue
+		// update the evaluation schedule to a window type
+		trigger.EvaluationScheduleType = TriggerEvaluationScheduleWindow
+		trigger.EvaluationSchedule = &TriggerEvaluationSchedule{
+			Window: TriggerEvaluationWindow{
+				DaysOfWeek: []string{"monday", "wednesday", "friday"},
+				StartTime:  "13:00",
+				EndTime:    "21:00",
+			},
+		}
 
 		result, err := c.Triggers.Update(ctx, dataset, trigger)
 
 		// copy IDs before asserting equality
 		trigger.QueryID = result.QueryID
-		trigger.AlertType = result.AlertType
 		assert.NoError(t, err)
 		assert.Equal(t, trigger, result)
 	})

--- a/docs/resources/trigger.md
+++ b/docs/resources/trigger.md
@@ -112,6 +112,17 @@ resource "honeycombio_trigger" "example" {
       pagerduty_severity = "info"
     }
   }
+
+  evaluation_schedule {
+    start_time = "13:00"
+    end_time   = "21:00"
+
+    days_of_week = [
+      "monday",
+      "wednesday",
+      "friday"
+    ]
+  }
 }
 ```
 
@@ -127,6 +138,10 @@ The following arguments are supported:
 * `disabled` - (Optional) The state of the trigger. If true, the trigger will not be run. Defaults to false.
 * `frequency` - (Optional) The interval (in seconds) in which to check the results of the query’s calculation against the threshold. This value must be divisible by 60, between 60 and 86400 (between 1 minute and 1 day), and not be more than 4 times the query's duration. Defaults to 900 (15 minutes).
 * `alert_type` - (Optional) The frequency for the alert to trigger. (`on_change` is the default behavior, `on_true` can also be selected)
+* `evaluation_schedule` - (Optional) A configuration block (described below) that determines when t he trigger is run.
+When the time is within the scheduled window the trigger will be run at the specified frequency.
+Outside of the window, the trigger will not be run.
+If no schedule is specified, the trigger will be run at the specified frequency at all times.
 * `recipient` - (Optional) Zero or more configuration blocks (described below) with the recipients to notify when the trigger fires.
 
 -> **NOTE** The query used in a Trigger must follow a strict subset: the query must contain *exactly one* calcuation and may only contain `calculation`, `filter`, `filter_combination` and `breakdowns` fields.
@@ -136,6 +151,12 @@ Each trigger configuration must contain exactly one `threshold` block, which acc
 
 * `op` - (Required) The operator to apply, allowed threshold operators are `>`, `>=`, `<`, and `<=`.
 * `value` - (Required) The value to be used with the operator.
+
+Each trigger configuration may provide an `evaluation_schedule` block, which accepts the following arguments:
+
+* `start_time` - (Required) UTC time to start evaluating the trigger in HH:mm format (e.g. `13:00`)
+* `end_time` - (Required) UTC time to start evaluating the trigger in HH:mm format (e.g. `13:00`)
+* `days_of_week` - (Required) A list of days of the week (in lowercase) to evaluate the trigger on
 
 Each trigger configuration may have zero or more `recipient` blocks, which each accept the following arguments. A trigger recipient block can either refer to an existing recipient (a recipient that is already present in another trigger) or a new recipient. When specifying an existing recipient, only `id` may be set. If you pass in a recipient without its ID and only include the type and target, Honeycomb will make a best effort to match to an existing recipient. To retrieve the ID of an existing recipient, refer to the [`honeycombio_recipient`](../data-sources/recipient.md) data source.
 

--- a/internal/models/triggers.go
+++ b/internal/models/triggers.go
@@ -3,16 +3,17 @@ package models
 import "github.com/hashicorp/terraform-plugin-framework/types"
 
 type TriggerResourceModel struct {
-	ID          types.String                 `tfsdk:"id"`
-	Name        types.String                 `tfsdk:"name"`
-	Dataset     types.String                 `tfsdk:"dataset"`
-	Description types.String                 `tfsdk:"description"`
-	Disabled    types.Bool                   `tfsdk:"disabled"`
-	QueryID     types.String                 `tfsdk:"query_id"`
-	AlertType   types.String                 `tfsdk:"alert_type"`
-	Frequency   types.Int64                  `tfsdk:"frequency"`
-	Threshold   []TriggerThresholdModel      `tfsdk:"threshold"`
-	Recipients  []NotificationRecipientModel `tfsdk:"recipient"`
+	ID                 types.String                     `tfsdk:"id"`
+	Name               types.String                     `tfsdk:"name"`
+	Dataset            types.String                     `tfsdk:"dataset"`
+	Description        types.String                     `tfsdk:"description"`
+	Disabled           types.Bool                       `tfsdk:"disabled"`
+	QueryID            types.String                     `tfsdk:"query_id"`
+	AlertType          types.String                     `tfsdk:"alert_type"`
+	Frequency          types.Int64                      `tfsdk:"frequency"`
+	Threshold          []TriggerThresholdModel          `tfsdk:"threshold"`
+	Recipients         []NotificationRecipientModel     `tfsdk:"recipient"`
+	EvaluationSchedule []TriggerEvaluationScheduleModel `tfsdk:"evaluation_schedule"`
 }
 
 type TriggerThresholdModel struct {
@@ -29,4 +30,10 @@ type NotificationRecipientModel struct {
 
 type NotificationRecipientDetailsModel struct {
 	PDSeverity types.String `tfsdk:"pagerduty_severity"`
+}
+
+type TriggerEvaluationScheduleModel struct {
+	DaysOfWeek []types.String `tfsdk:"days_of_week"`
+	StartTime  types.String   `tfsdk:"start_time"`
+	EndTime    types.String   `tfsdk:"end_time"`
 }


### PR DESCRIPTION
Adds support for Trigger Evaluation Schedules to the `honeycombio_trigger` resource.
