### PR TITLE
[docs] add environment-wide '__all__' note where supported

### DIFF
--- a/docs/data-sources/query_result.md
+++ b/docs/data-sources/query_result.md
@@ -36,7 +36,7 @@ output "event_count" {
 
 The following arguments are supported:
 
-* `dataset` - (Required) The dataset this query is associated with.
+* `dataset` - (Required) The dataset this query is associated with. Use `__all__` for Environment-wide queries.
 * `query_json` - (Required) A JSON object describing the query according to the Query Specification. While the JSON can be constructed manually, it is easiest to use the honeycombio_query_specification data source.
 
 ## Attribute Reference

--- a/docs/resources/derived_column.md
+++ b/docs/resources/derived_column.md
@@ -22,7 +22,7 @@ resource "honeycombio_derived_column" "duration_ms_log" {
 
 The following arguments are supported:
 
-* `dataset` - (Required) The dataset this derived column is added to.
+* `dataset` - (Required) The dataset this derived column is added to. Use `__all__` for Environment-wide derived columns.
 * `alias` - (Required) The name of the derived column. Must be unique per dataset.
 * `expression` - (Required) The function of the derived column. See [Derived Column Syntax](https://docs.honeycomb.io/working-with-your-data/customizing-your-query/derived-columns/#derived-column-syntax).
 * `description` - (Optional) A description that is shown in the UI.

--- a/docs/resources/marker.md
+++ b/docs/resources/marker.md
@@ -28,7 +28,7 @@ resource "honeycombio_marker" "marker" {
 
 The following arguments are supported:
 
-* `dataset` - (Required) The dataset this marker is placed on.
+* `dataset` - (Required) The dataset this marker is placed on. Use `__all__` for Environment-wide markers.
 * `message` - (Optional) The message on the marker.
 * `type` - (Optional) The type of the marker, Honeycomb.io can display markers in different colors depending on their type.
 * `url` - (Optional) A target for the Marker. If you click on the Marker text, it will take you to this URL.

--- a/docs/resources/marker_setting.md
+++ b/docs/resources/marker_setting.md
@@ -24,7 +24,7 @@ resource "honeycombio_marker_setting" "markerSetting" {
 
 The following arguments are supported:
 
-* `dataset` - (Required) The dataset this marker setting is placed on.
+* `dataset` - (Required) The dataset this marker setting is placed on. Use `__all__` for Environment-wide marker settings.
 * `type` - (Required) The type of the marker setting, Honeycomb.io can display markers in different colors depending on their type.
 * `color` - (Required) The color set for the marker as a hex color code (e.g. `#DF4661`)
 

--- a/docs/resources/query.md
+++ b/docs/resources/query.md
@@ -36,7 +36,7 @@ resource "honeycombio_query" "test_query" {
 
 The following arguments are supported:
 
-* `dataset` - (Required) The dataset this query is added to.
+* `dataset` - (Required) The dataset this query is added to. Use `__all__` for Environment-wide queries.
 * `query_json` - (Required) A JSON object describing the query according to the [Query Specification](https://docs.honeycomb.io/api/query-specification/#fields-on-a-query-specification). While the JSON can be constructed manually, it is easiest to use the [`honeycombio_query_specification`](../data-sources/query_specification.md) data source.
 
 ## Attribute Reference

--- a/docs/resources/query_annotation.md
+++ b/docs/resources/query_annotation.md
@@ -43,7 +43,7 @@ resource "honeycombio_query_annotation" "test_annotation" {
 
 The following arguments are supported:
 
-* `dataset` - (Required) The dataset this query is added to.
+* `dataset` - (Required) The dataset this query annotation is added to. Use `__all__` for Environment-wide query annotations.
 * `query_id` - (Required) The ID of the query that the annotation will be created on. Note that a query can have more than one annotation.
 * `name` - (Required) The name of the query annotation that will display in the Honeycomb UI.
 * `description` - (Optional) The description for the query annotation.


### PR DESCRIPTION
I had thought this was already done, but it clearly was not.

Noticed as a result of a [Pollinators question](https://honeycombpollinators.slack.com/archives/C4T3A32CX/p1696876673180979).