### PR TITLE
github automation improvements

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,7 +5,14 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    labels:
+      - "type: dependencies"
+    groups:
+      hashicorp:
+        - "github.com/hashicorp/*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
+    labels:
+      - "type: dependencies"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,7 +9,8 @@ updates:
       - dependencies
     groups:
       hashicorp:
-        - "github.com/hashicorp/*"
+        patterns:
+          - "github.com/hashicorp/*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,7 +6,7 @@ updates:
     schedule:
       interval: "daily"
     labels:
-      - "type: dependencies"
+      - dependencies
     groups:
       hashicorp:
         - "github.com/hashicorp/*"
@@ -15,4 +15,4 @@ updates:
     schedule:
       interval: "daily"
     labels:
-      - "type: dependencies"
+      - dependencies

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,22 @@
+changelog:
+    exclude:
+        labels:
+            - no-changelog
+    categories:
+        - title: NOTES
+          labels:
+              - breaking-change
+        - title: ENHANCEMENTS
+          labels:
+              - improvement
+              - feature
+        - title: BUGFIXES
+          labels:
+              - bug
+        - title: HOUSEKEEPING
+          labels:
+              - refactor
+              - dependencies
+        - title: Other Changes
+          labels:
+              - "*"


### PR DESCRIPTION
Enable some ✨ fancy ✨ GitHub features to help maintenance and release activities:

1. dependabot: group HashiCorp Go library updates together when possible
1. setup an initial `.github/release.yml` to help get CHANGELOG updates closer to the right format automatically