### PR TITLE
fix(slo, burn_alert, client) missing resources shouldn't error but be recreated

### DIFF
--- a/client/errors.go
+++ b/client/errors.go
@@ -90,7 +90,7 @@ func errorFromResponse(resp *http.Response) error {
 	err = json.Unmarshal(e, &detailedErr)
 	if err != nil {
 		// we failed to parse the body as a DetailedError, so build one from what we know
-		return &DetailedError{
+		return DetailedError{
 			Status:  resp.StatusCode,
 			Message: resp.Status,
 		}

--- a/honeycombio/resource_slo_test.go
+++ b/honeycombio/resource_slo_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 
 	"github.com/stretchr/testify/require"
 
@@ -14,41 +15,20 @@ import (
 )
 
 func TestAccHoneycombioSLO_basic(t *testing.T) {
-	ctx := context.Background()
-	c := testAccClient(t)
-	dataset := testAccDataset()
-
-	sli, err := c.DerivedColumns.Create(ctx, dataset, &honeycombio.DerivedColumn{
-		Alias:      "sli.acc_slo_test",
-		Expression: "LT($duration_ms, 1000)",
-	})
-	require.NoError(t, err)
-	//nolint:errcheck
-	t.Cleanup(func() {
-		// remove SLI DC at end of test run
-		c.DerivedColumns.Delete(ctx, dataset, sli.ID)
-	})
+	dataset, sliAlias := sloAccTestSetup(t)
+	slo := &honeycombio.SLO{}
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          testAccPreCheck(t),
 		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(`
-resource "honeycombio_slo" "test" {
-  name              = "TestAcc SLO"
-  description       = "integration test SLO"
-  dataset           = "%s"
-  sli               = "%s"
-  target_percentage = 99.95
-  time_period       = 30
-}
-`, dataset, sli.Alias),
+				Config: testAccConfigSLO_basic(dataset, sliAlias),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSLOExists(t, dataset, "honeycombio_slo.test"),
+					testAccCheckSLOExists(t, "honeycombio_slo.test", slo),
 					resource.TestCheckResourceAttr("honeycombio_slo.test", "name", "TestAcc SLO"),
 					resource.TestCheckResourceAttr("honeycombio_slo.test", "description", "integration test SLO"),
-					resource.TestCheckResourceAttr("honeycombio_slo.test", "sli", sli.Alias),
+					resource.TestCheckResourceAttr("honeycombio_slo.test", "sli", sliAlias),
 					resource.TestCheckResourceAttr("honeycombio_slo.test", "target_percentage", "99.95"),
 					resource.TestCheckResourceAttr("honeycombio_slo.test", "time_period", "30"),
 				),
@@ -57,19 +37,84 @@ resource "honeycombio_slo" "test" {
 	})
 }
 
-func testAccCheckSLOExists(t *testing.T, dataset string, name string) resource.TestCheckFunc {
+// Checks to ensure that if an SLO was removed from Honeycomb outside of Terraform (UI or API)
+// that it is detected and planned for recreation.
+func TestAccHoneycombioSLO_RecreateOnNotFound(t *testing.T) {
+	dataset, sliAlias := sloAccTestSetup(t)
+	slo := &honeycombio.SLO{}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          testAccPreCheck(t),
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfigSLO_basic(dataset, sliAlias),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckSLOExists(t, "honeycombio_slo.test", slo),
+					func(_ *terraform.State) error {
+						// the final 'check' deletes the SLO directly via the API leaving it behind in the state
+						err := testAccClient(t).SLOs.Delete(context.Background(), dataset, slo.ID)
+						require.NoError(t, err)
+						return nil
+					},
+				),
+				// ensure that the plan is non-empty after the deletion
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccConfigSLO_basic(dataset, sliAlias string) string {
+	return fmt.Sprintf(`
+	resource "honeycombio_slo" "test" {
+		name              = "TestAcc SLO"
+		description       = "integration test SLO"
+		dataset           = "%s"
+		sli               = "%s"
+		target_percentage = 99.95
+		time_period       = 30
+	}
+	`, dataset, sliAlias)
+}
+
+func testAccCheckSLOExists(t *testing.T, name string, slo *honeycombio.SLO) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		resourceState, ok := s.RootModule().Resources[name]
 		if !ok {
-			return fmt.Errorf("not found: %s", name)
+			return fmt.Errorf("\"%s\" not found in state", name)
 		}
 
 		client := testAccClient(t)
-		_, err := client.SLOs.Get(context.Background(), dataset, resourceState.Primary.ID)
+		rslo, err := client.SLOs.Get(context.Background(), resourceState.Primary.Attributes["dataset"], resourceState.Primary.ID)
 		if err != nil {
-			return fmt.Errorf("could not find created SLO: %w", err)
+			return fmt.Errorf("failed to fetch created SLO: %w", err)
 		}
+
+		*slo = *rslo
 
 		return nil
 	}
+}
+
+func sloAccTestSetup(t *testing.T) (string, string) {
+	t.Helper()
+
+	ctx := context.Background()
+	c := testAccClient(t)
+	dataset := testAccDataset()
+
+	sli, err := c.DerivedColumns.Create(ctx, dataset, &honeycombio.DerivedColumn{
+		Alias:      "sli." + acctest.RandString(8),
+		Expression: "BOOL(1)",
+	})
+	require.NoError(t, err)
+
+	//nolint:errcheck
+	t.Cleanup(func() {
+		// remove SLI DC at end of test run
+		c.DerivedColumns.Delete(ctx, dataset, sli.ID)
+	})
+
+	return dataset, sli.Alias
 }

