### PR TITLE
Fix description of end_time in trigger docs

### DIFF
--- a/docs/resources/trigger.md
+++ b/docs/resources/trigger.md
@@ -161,7 +161,7 @@ Each trigger configuration must contain exactly one `threshold` block, which acc
 Each trigger configuration may provide an `evaluation_schedule` block, which accepts the following arguments:
 
 * `start_time` - (Required) UTC time to start evaluating the trigger in HH:mm format (e.g. `13:00`)
-* `end_time` - (Required) UTC time to start evaluating the trigger in HH:mm format (e.g. `13:00`)
+* `end_time` - (Required) UTC time to stop evaluating the trigger in HH:mm format (e.g. `13:00`)
 * `days_of_week` - (Required) A list of days of the week (in lowercase) to evaluate the trigger on
 
 Each trigger configuration may have zero or more `recipient` blocks, which each accept the following arguments. A trigger recipient block can either refer to an existing recipient (a recipient that is already present in another trigger) or a new recipient. When specifying an existing recipient, only `id` may be set. If you pass in a recipient without its ID and only include the type and target, Honeycomb will make a best effort to match to an existing recipient. To retrieve the ID of an existing recipient, refer to the [`honeycombio_recipient`](../data-sources/recipient.md) data source.


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
Accuracy of documentation.

## Short description of the changes
This change fixes a copy/paste error in the docs for the `end_time` of an `evaluation_schedule`.

## How to verify that this has the expected result
It only affects the documentation. A review should be all that's needed.