### PR TITLE
chore(ci): switch to golangci-lint and fix lints

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,11 @@ jobs:
           go-version-file: "go.mod"
           cache: true
 
+      - name: Lint
+        uses: golangci/golangci-lint-action@v3.7.0
+        with:
+          version: latest
+
       - name: Build
         run: go build -v .
 
@@ -75,37 +80,3 @@ jobs:
 
       - name: Generate Coverage Report
         uses: codecov/codecov-action@v3.1.4
-
-  fmt:
-    name: Formatting
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: "go.mod"
-          cache: true
-
-      - name: Check formatting
-        run: |
-          # install goimports from another directory to not touch go.mod
-          pushd ../
-          go install golang.org/x/tools/cmd/goimports@v0.8.0
-          popd
-
-          goimports -l -w .
-
-          if ! git diff --quiet; then
-            echo Running goimports has caused changes, please run go fmt
-            exit 1
-          fi
-
-          go mod tidy
-
-          if ! git diff --quiet; then
-            echo 'go mod tidy' has caused changes, please run go mod tidy
-            exit 1
-          fi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"
-          cache: false
+          cache: false # https://github.com/golangci/golangci-lint-action/issues/807
 
       - name: Lint
         uses: golangci/golangci-lint-action@v3.7.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"
-          cache: true
+          cache: false
 
       - name: Lint
         uses: golangci/golangci-lint-action@v3.7.0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,3 +40,4 @@ run:
     # Prevent false positive timeouts in CI
     timeout: 5m
     tests: true
+    allow-parallel-runners: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -41,4 +41,3 @@ run:
     timeout: 5m
     tests: true
     allow-parallel-runners: true
-    modules-download-mode: readonly

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -41,3 +41,4 @@ run:
     timeout: 5m
     tests: true
     allow-parallel-runners: true