--- a/honeycombio/resource_slo_test.go
+++ b/honeycombio/resource_slo_test.go
@@ -54,7 +54,9 @@ func TestAccHoneycombioSLO_RecreateOnNotFound(t *testing.T) {
 					func(_ *terraform.State) error {
 						// the final 'check' deletes the SLO directly via the API leaving it behind in the state
 						err := testAccClient(t).SLOs.Delete(context.Background(), dataset, slo.ID)
-						require.NoError(t, err)
+						if err != nil {
+							return fmt.Errorf("failed to delete SLO: %w", err)
+						}
 						return nil
 					},
 				),

--- a/internal/provider/burn_alert_resource.go
+++ b/internal/provider/burn_alert_resource.go
@@ -437,18 +437,20 @@ func (r *burnAlertResource) Delete(ctx context.Context, req resource.DeleteReque
 	// Delete the burn alert, using the values from state
 	var detailedErr client.DetailedError
 	err := r.client.BurnAlerts.Delete(ctx, state.Dataset.ValueString(), state.ID.ValueString())
-	if errors.As(err, &detailedErr) {
-		// if not found consider it deleted -- so don't error
-		if !detailedErr.IsNotFound() {
-			resp.Diagnostics.Append(helper.NewDetailedErrorDiagnostic(
+	if err != nil {
+		if errors.As(err, &detailedErr) {
+			// if not found consider it deleted -- so don't error
+			if !detailedErr.IsNotFound() {
+				resp.Diagnostics.Append(helper.NewDetailedErrorDiagnostic(
+					"Error Deleting Honeycomb Burn Alert",
+					&detailedErr,
+				))
+			}
+		} else {
+			resp.Diagnostics.AddError(
 				"Error Deleting Honeycomb Burn Alert",
-				&detailedErr,
-			))
+				"Could not delete Burn Alert ID "+state.ID.ValueString()+": "+err.Error(),
+			)
 		}
-	} else {
-		resp.Diagnostics.AddError(
-			"Error Deleting Honeycomb Burn Alert",
-			"Could not delete Burn Alert ID "+state.ID.ValueString()+": "+err.Error(),
-		)
 	}
 }

--- a/internal/provider/burn_alert_resource_test.go
+++ b/internal/provider/burn_alert_resource_test.go
@@ -390,7 +390,9 @@ func TestAcc_BurnAlertResource_RecreateOnNotFound(t *testing.T) {
 					func(_ *terraform.State) error {
 						// the final 'check' deletes the Burn Alert directly via the API leaving it behind in the state
 						err := testAccClient(t).BurnAlerts.Delete(context.Background(), dataset, burnAlert.ID)
-						require.NoError(t, err)
+						if err != nil {
+							return fmt.Errorf("failed to delete Burn Alert: %w", err)
+						}
 						return nil
 					},
 				),

--- a/internal/provider/burn_alert_resource_test.go
+++ b/internal/provider/burn_alert_resource_test.go
@@ -371,6 +371,36 @@ func TestAcc_BurnAlertResource_validateBudgetRate(t *testing.T) {
 	})
 }
 
