### PR TITLE
fix: legacy api key typo

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -26,7 +26,7 @@ const (
 	DefaultAPIHostEnv = "HONEYCOMB_API_HOST"
 	DefaultAPIKeyEnv  = "HONEYCOMB_API_KEY"
 	// Deprecated: use DefaultAPIKeyEnv instead. To be removed in v1.0
-	LegacyAPIKeyEnv  = "HONEYCOMBIO_API_KEY"
+	LegacyAPIKeyEnv  = "HONEYCOMBIO_APIKEY"
 	defaultUserAgent = "go-honeycombio"
 )
 


### PR DESCRIPTION
## Which problem is this PR solving?

- Closes #410 

## Short description of the changes

Removes extra underscore in the legacy API key so it will start working again

