### PR TITLE
fix(client): fix queryspec equivalence for empty breakdowns

### DIFF
--- a/client/query_spec.go
+++ b/client/query_spec.go
@@ -104,9 +104,15 @@ func (qs *QuerySpec) EquivalentTo(other QuerySpec) bool {
 	if ValueOrDefault(qs.FilterCombination, DefaultFilterCombination) != ValueOrDefault(other.FilterCombination, DefaultFilterCombination) {
 		return false
 	}
-	if !reflect.DeepEqual(qs.Breakdowns, other.Breakdowns) {
+
+	if !reflect.DeepEqual(qs.Breakdowns, other.Breakdowns) &&
+		// an empty Breakdowns is equivalent to a nil Breakdowns, so we need to check that
+		// as DeepEqual will not consider them equal
+		!(qs.Breakdowns == nil && len(other.Breakdowns) == 0 ||
+			len(qs.Breakdowns) == 0 && other.Breakdowns == nil) {
 		return false
 	}
+
 	// the exact order of havings does not matter, but their equvalence does
 	if !Equivalent(qs.Havings, other.Havings) {
 		return false

--- a/client/query_spec_test.go
+++ b/client/query_spec_test.go
@@ -348,6 +348,14 @@ func TestQuerySpec_EquivalentTo(t *testing.T) {
 			},
 			false,
 		},
+		{
+			"Not equivalent breakdowns",
+			client.QuerySpec{
+				Breakdowns: []string{"column_1"},
+			},
+			client.QuerySpec{},
+			false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/client/query_spec_test.go
+++ b/client/query_spec_test.go
@@ -97,6 +97,8 @@ func TestQuerySpec_EquivalentTo(t *testing.T) {
 				TimeRange:         client.ToPtr(client.DefaultQueryTimeRange),
 				// Granularity may be exported out of the Query Builder as '0' when not provided
 				Granularity: client.ToPtr(0),
+				Breakdowns:  []string{},
+				Orders:      []client.OrderSpec{},
 			},
 			client.QuerySpec{},
 			true,


### PR DESCRIPTION
Reported via Pollinators ([link](https://honeycombpollinators.slack.com/archives/C017T9FFT0D/p1705836614190879)).

If `breakdowns` is provided as an empty slice DeepEqual fails to view that as equal to a queryspec without the slice defined ([]string string vs []string nil).

Adds an empty list of `orders` to be sure it didn't have a similar issue, but it pass the empty equivalence test fine.