+// Checks to ensure that if a Burn Alert was removed from Honeycomb outside of Terraform (UI or API)
+// that it is detected and planned for recreation.
+func TestAcc_BurnAlertResource_RecreateOnNotFound(t *testing.T) {
+	dataset, sloID := burnAlertAccTestSetup(t)
+	burnAlert := &client.BurnAlert{}
+
+	exhaustionMinutes := 240
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 testAccPreCheck(t),
+		ProtoV5ProviderFactories: testAccProtoV5MuxServerFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfigBurnAlertExhaustionTime_basic(exhaustionMinutes, dataset, sloID, "info"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccEnsureSuccessExhaustionTimeAlert(t, burnAlert, exhaustionMinutes, "info", sloID),
+					func(_ *terraform.State) error {
+						// the final 'check' deletes the Burn Alert directly via the API leaving it behind in the state
+						err := testAccClient(t).BurnAlerts.Delete(context.Background(), dataset, burnAlert.ID)
+						require.NoError(t, err)
+						return nil
+					},
+				),
+				// ensure that the plan is non-empty after the deletion
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 // Checks that the exhaustion time burn alert exists, has the correct attributes, and has the correct state
 func testAccEnsureSuccessExhaustionTimeAlert(t *testing.T, burnAlert *client.BurnAlert, exhaustionMinutes int, pagerdutySeverity, sloID string) resource.TestCheckFunc {
 	return resource.ComposeAggregateTestCheckFunc(
@@ -522,9 +552,8 @@ func burnAlertAccTestSetup(t *testing.T) (string, string) {
 		Alias:      "sli." + acctest.RandString(8),
 		Expression: "BOOL(1)",
 	})
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
+
 	slo, err := c.SLOs.Create(ctx, dataset, &client.SLO{
 		Name:             acctest.RandString(8) + " SLO",
 		TimePeriodDays:   14,

--- a/internal/provider/trigger_resource.go
+++ b/internal/provider/trigger_resource.go
@@ -379,19 +379,21 @@ func (r *triggerResource) Delete(ctx context.Context, req resource.DeleteRequest
 
 	var detailedErr client.DetailedError
 	err := r.client.Triggers.Delete(ctx, state.Dataset.ValueString(), state.ID.ValueString())
-	if errors.As(err, &detailedErr) {
-		// if not found consider it deleted -- so don't error
-		if !detailedErr.IsNotFound() {
-			resp.Diagnostics.Append(helper.NewDetailedErrorDiagnostic(
+	if err != nil {
+		if errors.As(err, &detailedErr) {
+			// if not found consider it deleted -- so don't error
+			if !detailedErr.IsNotFound() {
+				resp.Diagnostics.Append(helper.NewDetailedErrorDiagnostic(
+					"Error Deleting Honeycomb Trigger",
+					&detailedErr,
+				))
+			}
+		} else {
+			resp.Diagnostics.AddError(
 				"Error Deleting Honeycomb Trigger",
-				&detailedErr,
-			))
+				"Could not delete Trigger ID "+state.ID.ValueString()+": "+err.Error(),
+			)
 		}
-	} else {
-		resp.Diagnostics.AddError(
-			"Error Deleting Honeycomb Trigger",
-			"Could not delete Trigger ID "+state.ID.ValueString()+": "+err.Error(),
-		)
 	}
 }
 


### PR DESCRIPTION
v0.19.0's client re-write introduced new client error handling but mishandled the classic "re-create when missing remotely" behaviour that Terraform in known -- and loved -- for.

The TL;DR for the fix is that pointers to errors and `errors.As()` are not a good mix for successful error checking.

Initially reported as a bug via Honeycomb Support.