### PR TITLE
ci: fix release workflow

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -9,6 +9,9 @@ jobs:
   goreleaser:
     name: Release (GoReleaser)
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
 
     steps:
       - name: Checkout


### PR DESCRIPTION
While trying to release v0.18.0 we got a new permissions error during the "release workflow" ([link](https://github.com/honeycombio/terraform-provider-honeycombio/actions/runs/6487306414/job/17617320152)):

> error=scm releases: failed to publish artifacts: could not release: POST https://api.github.com/repos/honeycombio/terraform-provider-honeycombio/releases: 403 Resource not accessible by integration []

Looking at some similar errors, we think goreleaser may (now?) require increased permissions to create a draft release ([reference](https://github.com/goreleaser/goreleaser/issues/2642))