### PR TITLE
fix(ci): fix codecov after v4 upgrade

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,3 +80,5 @@ jobs:
 
       - name: Generate Coverage Report
         uses: codecov/codecov-action@v4.0.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
The upgrade to v4 of the codecov action broke "tokenless uploads".

This fixes that, while continuing to not fail CI if we can't upload, as it's a nice-but-not-gating metric to continue to track.
