### PR TITLE
Fix minor typo in d/query_specification documentation

### DIFF
--- a/docs/data-sources/query_specification.md
+++ b/docs/data-sources/query_specification.md
@@ -94,5 +94,5 @@ Each query configuration may have zero or more `having` blocks, which each accep
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - ID of the trigger.
+* `id` - ID of the query specification.
 * `json` - JSON representation of the query according to the [Query Specification](https://docs.honeycomb.io/api/query-specification/#fields-on-a-query-specification), can be used as input for other resources.


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Short description of the changes

This PR fixes a very tiny typo in the documentation for the query specification data source that I noticed while working with the trigger resource. 

## How to verify that this has the expected result

Look at the documentation and verify that it is correct and free of typos.