+    modules-download-mode: readonly

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,42 @@
+issues:
+    max-issues-per-linter: 0
+    max-same-issues: 0
+    exclude-rules:
+        - path: '(.+)_test\.go'
+          linters:
+              - errcheck
+          # disabling both of these for the SDKv2-based code as it's idomatic for the SDK
+        - path: honeycombio/*
+          text: "Error return value of `d.Set` is not checked"
+        - path: honeycombio/*
+          text: "type assertion must be checked"
+
+linters-settings:
+    goimports:
+        local-prefixes: github.com/honeycombio/terraform-provider-honeycombio
+
+linters:
+    disable-all: true
+    enable:
+        - durationcheck
+        - errcheck
+        - exportloopref
+        - forcetypeassert
+        - goimports
+        - gosimple
+        - ineffassign
+        - makezero
+        - misspell
+        - nilerr
+        - predeclared
+        - staticcheck
+        - tenv
+        - unconvert
+        - unparam
+        - unused
+        - vet
+
+run:
+    # Prevent false positive timeouts in CI
+    timeout: 5m
+    tests: true

--- a/client/board.go
+++ b/client/board.go
@@ -45,7 +45,7 @@ type Board struct {
 	Name string `json:"name"`
 	// Description of the board.
 	Description string `json:"description,omitempty"`
-	// The number of columns to be layed out when displaying the board.
+	// The number of columns to be laid out when displaying the board.
 	// Defaults to "multi".
 	//
 	// n.b. 'list' style boards cannot specify a column layout

--- a/client/client.go
+++ b/client/client.go
@@ -197,7 +197,9 @@ func (c *Client) Do(ctx context.Context, method, path string, requestBody, respo
 	if requestBody != nil {
 		buf := new(bytes.Buffer)
 		err := json.NewEncoder(buf).Encode(requestBody)
-
+		if err != nil {
+			return err
+		}
 		body = buf
 	}
 

--- a/client/client.go
+++ b/client/client.go
@@ -189,7 +189,7 @@ func (c *Client) IsClassic(ctx context.Context) bool {
 //
 // The response is parsed in responseBody, if responseBody is not nil.
 //
-// Attemps to return a DetailedError if the response status code is not 2xx,
+// Attempts to return a DetailedError if the response status code is not 2xx,
 // but can return a generic error.
 func (c *Client) Do(ctx context.Context, method, path string, requestBody, responseBody interface{}) error {
 	var body io.Reader

--- a/client/client.go
+++ b/client/client.go
@@ -197,9 +197,7 @@ func (c *Client) Do(ctx context.Context, method, path string, requestBody, respo
 	if requestBody != nil {
 		buf := new(bytes.Buffer)
 		err := json.NewEncoder(buf).Encode(requestBody)
-		if err != nil {
-			return err
-		}
+
 		body = buf
 	}
 

--- a/client/dataset_test.go
+++ b/client/dataset_test.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/honeycombio/terraform-provider-honeycombio/client"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/honeycombio/terraform-provider-honeycombio/client"
 )
 
 func TestDatasets(t *testing.T) {

--- a/client/marker.go
+++ b/client/marker.go
@@ -88,9 +88,9 @@ func (s *markers) Get(ctx context.Context, dataset string, id string) (*Marker, 
 			return &m, nil
 		}
 	}
-	return nil, &DetailedError{
+	return nil, DetailedError{
 		Status:  http.StatusNotFound,
-		Message: "Marker Setting Not Found.",
+		Message: "Marker Not Found.",
 	}
 }
 

--- a/client/marker_settings.go
+++ b/client/marker_settings.go
@@ -75,7 +75,7 @@ func (s *markerSettings) Get(ctx context.Context, dataset string, id string) (*M
 			return &m, nil
 		}
 	}
-	return nil, &DetailedError{
+	return nil, DetailedError{
 		Status:  http.StatusNotFound,
 		Message: "Marker Setting Not Found.",
 	}

--- a/client/marker_settings_test.go
+++ b/client/marker_settings_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/honeycombio/terraform-provider-honeycombio/client"
 	"github.com/honeycombio/terraform-provider-honeycombio/internal/helper/test"
@@ -29,10 +30,7 @@ func TestMarkerSettings(t *testing.T) {
 	t.Run("Create", func(t *testing.T) {
 
 		m, err = c.MarkerSettings.Create(ctx, dataset, currentMarkerSetting)
-
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		assert.NotNil(t, m.ID)
 		assert.Equal(t, currentMarkerSetting.Type, m.Type)
@@ -63,7 +61,6 @@ func TestMarkerSettings(t *testing.T) {
 	})
 
 	t.Run("Update", func(t *testing.T) {
-
 		result, err := c.MarkerSettings.Update(ctx, dataset, m)
 
 		assert.NoError(t, err)
@@ -79,7 +76,9 @@ func TestMarkerSettings(t *testing.T) {
 	t.Run("Fail to Get deleted Marker Setting", func(t *testing.T) {
 		_, err := c.MarkerSettings.Get(ctx, dataset, m.ID)
 
+		var de client.DetailedError
 		assert.Error(t, err)
-		assert.True(t, err.(*client.DetailedError).IsNotFound())
+		assert.ErrorAs(t, err, &de)
+		assert.True(t, de.IsNotFound())
 	})
 }

--- a/client/marker_test.go
+++ b/client/marker_test.go
@@ -84,7 +84,9 @@ func TestMarkers(t *testing.T) {
 	t.Run("Fail to Get deleted Marker", func(t *testing.T) {
 		_, err := c.Markers.Get(ctx, dataset, m.ID)
 
+		var de client.DetailedError
 		assert.Error(t, err)
-		assert.True(t, err.(*client.DetailedError).IsNotFound())
+		assert.ErrorAs(t, err, &de)
+		assert.True(t, de.IsNotFound())
 	})
 }

--- a/client/query_annotation_test.go
+++ b/client/query_annotation_test.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"testing"
 
-	"github.com/honeycombio/terraform-provider-honeycombio/client"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/honeycombio/terraform-provider-honeycombio/client"
 )
 
 func TestQueryAnnotations(t *testing.T) {

--- a/client/query_test.go
+++ b/client/query_test.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"testing"
 
-	"github.com/honeycombio/terraform-provider-honeycombio/client"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/honeycombio/terraform-provider-honeycombio/client"
 )
 
 func TestQueries(t *testing.T) {

--- a/client/trigger.go
+++ b/client/trigger.go
@@ -150,7 +150,7 @@ func (t *Trigger) MarshalJSON() ([]byte, error) {
 			EvaluationScheduleType: t.EvaluationScheduleType,
 			EvaluationSchedule:     t.EvaluationSchedule,
 		}
-		return json.Marshal(&struct{ *ATrigger }{ATrigger: (*ATrigger)(a)})
+		return json.Marshal(&struct{ *ATrigger }{ATrigger: a})
 	}
 
 	return json.Marshal(&struct{ *ATrigger }{ATrigger: (*ATrigger)(t)})

--- a/honeycombio/data_source_column.go
+++ b/honeycombio/data_source_column.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	honeycombio "github.com/honeycombio/terraform-provider-honeycombio/client"
 )
 

--- a/honeycombio/data_source_columns.go
+++ b/honeycombio/data_source_columns.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	honeycombio "github.com/honeycombio/terraform-provider-honeycombio/client"
 	"github.com/honeycombio/terraform-provider-honeycombio/internal/helper/hashcode"
 )

--- a/honeycombio/data_source_datasets.go
+++ b/honeycombio/data_source_datasets.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	honeycombio "github.com/honeycombio/terraform-provider-honeycombio/client"
 	"github.com/honeycombio/terraform-provider-honeycombio/internal/helper/hashcode"
 )

--- a/honeycombio/data_source_datasets_test.go
+++ b/honeycombio/data_source_datasets_test.go
@@ -22,7 +22,7 @@ func TestAccDataSourceHoneycombioDataset_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDataSourceDatasetConfig([]string{"starts_with = \"" + string(dataset[0:2]) + "\""}),
+				Config: testAccDataSourceDatasetConfig([]string{"starts_with = \"" + dataset[0:2] + "\""}),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckOutputContains("names", dataset),
 				),

--- a/honeycombio/data_source_query_result.go
+++ b/honeycombio/data_source_query_result.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	honeycombio "github.com/honeycombio/terraform-provider-honeycombio/client"
 	"github.com/honeycombio/terraform-provider-honeycombio/honeycombio/internal/verify"
 )

--- a/honeycombio/data_source_query_specification.go
+++ b/honeycombio/data_source_query_specification.go
@@ -286,9 +286,7 @@ func extractCalculations(d *schema.ResourceData) ([]honeycombio.CalculationSpec,
 	// none have been provided. As this can potentially cause an infinite diff
 	// we'll set the default here if we haven't parsed any
 	if len(calculations) == 0 {
-		calculations = append(calculations, honeycombio.CalculationSpec{
-			Op: honeycombio.CalculationOpCount,
-		})
+		calculations = []honeycombio.CalculationSpec{{Op: honeycombio.CalculationOpCount}}
 	}
 
 	return calculations, nil
@@ -390,7 +388,6 @@ func extractFilter(d *schema.ResourceData, index int) (honeycombio.FilterSpec, e
 			return filter, fmt.Errorf(multipleValuesError)
 		}
 		filter.Value = vb
-		valueSet = true
 	}
 
 	if filter.Op == honeycombio.FilterOpIn || filter.Op == honeycombio.FilterOpNotIn {

--- a/honeycombio/data_source_recipient.go
+++ b/honeycombio/data_source_recipient.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
 	honeycombio "github.com/honeycombio/terraform-provider-honeycombio/client"
 	"github.com/honeycombio/terraform-provider-honeycombio/internal/helper"
 )
@@ -161,7 +162,7 @@ func dataSourceHoneycombioRecipientRead(ctx context.Context, d *schema.ResourceD
 		return diag.Errorf("your recipient query returned no results.")
 	}
 	if len(filteredRcpts) > 1 {
-		return diag.Errorf("your recipient query returned more than one result. Please try a more specific search critera.")
+		return diag.Errorf("your recipient query returned more than one result. Please try a more specific search criteria.")
 	}
 	rcpt := filteredRcpts[0]
 	d.SetId(rcpt.ID)

--- a/honeycombio/data_source_recipient_test.go
+++ b/honeycombio/data_source_recipient_test.go
@@ -139,11 +139,11 @@ func TestAccDataSourceHoneycombioRecipient_basic(t *testing.T) {
 			},
 			{
 				Config:      testAccRecipientWithFilterRegex("email", "address", "^acctest*"),
-				ExpectError: regexp.MustCompile("your recipient query returned more than one result. Please try a more specific search critera."),
+				ExpectError: regexp.MustCompile("your recipient query returned more than one result. Please try a more specific search criteria."),
 			},
 			{
 				Config:      testAccRecipientWithFilterRegex("pagerduty", "integration_name", "^.*Important Service$"),
-				ExpectError: regexp.MustCompile("your recipient query returned more than one result. Please try a more specific search critera."),
+				ExpectError: regexp.MustCompile("your recipient query returned more than one result. Please try a more specific search criteria."),
 			},
 		},
 	})

--- a/honeycombio/data_source_recipients.go
+++ b/honeycombio/data_source_recipients.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
 	honeycombio "github.com/honeycombio/terraform-provider-honeycombio/client"
 	"github.com/honeycombio/terraform-provider-honeycombio/internal/helper"
 	"github.com/honeycombio/terraform-provider-honeycombio/internal/helper/hashcode"

--- a/honeycombio/internal/verify/json.go
+++ b/honeycombio/internal/verify/json.go
@@ -8,14 +8,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func SuppressEquivJSONDiffs(_, orig, new string, d *schema.ResourceData) bool {
+func SuppressEquivJSONDiffs(_, j1, j2 string, d *schema.ResourceData) bool {
 	oldBuf := bytes.NewBufferString("")
-	if err := json.Compact(oldBuf, []byte(orig)); err != nil {
+	if err := json.Compact(oldBuf, []byte(j1)); err != nil {
 		return false
 	}
 
 	newBuf := bytes.NewBufferString("")
-	if err := json.Compact(newBuf, []byte(new)); err != nil {
+	if err := json.Compact(newBuf, []byte(j2)); err != nil {
 		return false
 	}
 

--- a/honeycombio/internal/verify/query_spec.go
+++ b/honeycombio/internal/verify/query_spec.go
@@ -4,16 +4,17 @@ import (
 	"encoding/json"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/honeycombio/terraform-provider-honeycombio/client"
 )
 
-func SupressEquivQuerySpecDiff(_, orig, new string, _ *schema.ResourceData) bool {
+func SupressEquivQuerySpecDiff(_, q1, q2 string, _ *schema.ResourceData) bool {
 	var qs1, qs2 client.QuerySpec
 
-	if err := json.Unmarshal([]byte(orig), &qs1); err != nil {
+	if err := json.Unmarshal([]byte(q1), &qs1); err != nil {
 		return false
 	}
-	if err := json.Unmarshal([]byte(new), &qs2); err != nil {
+	if err := json.Unmarshal([]byte(q2), &qs2); err != nil {
 		return false
 	}
 	return qs1.EquivalentTo(qs2)

--- a/honeycombio/provider.go
+++ b/honeycombio/provider.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	honeycombio "github.com/honeycombio/terraform-provider-honeycombio/client"
 	"github.com/honeycombio/terraform-provider-honeycombio/internal/helper/log"
 )
@@ -69,6 +70,7 @@ func Provider(version string) *schema.Provider {
 		apiKey := os.Getenv(honeycombio.DefaultAPIKeyEnv)
 		if apiKey == "" {
 			// fall through to legacy env var
+			//nolint:staticcheck
 			apiKey = os.Getenv(honeycombio.LegacyAPIKeyEnv)
 		}
 		if v, ok := d.GetOk("api_key"); ok {

--- a/honeycombio/provider_test.go
+++ b/honeycombio/provider_test.go
@@ -5,8 +5,9 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	honeycombio "github.com/honeycombio/terraform-provider-honeycombio/client"
 	"github.com/joho/godotenv"
+
+	honeycombio "github.com/honeycombio/terraform-provider-honeycombio/client"
 )
 
 func init() {
@@ -26,6 +27,7 @@ func testAccPreCheck(t *testing.T) func() {
 }
 
 var testAccProviderFactories = map[string]func() (*schema.Provider, error){
+	//nolint:unparam
 	"honeycombio": func() (*schema.Provider, error) {
 		return Provider("test"), nil
 	},

--- a/honeycombio/query_spec.go
+++ b/honeycombio/query_spec.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	honeycombio "github.com/honeycombio/terraform-provider-honeycombio/client"
 )
 

--- a/honeycombio/resource_board.go
+++ b/honeycombio/resource_board.go
@@ -95,7 +95,7 @@ See [Graph Settings](https://docs.honeycomb.io/working-with-your-data/graph-sett
 										Type:        schema.TypeBool,
 										Default:     false,
 										Optional:    true,
-										Description: "Enable interpolatation between datapoints when the interveneing time buckets have no matching events.",
+										Description: "Enable interpolatation between datapoints when the intervening time buckets have no matching events.",
 									},
 									"hide_markers": {
 										Type:        schema.TypeBool,

--- a/honeycombio/resource_board_test.go
+++ b/honeycombio/resource_board_test.go
@@ -240,6 +240,7 @@ resource "honeycombio_board" "test" {
 }`, dataset)
 }
 
+//nolint:unparam
 func testAccCheckBoardExists(t *testing.T, name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		resourceState, ok := s.RootModule().Resources[name]

--- a/honeycombio/resource_column.go
+++ b/honeycombio/resource_column.go
@@ -127,7 +127,7 @@ func resourceColumnRead(ctx context.Context, d *schema.ResourceData, meta interf
 		columnName = d.Get("key_name").(string)
 	}
 
-	// we read by name here to faciliate importing by name instead of ID
+	// we read by name here to facilitate importing by name instead of ID
 	var detailedErr honeycombio.DetailedError
 	column, err := client.Columns.GetByKeyName(ctx, dataset, columnName)
 	if errors.As(err, &detailedErr) {

--- a/honeycombio/resource_dataset.go
+++ b/honeycombio/resource_dataset.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
 	honeycombio "github.com/honeycombio/terraform-provider-honeycombio/client"
 )
 

--- a/honeycombio/resource_dataset_definition.go
+++ b/honeycombio/resource_dataset_definition.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
 	honeycombio "github.com/honeycombio/terraform-provider-honeycombio/client"
 	"github.com/honeycombio/terraform-provider-honeycombio/internal/helper/hashcode"
 )

--- a/honeycombio/resource_dataset_definition_test.go
+++ b/honeycombio/resource_dataset_definition_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
 	honeycombio "github.com/honeycombio/terraform-provider-honeycombio/client"
 	"github.com/honeycombio/terraform-provider-honeycombio/internal/helper/test"
 

--- a/honeycombio/resource_derived_column.go
+++ b/honeycombio/resource_derived_column.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
 	honeycombio "github.com/honeycombio/terraform-provider-honeycombio/client"
 )
 

--- a/honeycombio/resource_email_recipient.go
+++ b/honeycombio/resource_email_recipient.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	honeycombio "github.com/honeycombio/terraform-provider-honeycombio/client"
 )
 

--- a/honeycombio/resource_marker.go
+++ b/honeycombio/resource_marker.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	honeycombio "github.com/honeycombio/terraform-provider-honeycombio/client"
 )
 

--- a/honeycombio/resource_marker_setting.go
+++ b/honeycombio/resource_marker_setting.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
 	honeycombio "github.com/honeycombio/terraform-provider-honeycombio/client"
 )
 

--- a/honeycombio/resource_msteams_recipient.go
+++ b/honeycombio/resource_msteams_recipient.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
 	honeycombio "github.com/honeycombio/terraform-provider-honeycombio/client"
 )
 

--- a/honeycombio/resource_pagerduty_recipient.go
+++ b/honeycombio/resource_pagerduty_recipient.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
 	honeycombio "github.com/honeycombio/terraform-provider-honeycombio/client"
 )
 

--- a/honeycombio/resource_query.go
+++ b/honeycombio/resource_query.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	honeycombio "github.com/honeycombio/terraform-provider-honeycombio/client"
 	"github.com/honeycombio/terraform-provider-honeycombio/honeycombio/internal/verify"
 )

--- a/honeycombio/resource_query_annotation.go
+++ b/honeycombio/resource_query_annotation.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
 	honeycombio "github.com/honeycombio/terraform-provider-honeycombio/client"
 )
 

--- a/honeycombio/resource_query_test.go
+++ b/honeycombio/resource_query_test.go
@@ -8,8 +8,9 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	honeycombio "github.com/honeycombio/terraform-provider-honeycombio/client"
 	"github.com/stretchr/testify/assert"
+
+	honeycombio "github.com/honeycombio/terraform-provider-honeycombio/client"
 )
 
 func TestAccHoneycombioQuery_update(t *testing.T) {

--- a/honeycombio/resource_slack_recipient.go
+++ b/honeycombio/resource_slack_recipient.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
 	honeycombio "github.com/honeycombio/terraform-provider-honeycombio/client"
 )
 

--- a/honeycombio/resource_slo.go
+++ b/honeycombio/resource_slo.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
 	honeycombio "github.com/honeycombio/terraform-provider-honeycombio/client"
 	"github.com/honeycombio/terraform-provider-honeycombio/internal/helper"
 )
@@ -159,6 +160,7 @@ func resourceSLODelete(ctx context.Context, d *schema.ResourceData, meta interfa
 	return nil
 }
 
+//nolint:unparam
 func expandSLO(d *schema.ResourceData) (*honeycombio.SLO, error) {
 	s := &honeycombio.SLO{
 		ID:               d.Id(),

--- a/honeycombio/resource_webhook_recipient.go
+++ b/honeycombio/resource_webhook_recipient.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
 	honeycombio "github.com/honeycombio/terraform-provider-honeycombio/client"
 )
 

--- a/internal/helper/validation/divisible_by_test.go
+++ b/internal/helper/validation/divisible_by_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
 	"github.com/honeycombio/terraform-provider-honeycombio/internal/helper/validation"
 )
 

--- a/internal/helper/validation/precision_at_most.go
+++ b/internal/helper/validation/precision_at_most.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+
 	"github.com/honeycombio/terraform-provider-honeycombio/internal/helper"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"

--- a/internal/helper/validation/precision_at_most_test.go
+++ b/internal/helper/validation/precision_at_most_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
 	"github.com/honeycombio/terraform-provider-honeycombio/internal/helper/validation"
 )
 

--- a/internal/helper/validation/valid_regex_test.go
+++ b/internal/helper/validation/valid_regex_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
 	"github.com/honeycombio/terraform-provider-honeycombio/internal/helper/validation"
 )
 

--- a/internal/provider/burn_alert_resource.go
+++ b/internal/provider/burn_alert_resource.go
@@ -5,8 +5,9 @@ import (
 	"errors"
 	"strings"
 
-	"github.com/honeycombio/terraform-provider-honeycombio/internal/helper/validation"
 	"golang.org/x/exp/slices"
+
+	"github.com/honeycombio/terraform-provider-honeycombio/internal/helper/validation"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/float64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
@@ -340,7 +341,7 @@ func (r *burnAlertResource) Read(ctx context.Context, req resource.ReadRequest, 
 				return s.Type.ValueString() == string(r.Type) && s.Target.ValueString() == r.Target
 			})
 			if idx < 0 {
-				// this should never happen?! But if it does, we'll just skip it and hope to get a reproducable case
+				// this should never happen?! But if it does, we'll just skip it and hope to get a reproducible case
 				resp.Diagnostics.AddError(
 					"Error Reading Honeycomb Burn Alert",
 					"Could not find Recipient "+r.ID+" in state",

--- a/internal/provider/burn_alert_resource_test.go
+++ b/internal/provider/burn_alert_resource_test.go
@@ -11,8 +11,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/honeycombio/terraform-provider-honeycombio/internal/helper"
 	"github.com/stretchr/testify/require"
+
+	"github.com/honeycombio/terraform-provider-honeycombio/internal/helper"
 
 	"github.com/honeycombio/terraform-provider-honeycombio/client"
 )

--- a/internal/provider/derived_columns_data_source_test.go
+++ b/internal/provider/derived_columns_data_source_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
 	"github.com/honeycombio/terraform-provider-honeycombio/client"
 )
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -100,6 +100,7 @@ func (p *HoneycombioProvider) Configure(ctx context.Context, req provider.Config
 	apiKey := os.Getenv(client.DefaultAPIKeyEnv)
 	if apiKey == "" {
 		// fall through to legacy env var
+		//nolint:staticcheck
 		apiKey = os.Getenv(client.LegacyAPIKeyEnv)
 	}
 	if !config.APIKey.IsNull() {
@@ -146,6 +147,7 @@ func getClientFromDatasourceRequest(req *datasource.ConfigureRequest) *client.Cl
 	if req.ProviderData == nil {
 		return nil
 	}
+	//nolint:forcetypeassert
 	return req.ProviderData.(*client.Client)
 }
 
@@ -153,5 +155,6 @@ func getClientFromResourceRequest(req *resource.ConfigureRequest) *client.Client
 	if req.ProviderData == nil {
 		return nil
 	}
+	//nolint:forcetypeassert
 	return req.ProviderData.(*client.Client)
 }

--- a/internal/provider/trigger_resource.go
+++ b/internal/provider/trigger_resource.go
@@ -300,7 +300,7 @@ func (r *triggerResource) Read(ctx context.Context, req resource.ReadRequest, re
 				return s.Type.ValueString() == string(r.Type) && s.Target.ValueString() == r.Target
 			})
 			if idx < 0 {
-				// this should never happen?! But if it does, we'll just skip it and hope to get a reproducable case
+				// this should never happen?! But if it does, we'll just skip it and hope to get a reproducible case
 				resp.Diagnostics.AddError(
 					"Error Reading Honeycomb Trigger",
 					"Could not find Recipient "+r.ID+" in state",


### PR DESCRIPTION
Switches the project to use the more full-featured `golangci-lint` with a suite of recommended linters coming from the `terraform-provider-scaffolding-framework` ([link](https://github.com/hashicorp/terraform-provider-scaffolding-framework/blob/main/.golangci.yml)) but electing to disable `godot` and customize some of the lints applied against the SDKv2 portion of the provider.