### PR TITLE
docs: cleanup value_string reference

### DIFF
--- a/docs/data-sources/query_specification.md
+++ b/docs/data-sources/query_specification.md
@@ -65,7 +65,7 @@ Each query configuration may have zero or more `filter` blocks, which each accep
 
 * `column` - (Required) The column to apply the filter to.
 * `op` - (Required) The operator to apply, see the supported list of filter operators at [Filter Operators](https://docs.honeycomb.io/api/query-specification/#filter-operators). Not all operators require a value.
-* `value` - (Optional) The value used for the filter. Not needed if op is `exists`, `not-exists`, `in` or `not-in`. Mutually exclusive with the other `value_*` options.
+* `value` - (Optional) The value used for the filter. Not needed if op is `exists` or `not-exists`. Mutually exclusive with the other `value_*` options.
 * `value_string` - (Optional) Deprecated: use 'value' instead. The value used for the filter when the column is a string. Mutually exclusive with `value` and the other `value_*` options.
 * `value_integer` - (Optional) Deprecated: use 'value' instead. The value used for the filter when the column is an integer. Mutually exclusive with `value` and the other `value_*` options.
 * `value_float` - (Optional) Deprecated: use 'value' instead. The value used for the filter when the column is a float. Mutually exclusive with `value` and the other `value_*` options.

--- a/docs/data-sources/query_specification.md
+++ b/docs/data-sources/query_specification.md
@@ -71,9 +71,7 @@ Each query configuration may have zero or more `filter` blocks, which each accep
 * `value_float` - (Optional) Deprecated: use 'value' instead. The value used for the filter when the column is a float. Mutually exclusive with `value` and the other `value_*` options.
 * `value_boolean` - (Optional) Deprecated: use 'value' instead. The value used for the filter when the column is a boolean. Mutually exclusive with `value` and the other `value_*` options.
 
--> **NOTE** The type of the filter value should match with the type of the column. To determine the type of a column visit the dataset settings page, all the columns and their type are listed under _Schema_. This provider will not be able to detect invalid combinations.
-
--> **NOTE** Filter op `in` and `not-in` expect an array of strings as value. Use the `value` attribute and pass the values in single string separated by `,` without additional spaces (similar to the query builder in the UI). For example: the list `foo`, `bar` becomes `foo,bar`.
+* -> **NOTE** Filter op `in` and `not-in` expect an array of strings as value. Use the `value` attribute and pass the values in single string separated by `,` without additional spaces (similar to the query builder in the UI). For example: the list `foo`, `bar` becomes `foo,bar`.
 
 Each query configuration may have zero or more `order` blocks, which each accept the following arguments. An order term can refer to a `calculation` or a column set in `breakdowns`. When referring to a `calculation`, `op` and `column` must be the same as the calculation.
 

--- a/docs/data-sources/query_specification.md
+++ b/docs/data-sources/query_specification.md
@@ -73,7 +73,7 @@ Each query configuration may have zero or more `filter` blocks, which each accep
 
 -> **NOTE** The type of the filter value should match with the type of the column. To determine the type of a column visit the dataset settings page, all the columns and their type are listed under _Schema_. This provider will not be able to detect invalid combinations.
 
--> **NOTE** Filter op `in` and `not-in` expect an array of strings as value. Use the `value_string` attribute and pass the values in single string separated by `,` without additional spaces (similar to the query builder in the UI). For example: the list `foo`, `bar` becomes `foo,bar`.
+-> **NOTE** Filter op `in` and `not-in` expect an array of strings as value. Use the `value` attribute and pass the values in single string separated by `,` without additional spaces (similar to the query builder in the UI). For example: the list `foo`, `bar` becomes `foo,bar`.
 
 Each query configuration may have zero or more `order` blocks, which each accept the following arguments. An order term can refer to a `calculation` or a column set in `breakdowns`. When referring to a `calculation`, `op` and `column` must be the same as the calculation.
 

--- a/honeycombio/data_source_query_specification.go
+++ b/honeycombio/data_source_query_specification.go
@@ -54,7 +54,7 @@ func dataSourceHoneycombioQuerySpec() *schema.Resource {
 						},
 						"value": {
 							Type:        schema.TypeString,
-							Description: "The value used for the filter. Not needed if op is `exists`, `not-exists`, `in` or `not-in`. Mutually exclusive with the other `value_*` options.",
+							Description: "The value used for the filter. Not needed if op is `exists` or `not-exists`. Mutually exclusive with the other `value_*` options.",
 							Optional:    true,
 						},
 						"value_string": {


### PR DESCRIPTION
## Short description of the changes
Updates the note about `in` and `not-in` to reference `value` instead of `value_string` (which is deprecated) as well as a couple other cleanups related to the move to `value`
