### PR TITLE
[goreleaser] fix regression and set version on released artifact

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,7 +10,7 @@ builds:
     flags:
       - -trimpath
     ldflags:
-      - "-s -w -X github.com/honeycombio/terraform-provider-honeycombio/main.providerVersion={{.Version}}"
+      - "-s -w -X main.providerVersion={{.Version}}"
     goos:
       - freebsd
       - windows


### PR DESCRIPTION
Properly set the provider version on release

Introduced by: #305 
