### PR TITLE
chore: first pass at moving away from pre-created columns

### DIFF
--- a/client/auth_test.go
+++ b/client/auth_test.go
@@ -8,11 +8,12 @@ import (
 )
 
 func TestAuthMetadata(t *testing.T) {
-	ctx := context.Background()
+	t.Parallel()
+
 	c := newTestClient(t)
 
 	t.Run("List", func(t *testing.T) {
-		metadata, err := c.Auth.List(ctx)
+		metadata, err := c.Auth.List(context.Background())
 
 		assert.NoError(t, err)
 		assert.NotEmpty(t, metadata.APIKeyAccess)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -45,6 +45,8 @@ func testDataset(t *testing.T) string {
 }
 
 func TestClient_InvalidConfig(t *testing.T) {
+	t.Parallel()
+
 	_, err := NewClient(&Config{
 		APIKey: "123",
 		APIUrl: "cache_object:foo/bar",
@@ -54,6 +56,8 @@ func TestClient_InvalidConfig(t *testing.T) {
 }
 
 func TestClient_IsClassic(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	c := newTestClient(t)
 

--- a/client/dataset_definitions.go
+++ b/client/dataset_definitions.go
@@ -85,7 +85,7 @@ func DatasetDefinitionDefaults() map[string][]string {
 		"error":           {"error"},
 		"name":            {"name"},
 		"parent_id":       {"trace.parent_id", "parentId"},
-		"route":           {"route", "request_path"},
+		"route":           {"route", "http.route", "request_path"},
 		"service_name":    {"service_name", "service.name", "serviceName"},
 		"span_id":         {"id", "trace.span_id"},
 		"span_kind":       {"meta.span_type"},

--- a/client/dataset_definitions_test.go
+++ b/client/dataset_definitions_test.go
@@ -4,28 +4,60 @@ import (
 	"context"
 	"testing"
 
+	"github.com/honeycombio/terraform-provider-honeycombio/internal/helper/test"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDatasetDefinitions(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	c := newTestClient(t)
 	dataset := testDataset(t)
+	definitionDefaults := DatasetDefinitionDefaults()
 
-	col, err := c.Columns.Create(ctx, dataset, &Column{KeyName: "happy.duck"})
-	assert.NoError(t, err)
-	dc, err := c.DerivedColumns.Create(ctx, dataset, &DerivedColumn{
-		Alias:      "happy.error",
-		Expression: `NOT(CONTAINS($app.error, "fatal"))`,
+	// ensure default definition columns exist -- create any which may be missing.
+	// we leave these behind at the end of the test run
+	// as they can't be deleted while being used as a definition column
+	for _, col := range []Column{
+		{KeyName: "duration_ms", Type: ToPtr(ColumnTypeFloat)},
+		{KeyName: "error", Type: ToPtr(ColumnTypeBoolean)},
+		{KeyName: "name", Type: ToPtr(ColumnTypeString)},
+		{KeyName: "trace.parent_id", Type: ToPtr(ColumnTypeString)},
+		{KeyName: "http.route", Type: ToPtr(ColumnTypeString)},
+		{KeyName: "service.name", Type: ToPtr(ColumnTypeString)},
+		{KeyName: "trace.span_id", Type: ToPtr(ColumnTypeString)},
+		{KeyName: "meta.span_type", Type: ToPtr(ColumnTypeString)},
+		{KeyName: "meta.annotation_type", Type: ToPtr(ColumnTypeString)},
+		{KeyName: "http.status_code", Type: ToPtr(ColumnTypeInteger)},
+		{KeyName: "trace.trace_id", Type: ToPtr(ColumnTypeString)},
+		{KeyName: "request.user.id", Type: ToPtr(ColumnTypeString)},
+		{KeyName: "request.user.username", Type: ToPtr(ColumnTypeString)},
+		{KeyName: "trace.link.trace_id", Type: ToPtr(ColumnTypeString)},
+		{KeyName: "trace.link.span_id", Type: ToPtr(ColumnTypeString)},
+	} {
+		//nolint:errcheck
+		// ignore errors, we don't care if the column already exists
+		c.Columns.Create(ctx, dataset, &col)
+	}
+
+	// create some new columns to assign as definitions -- we will clean these up at the end of the test run
+	testCol, err := c.Columns.Create(ctx, dataset, &Column{KeyName: test.RandomStringWithPrefix("test.", 10)})
+	require.NoError(t, err)
+	testDC, err := c.DerivedColumns.Create(ctx, dataset, &DerivedColumn{
+		Alias:      test.RandomStringWithPrefix("test.", 10),
+		Expression: "BOOL(1)",
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
+
 	// reset all defs and remove test helpers at end of test run
 	//nolint:errcheck
 	t.Cleanup(func() {
 		c.DatasetDefinitions.ResetAll(ctx, dataset)
-		c.Columns.Delete(ctx, dataset, col.ID)
-		c.DerivedColumns.Delete(ctx, dataset, dc.ID)
+		c.Columns.Delete(ctx, dataset, testCol.ID)
+		c.DerivedColumns.Delete(ctx, dataset, testDC.ID)
 	})
 
 	t.Run("Reset and Assert Default state", func(t *testing.T) {
@@ -34,48 +66,44 @@ func TestDatasetDefinitions(t *testing.T) {
 
 		result, err := c.DatasetDefinitions.Get(ctx, dataset)
 		assert.NoError(t, err)
-		assert.Equal(t, "duration_ms", result.DurationMs.Name)
-		assert.Nil(t, result.Error)
+		assert.Contains(t, definitionDefaults["duration_ms"], result.DurationMs.Name)
+		assert.Equal(t, "error", result.Error.Name)
 		assert.Equal(t, "name", result.Name.Name)
-		assert.Equal(t, "trace.parent_id", result.ParentID.Name)
-		assert.Nil(t, result.Route)
-		assert.Equal(t, "service_name", result.ServiceName.Name)
-		assert.Equal(t, "trace.span_id", result.SpanID.Name)
-		assert.Nil(t, result.SpanKind)
-		assert.Nil(t, result.AnnotationType)
-		assert.Nil(t, result.LinkTraceID)
-		assert.Nil(t, result.LinkSpanID)
-		assert.Nil(t, result.Status)
-		assert.Equal(t, "trace.trace_id", result.TraceID.Name)
-		assert.Nil(t, result.User)
+		assert.Contains(t, definitionDefaults["parent_id"], result.ParentID.Name)
+		assert.Contains(t, definitionDefaults["route"], result.Route.Name)
+		assert.Contains(t, definitionDefaults["service_name"], result.ServiceName.Name)
+		assert.Contains(t, definitionDefaults["span_id"], result.SpanID.Name)
+		assert.Contains(t, definitionDefaults["span_kind"], result.SpanKind.Name)
+		assert.Contains(t, definitionDefaults["annotation_type"], result.AnnotationType.Name)
+		assert.Contains(t, definitionDefaults["link_trace_id"], result.LinkTraceID.Name)
+		assert.Contains(t, definitionDefaults["link_span_id"], result.LinkSpanID.Name)
+		assert.Contains(t, definitionDefaults["status"], result.Status.Name)
+		assert.Contains(t, definitionDefaults["trace_id"], result.TraceID.Name)
+		assert.Contains(t, definitionDefaults["user"], result.User.Name)
 	})
 
 	t.Run("Update a pair of definitions", func(t *testing.T) {
 		_, err := c.DatasetDefinitions.Update(ctx, dataset, &DatasetDefinition{
-			Name:  &DefinitionColumn{Name: col.KeyName},
-			Error: &DefinitionColumn{Name: dc.Alias},
+			Name:  &DefinitionColumn{Name: testCol.KeyName},
+			Error: &DefinitionColumn{Name: testDC.Alias},
 		})
 		assert.NoError(t, err)
 		// refetch to be extra sure that our update took effect
 		datasetDef, err := c.DatasetDefinitions.Get(ctx, dataset)
 		assert.NoError(t, err)
-		assert.Equal(t, datasetDef.Name.Name, col.KeyName)
+		assert.Equal(t, datasetDef.Name.Name, testCol.KeyName)
 		assert.Equal(t, datasetDef.Name.ColumnType, "column")
-		assert.Equal(t, datasetDef.Error.Name, dc.Alias)
+		assert.Equal(t, datasetDef.Error.Name, testDC.Alias)
 		assert.Equal(t, datasetDef.Error.ColumnType, "derived_column")
-		// spot check a few of the original fields from above to ensure they were unchanged
-		assert.Nil(t, datasetDef.Route)
-		assert.Equal(t, "service_name", datasetDef.ServiceName.Name)
-		assert.Equal(t, "trace.span_id", datasetDef.SpanID.Name)
 	})
 
-	t.Run("Reset two fields: one with a default", func(t *testing.T) {
+	t.Run("Reset the fields: ensure reverted to default", func(t *testing.T) {
 		result, err := c.DatasetDefinitions.Update(ctx, dataset, &DatasetDefinition{
 			Name:  EmptyDatasetDefinition(),
 			Error: EmptyDatasetDefinition(),
 		})
 		assert.NoError(t, err)
 		assert.Equal(t, result.Name.Name, "name")
-		assert.Nil(t, result.Error)
+		assert.Equal(t, result.Error.Name, "error")
 	})
 }

--- a/client/dataset_test.go
+++ b/client/dataset_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestDatasets(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	c := newTestClient(t)

--- a/client/derived_column_test.go
+++ b/client/derived_column_test.go
@@ -5,11 +5,14 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/honeycombio/terraform-provider-honeycombio/internal/helper/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestDerivedColumns(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	c := newTestClient(t)
@@ -20,8 +23,8 @@ func TestDerivedColumns(t *testing.T) {
 
 	t.Run("Create", func(t *testing.T) {
 		data := &DerivedColumn{
-			Alias:       "derived_column_test",
-			Expression:  "LOG10($duration_ms)",
+			Alias:       test.RandomStringWithPrefix("test.", 10),
+			Expression:  "BOOL(1)",
 			Description: "This derived column is created by a test",
 		}
 		derivedColumn, err = c.DerivedColumns.Create(ctx, dataset, data)
@@ -34,8 +37,8 @@ func TestDerivedColumns(t *testing.T) {
 
 	t.Run("Create_DuplicateErr", func(t *testing.T) {
 		data := &DerivedColumn{
-			Alias:       "derived_column_test",
-			Expression:  "LOG10($duration_ms)",
+			Alias:       derivedColumn.Alias,
+			Expression:  "BOOL(0)",
 			Description: "This is a derived column with the same name as an existing one",
 		}
 		_, err = c.DerivedColumns.Create(ctx, dataset, data)
@@ -71,8 +74,8 @@ func TestDerivedColumns(t *testing.T) {
 		// change all the fields to test
 		data := &DerivedColumn{
 			ID:          derivedColumn.ID,
-			Alias:       "derived_column_test_new_alias",
-			Expression:  "DIV($duration_ms, 2)",
+			Alias:       test.RandomStringWithPrefix("test.", 10),
+			Expression:  "BOOL(0)",
 			Description: "This is a new description",
 		}
 		derivedColumn, err = c.DerivedColumns.Update(ctx, dataset, data)

--- a/client/errors_test.go
+++ b/client/errors_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestClient_ParseDetailedError(t *testing.T) {
+	t.Parallel()
+
 	var de DetailedError
 	ctx := context.Background()
 	c := newTestClient(t)
@@ -112,6 +114,8 @@ func TestErrors_DetailedError_Error(t *testing.T) {
 }
 
 func TestErrors_ErrorTypeDetail_String(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		name           string
 		input          ErrorTypeDetail

--- a/client/marker_settings_test.go
+++ b/client/marker_settings_test.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"testing"
 
+	"github.com/honeycombio/terraform-provider-honeycombio/internal/helper/test"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestMarkerSettings(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	var m *MarkerSetting
@@ -17,7 +20,7 @@ func TestMarkerSettings(t *testing.T) {
 	dataset := testDataset(t)
 
 	currentMarkerSetting := &MarkerSetting{
-		Type:  "test11",
+		Type:  test.RandomStringWithPrefix("test.", 8),
 		Color: "#b71c1c",
 	}
 

--- a/client/marker_test.go
+++ b/client/marker_test.go
@@ -6,11 +6,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/honeycombio/terraform-provider-honeycombio/internal/helper/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestMarkers(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	var m *Marker
@@ -22,7 +25,7 @@ func TestMarkers(t *testing.T) {
 	t.Run("Create", func(t *testing.T) {
 		data := &Marker{
 			Message:   fmt.Sprintf("Test run at %v", time.Now()),
-			Type:      "deploys",
+			Type:      test.RandomStringWithPrefix("test.", 8),
 			URL:       "http://example.com",
 			StartTime: time.Now().Unix(),
 		}

--- a/client/query_annotation_test.go
+++ b/client/query_annotation_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestQueryAnnotations(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	c := newTestClient(t)

--- a/client/query_result_test.go
+++ b/client/query_result_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestQueryResults(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	var result *QueryResult

--- a/client/query_spec_test.go
+++ b/client/query_spec_test.go
@@ -9,6 +9,8 @@ import (
 
 // create a query with an elaborate QuerySpec as smoke test
 func TestQuerySpec(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	c := newTestClient(t)
@@ -73,6 +75,8 @@ func TestQuerySpec(t *testing.T) {
 }
 
 func TestQuerySpec_EquivalentTo(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		a, b QuerySpec

--- a/client/recipient_test.go
+++ b/client/recipient_test.go
@@ -5,11 +5,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/honeycombio/terraform-provider-honeycombio/internal/helper/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestRecipientsEmail(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	var rcpt *Recipient
@@ -21,7 +24,7 @@ func TestRecipientsEmail(t *testing.T) {
 		data := &Recipient{
 			Type: RecipientTypeEmail,
 			Details: RecipientDetails{
-				EmailAddress: "hnytest@example.com",
+				EmailAddress: test.RandomString(8) + "@example.com",
 			},
 		}
 		now := time.Now()
@@ -76,6 +79,8 @@ func TestRecipientsEmail(t *testing.T) {
 }
 
 func TestRecipientsWebhooksandMSTeams(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	c := newTestClient(t)
 
@@ -83,7 +88,7 @@ func TestRecipientsWebhooksandMSTeams(t *testing.T) {
 		{
 			Type: RecipientTypeWebhook,
 			Details: RecipientDetails{
-				WebhookName:   "test webhook",
+				WebhookName:   test.RandomStringWithPrefix("test.", 10),
 				WebhookURL:    "https://example.com",
 				WebhookSecret: "secret",
 			},
@@ -91,7 +96,7 @@ func TestRecipientsWebhooksandMSTeams(t *testing.T) {
 		{
 			Type: RecipientTypeMSTeams,
 			Details: RecipientDetails{
-				WebhookName: "test channel",
+				WebhookName: test.RandomStringWithPrefix("test.", 10),
 				WebhookURL:  "https://corp.office.com/webhook",
 			},
 		},

--- a/client/slo_test.go
+++ b/client/slo_test.go
@@ -4,10 +4,14 @@ import (
 	"context"
 	"testing"
 
+	"github.com/honeycombio/terraform-provider-honeycombio/internal/helper/test"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSLOs(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 
 	var slo *SLO
@@ -17,12 +21,11 @@ func TestSLOs(t *testing.T) {
 	dataset := testDataset(t)
 
 	sli, err := c.DerivedColumns.Create(ctx, dataset, &DerivedColumn{
-		Alias:      "sli.slo_test",
-		Expression: "LT($duration_ms, 1000)",
+		Alias:      test.RandomStringWithPrefix("test.", 10),
+		Expression: "BOOL(1)",
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err, "unable to create SLI")
+
 	// remove SLI DC at end of test run
 	t.Cleanup(func() {
 		//nolint:errcheck
@@ -31,13 +34,12 @@ func TestSLOs(t *testing.T) {
 
 	t.Run("Create", func(t *testing.T) {
 		data := &SLO{
-			Name:             "Testsuite SLO",
+			Name:             test.RandomStringWithPrefix("test.", 10),
 			Description:      "My Super Sweet Test",
 			TimePeriodDays:   30,
 			TargetPerMillion: 995000,
 			SLI:              SLIRef{Alias: sli.Alias},
 		}
-
 		slo, err = c.SLOs.Create(ctx, dataset, data)
 
 		assert.NoError(t, err, "unable to create SLO")
@@ -66,7 +68,7 @@ func TestSLOs(t *testing.T) {
 	})
 
 	t.Run("Update", func(t *testing.T) {
-		slo.Name = "Test Sweet SLO"
+		slo.Name = test.RandomStringWithPrefix("test.", 10)
 		slo.TimePeriodDays = 14
 		slo.Description = "Even sweeter"
 		slo.TargetPerMillion = 990000

--- a/client/type_helpers_test.go
+++ b/client/type_helpers_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 func TestEquivalent(t *testing.T) {
+	t.Parallel()
+
 	type Person struct {
 		Name string
 		Age  int

--- a/internal/helper/test/strings.go
+++ b/internal/helper/test/strings.go
@@ -1,0 +1,25 @@
+package test
+
+import "math/rand"
+
+const alphaNumericChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+// RandomString generates a random string of the given length.
+func RandomString(length int) string {
+	result := make([]byte, length)
+	for i := range result {
+		result[i] = alphaNumericChars[rand.Intn(len(alphaNumericChars))]
+	}
+	return string(result)
+}
+
+// RandomStringWithPrefix generates a random string of characters of the given length
+// with the provided prefix.
+// This is useful for generating unique names for resources.
+//
+// Example:
+//
+//	RandomStringWithPrefix("test-", 10) => "test-abcde12345"
+func RandomStringWithPrefix(prefix string, length int) string {
+	return prefix + RandomString(length)
+}


### PR DESCRIPTION
First step toward removing the dependency on `scripts/setup-testsuite-dataset` and also not being in a position that some failed test runs cause subsequent runs to fail due to conflicts.

In addition to randomly generating strings, the idea is to prefix the things we create with `test.` and make email addresses in the `@example.com` domain so that we can in future make use of [Sweepers](https://developer.hashicorp.com/terraform/plugin/testing/acceptance-tests/sweepers) to remove anything starting with `test.` or in the `@example.com` domain.

More to improve here, but this was intended to be a "time boxed" first pass.