### PR TITLE
fix(client) - queryspec Granularity equivalency

### DIFF
--- a/client/query_spec.go
+++ b/client/query_spec.go
@@ -120,7 +120,8 @@ func (qs *QuerySpec) EquivalentTo(other QuerySpec) bool {
 	if !reflect.DeepEqual(qs.StartTime, other.StartTime) || !reflect.DeepEqual(qs.EndTime, other.EndTime) {
 		return false
 	}
-	if !reflect.DeepEqual(qs.Granularity, other.Granularity) {
+	// Granularity may be exported out of the Query Builder as '0' when not provided
+	if PtrValueOrDefault(qs.Granularity, 0) != PtrValueOrDefault(other.Granularity, 0) {
 		return false
 	}
 

--- a/client/query_spec_test.go
+++ b/client/query_spec_test.go
@@ -93,6 +93,8 @@ func TestQuerySpec_EquivalentTo(t *testing.T) {
 				},
 				FilterCombination: "AND",
 				TimeRange:         ToPtr(DefaultQueryTimeRange),
+				// Granularity may be exported out of the Query Builder as '0' when not provided
+				Granularity: ToPtr(0),
 			},
 			QuerySpec{},
 			true,


### PR DESCRIPTION
Reported via Pollinators ([link](https://honeycombpollinators.slack.com/archives/C017T9FFT0D/p1700814782578459)).

The Query Builder will export JSON query specs with `"granularity": 0`, but the API will not return this field if it's set to zero. This marks either case as equivalent.

Prior to this change a `honeycombio_query` as below would cause an infinite diff:

```hcl
resource "honeycombio_query" "test" {
  dataset    = var.dataset
  query_json = <<-EOF
{
  "breakdowns": ["app.tenant"],
  "calculations": [{ "op": "COUNT" }],
  "orders": [
    {
      "column": "app.tenant",
      "order": "ascending"
    }
  ],
  "granularity": 0
  "filter_combination": "AND",
}
EOF
}
```

Plan output:

```
  # honeycombio_query.test must be replaced
-/+ resource "honeycombio_query" "test" {
      ~ id         = "AD1Ue8TJCfC" -> (known after apply)
      ~ query_json = jsonencode(
          ~ {
              + filter_combination = "AND"
              + granularity        = 0
              ~ orders             = [
                  ~ {
                      + order  = "ascending"
                        # (1 unchanged attribute hidden)
                    },
                ]
                # (3 unchanged attributes hidden)
            } # forces replacement
        )
        # (1 unchanged attribute hidden)
    }
```

