### PR TITLE
feat(client): standardize and document API endpoint envvar

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,14 @@ A Terraform provider for Honeycomb.io.
 
 🏗️ Examples can be found in [example/](example/)
 
-❓ Questions? Feel free to create a new issue or find us on the **Honeycomb Pollinators** Slack, channel [**#terraform-provider**](https://honeycombpollinators.slack.com/archives/C017T9FFT0D) (you can find a link to request an invite [here](https://www.honeycomb.io/blog/spread-the-love-appreciating-our-pollinators-community/))
+❓ Questions? Feel free to create a new issue or find us on the **Honeycomb Pollinators** Slack, channel [**#discuss-api-and-terraform**](https://honeycombpollinators.slack.com/archives/C017T9FFT0D) (you can find a link to request an invite [here](https://www.honeycomb.io/blog/spread-the-love-appreciating-our-pollinators-community/))
 
 🔧 Want to contribute? Check out [CONTRIBUTING.md](./CONTRIBUTING.md)
 
 ## Using the provider
 
-You can install the provider directly from the [Terraform Registry](https://registry.terraform.io/providers/honeycombio/honeycombio/latest). Add the following block in your Terraform config, this will download the provider from the Terraform Registry:
+You can install the provider directly from the [Terraform Registry](https://registry.terraform.io/providers/honeycombio/honeycombio/latest).
+Add the following block in your Terraform config, this will download the provider from the Terraform Registry:
 
 ```hcl
 terraform {
@@ -31,6 +32,18 @@ terraform {
 ```
 
 Set the API key used by Terraform setting the `HONEYCOMB_API_KEY` environment variable.
+You can override the default API Endpoint (`https://api.honeycomb.io`) by setting the `HONEYCOMB_API_ENDPOINT` environment variable.
+
+### Configuring the provider for Honeycomb EU
+
+If you are a Honeycomb EU customer, to use the provider you must override the default API host.
+This can be done with a `provider` block (example below) or by setting the `HONEYCOMB_API_ENDPOINT` environment variable.
+
+```hcl
+provider "honeycombio" {
+  api_url = "https://api.eu1.honeycomb.io"
+}
+```
 
 ## License
 

--- a/client/client.go
+++ b/client/client.go
@@ -22,9 +22,9 @@ import (
 )
 
 const (
-	DefaultAPIHost    = "https://api.honeycomb.io"
-	DefaultAPIHostEnv = "HONEYCOMB_API_HOST"
-	DefaultAPIKeyEnv  = "HONEYCOMB_API_KEY"
+	DefaultAPIHost        = "https://api.honeycomb.io"
+	DefaultAPIEndpointEnv = "HONEYCOMB_API_ENDPOINT"
+	DefaultAPIKeyEnv      = "HONEYCOMB_API_KEY"
 	// Deprecated: use DefaultAPIKeyEnv instead. To be removed in v1.0
 	LegacyAPIKeyEnv  = "HONEYCOMBIO_APIKEY"
 	defaultUserAgent = "go-honeycombio"
@@ -71,7 +71,7 @@ type Client struct {
 func DefaultConfig() *Config {
 	c := &Config{
 		APIKey:     os.Getenv(DefaultAPIKeyEnv),
-		APIUrl:     os.Getenv(DefaultAPIHostEnv),
+		APIUrl:     os.Getenv(DefaultAPIEndpointEnv),
 		Debug:      false,
 		HTTPClient: cleanhttp.DefaultPooledClient(),
 		UserAgent:  defaultUserAgent,

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,6 +38,17 @@ resource "honeycombio_marker" "hello" {
 
 More advanced examples can be found in the [example directory](https://github.com/honeycombio/terraform-provider-honeycombio/tree/main/example).
 
+### Configuring the provider for Honeycomb EU
+
+If you are a Honeycomb EU customer, to use the provider you must override the default API host.
+This can be done with a `provider` block or by setting the `HONEYCOMB_API_ENDPOINT` environment variable.
+
+```hcl
+provider "honeycombio" {
+  api_url = "https://api.eu1.honeycomb.io"
+}
+```
+
 ## Authentication
 
 The Honeycomb provider requires an API key to communicate with the Honeycomb API. API keys and their permissions can be managed in _Team settings_.
@@ -46,12 +57,12 @@ The key can be set with the `api_key` argument or via the `HONEYCOMB_API_KEY` or
 
 `HONEYCOMB_API_KEY` environment variable will take priority over the `HONEYCOMBIO_APIKEY` environment variable.
 
-~> **Note** Hard-coding API keys in any Terraform configuration is not recommended. Consider using the one of the  environment variable options.
+~> **Note** Hard-coding API keys in any Terraform configuration is not recommended. Consider using the one of the environment variable options.
 
 ## Argument Reference
 
 Arguments accepted by this provider include:
 
 * `api_key` - (Required) The Honeycomb API key to use. It can also be set using `HONEYCOMB_API_KEY` or `HONEYCOMBIO_APIKEY` environment variables.
-* `api_url` - (Optional) Override the url of the Honeycomb.io API. Defaults to `https://api.honeycomb.io`.
+* `api_url` - (Optional) Override the URL of the Honeycomb.io API. It can also be set using `HONEYCOMB_API_ENDPOINT`. Defaults to `https://api.honeycomb.io`.
 * `debug` - (Optional) Enable to log additional debug information. To view the logs, set `TF_LOG` to at least debug.

--- a/internal/provider/burn_alert_resource_test.go
+++ b/internal/provider/burn_alert_resource_test.go
@@ -230,7 +230,7 @@ func TestAcc_BurnAlertResourceUpgradeFromVersion015(t *testing.T) {
 				// support setting the API host easily. We'll skip them for now
 				// if we have a non-default API host.
 				SkipFunc: func() (bool, error) {
-					apiHost := os.Getenv(client.DefaultAPIHostEnv)
+					apiHost := os.Getenv(client.DefaultAPIEndpointEnv)
 					if apiHost == "" {
 						return false, nil
 					}

--- a/internal/provider/trigger_resource_test.go
+++ b/internal/provider/trigger_resource_test.go
@@ -73,7 +73,7 @@ func TestAcc_TriggerResourceUpgradeFromVersion014(t *testing.T) {
 				// support setting the API host easily. We'll skip them for now
 				// if we have a non-default API host.
 				SkipFunc: func() (bool, error) {
-					apiHost := os.Getenv(client.DefaultAPIHostEnv)
+					apiHost := os.Getenv(client.DefaultAPIEndpointEnv)
 					if apiHost == "" {
 						return false, nil
 					}


### PR DESCRIPTION
This switches the -- previously undocumented -- API Endpoint envvar to the more standard `HONEYCOMB_API_ENDPOINT` and documents it along with specific instructions on how to use the provider with Honeycomb EU.

This is technically a breaking change (even though the envvar was undocumented) and will need to be called out as such in the release notes