### PR TITLE
fix - queryspec Orders equivalency

### DIFF
--- a/client/query_spec.go
+++ b/client/query_spec.go
@@ -81,6 +81,22 @@ func (qs *QuerySpec) EquivalentTo(other QuerySpec) bool {
 		}
 	}
 
+	// Orders have a default ascending order, so we need to check equivalence
+	if len(qs.Orders) != len(other.Orders) {
+		return false
+	}
+	for i := range qs.Orders {
+		if PtrValueOrDefault(qs.Orders[i].Order, SortOrderAsc) != PtrValueOrDefault(other.Orders[i].Order, SortOrderAsc) {
+			return false
+		}
+		if !reflect.DeepEqual(qs.Orders[i].Column, other.Orders[i].Column) {
+			return false
+		}
+		if !reflect.DeepEqual(qs.Orders[i].Op, other.Orders[i].Op) {
+			return false
+		}
+	}
+
 	// the exact order of filters does not matter, but their equvalence does
 	if !Equivalent(qs.Filters, other.Filters) {
 		return false
@@ -89,9 +105,6 @@ func (qs *QuerySpec) EquivalentTo(other QuerySpec) bool {
 		return false
 	}
 	if !reflect.DeepEqual(qs.Breakdowns, other.Breakdowns) {
-		return false
-	}
-	if !reflect.DeepEqual(qs.Orders, other.Orders) {
 		return false
 	}
 	// the exact order of havings does not matter, but their equvalence does

--- a/client/query_spec_test.go
+++ b/client/query_spec_test.go
@@ -266,6 +266,78 @@ func TestQuerySpec_EquivalentTo(t *testing.T) {
 			},
 			false,
 		},
+		{
+			"Equivalent column orders",
+			QuerySpec{
+				Orders: []OrderSpec{
+					{Column: ToPtr("column_1")},
+				},
+			},
+			QuerySpec{
+				Orders: []OrderSpec{
+					{
+						Column: ToPtr("column_1"),
+						Order:  ToPtr(SortOrderAsc),
+					},
+				},
+			},
+			true,
+		},
+		{
+			"Not equivalent column orders",
+			QuerySpec{
+				Orders: []OrderSpec{
+					{Column: ToPtr("column_2")},
+				},
+			},
+			QuerySpec{
+				Orders: []OrderSpec{
+					{
+						Column: ToPtr("column_1"),
+						Order:  ToPtr(SortOrderAsc),
+					},
+				},
+			},
+			false,
+		},
+		{
+			"Equivalent Op orders with unspecified default",
+			QuerySpec{
+				Orders: []OrderSpec{
+					{
+						Op:    ToPtr(CalculationOpCount),
+						Order: ToPtr(SortOrderAsc),
+					},
+				},
+			},
+			QuerySpec{
+				Orders: []OrderSpec{
+					{Op: ToPtr(CalculationOpCount)},
+				},
+			},
+			true,
+		},
+		{
+			"Not equivalent Op orders",
+			QuerySpec{
+				Orders: []OrderSpec{
+					{
+						Op:     ToPtr(CalculationOpCountDistinct),
+						Column: ToPtr("column_1"),
+						Order:  ToPtr(SortOrderAsc),
+					},
+				},
+			},
+			QuerySpec{
+				Orders: []OrderSpec{
+					{
+						Op:    ToPtr(CalculationOpCount),
+						Order: ToPtr(SortOrderDesc),
+					},
+				},
+			},
+			false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Reported via Pollinators ([link](https://honeycombpollinators.slack.com/archives/C017T9FFT0D/p1692690089887929)).

Prior to this change a `honeycombio_query` as below would cause an infinite diff:

```hcl
resource "honeycombio_query" "test" {
  dataset    = var.dataset
  query_json = <<-EOF
{
  "breakdowns": ["app.tenant"],
  "calculations": [{ "op": "COUNT" }],
  "orders": [
    {
      "column": "app.tenant",
      "order": "ascending"
    }
  ],
  "time_range": 7200
}
EOF
}
```

Plan output:

```
  # honeycombio_query.test must be replaced
-/+ resource "honeycombio_query" "test" {
      ~ id         = "AD1Ue8TJCfC" -> (known after apply)
      ~ query_json = jsonencode(
          ~ {
              + filter_combination = "AND"
              ~ orders             = [
                  ~ {
                      + order  = "ascending"
                        # (1 unchanged attribute hidden)
                    },
                ]
                # (3 unchanged attributes hidden)
            } # forces replacement
        )
        # (1 unchanged attribute hidden)
    }
```
