### PR TITLE
bugfix: ensure Summary is set on SDK v2 Diagnostics

### DIFF
--- a/honeycombio/resource_derived_column_test.go
+++ b/honeycombio/resource_derived_column_test.go
@@ -2,6 +2,7 @@ package honeycombio
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -45,6 +46,29 @@ func TestAccHoneycombioDerivedColumn_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("honeycombio_derived_column.test", "expression", "LOG10($duration_ms)"),
 					resource.TestCheckResourceAttr("honeycombio_derived_column.test", "description", "LOG10 of duration_ms"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccHoneycombioDerivedColumn_error(t *testing.T) {
+	dataset := testAccDataset()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          testAccPreCheck(t),
+		ProviderFactories: testAccProviderFactories,
+		IDRefreshName:     "honeycombio_derived_column.test",
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "honeycombio_derived_column" "invalid_column_in_expression" {
+  alias       = "invalid_column_in_expression"
+  expression  = "LOG10($invalid_column)"
+
+  dataset = "%s"
+}
+`, dataset),
+				ExpectError: regexp.MustCompile(`Error: unknown column name: invalid_column`),
 			},
 		},
 	})

--- a/honeycombio/type_helpers.go
+++ b/honeycombio/type_helpers.go
@@ -464,8 +464,8 @@ func diagFromDetailedErr(err honeycombio.DetailedError) diag.Diagnostics {
 	} else {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
-			Summary:  err.Title,
-			Detail:   err.Message,
+			Summary:  err.Message,
+			Detail:   err.Title,
 		})
 	}
 


### PR DESCRIPTION
SDKv2 based resources reporting errors that weren't complete RFC7807-style errors reported something like the following:

> Error: Empty Summary: This is always a bug in the provider and should be reported to the provider developers.

This fixes that by always ensuring that "Summary" is set.