### PR TITLE
fix(honeycombio_board) graph_settings should revert to false when removed

### DIFF
--- a/client/board.go
+++ b/client/board.go
@@ -113,12 +113,12 @@ const (
 
 // BoardGraphSettings represents the display settings for an individual graph in a board.
 type BoardGraphSettings struct {
-	OmitMissingValues    bool `json:"omit_missing_values,omitempty"`
-	UseStackedGraphs     bool `json:"stacked_graphs,omitempty"`
-	UseLogScale          bool `json:"log_scale,omitempty"`
-	UseUTCXAxis          bool `json:"utc_xaxis,omitempty"`
-	HideMarkers          bool `json:"hide_markers,omitempty"`
-	PreferOverlaidCharts bool `json:"overlaid_charts,omitempty"`
+	OmitMissingValues    bool `json:"omit_missing_values"`
+	UseStackedGraphs     bool `json:"stacked_graphs"`
+	UseLogScale          bool `json:"log_scale"`
+	UseUTCXAxis          bool `json:"utc_xaxis"`
+	HideMarkers          bool `json:"hide_markers"`
+	PreferOverlaidCharts bool `json:"overlaid_charts"`
 }
 
 // BoardQueryStyles returns an exhaustive list of board query styles.

--- a/honeycombio/resource_board.go
+++ b/honeycombio/resource_board.go
@@ -78,7 +78,6 @@ func newBoard() *schema.Resource {
 						},
 						"graph_settings": {
 							Type:     schema.TypeList,
-							MinItems: 1,
 							MaxItems: 1,
 							Computed: true,
 							Optional: true,
@@ -88,37 +87,37 @@ See [Graph Settings](https://docs.honeycomb.io/working-with-your-data/graph-sett
 								Schema: map[string]*schema.Schema{
 									"log_scale": {
 										Type:        schema.TypeBool,
-										Computed:    true,
+										Default:     false,
 										Optional:    true,
 										Description: "Set the graph's Y axis to Log scale.",
 									},
 									"omit_missing_values": {
 										Type:        schema.TypeBool,
-										Computed:    true,
+										Default:     false,
 										Optional:    true,
 										Description: "Enable interpolatation between datapoints when the interveneing time buckets have no matching events.",
 									},
 									"hide_markers": {
 										Type:        schema.TypeBool,
-										Computed:    true,
+										Default:     false,
 										Optional:    true,
 										Description: "Disable the overlay of Markers on the graph.",
 									},
 									"stacked_graphs": {
 										Type:        schema.TypeBool,
-										Computed:    true,
+										Default:     false,
 										Optional:    true,
 										Description: "Enable the display of groups as stacked colored area under their line graphs.",
 									},
 									"utc_xaxis": {
 										Type:        schema.TypeBool,
-										Computed:    true,
+										Default:     false,
 										Optional:    true,
 										Description: "Set the graph's X axis to UTC.",
 									},
 									"overlaid_charts": {
 										Type:        schema.TypeBool,
-										Computed:    true,
+										Default:     false,
 										Optional:    true,
 										Description: "Allow charts to be overlaid when using supported Visualize operators.",
 									},


### PR DESCRIPTION
When removing a setting from `graph_settings` the value is not reverted to "false" (the documented default).

During testing #399 was discovered but I believe the fix there is to re-implement the resource in the Plugin Framework.

Initially reported via Honeycomb Support.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205951498507418