### PR TITLE
fix: handle column and derived column imports with slashes in the name

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -61,6 +61,9 @@ func TestClient_InvalidConfig(t *testing.T) {
 func TestClient_IsClassic(t *testing.T) {
 	t.Parallel()
 
+	// load environment values from a .env, if available
+	_ = godotenv.Load("../.env")
+
 	ctx := context.Background()
 	apiKey, ok := os.LookupEnv(client.DefaultAPIKeyEnv)
 	if !ok {

--- a/honeycombio/resource_column.go
+++ b/honeycombio/resource_column.go
@@ -3,7 +3,6 @@ package honeycombio
 import (
 	"context"
 	"errors"
-	"fmt"
 	"strings"
 	"time"
 
@@ -88,14 +87,13 @@ func newColumn() *schema.Resource {
 
 func resourceColumnImport(ctx context.Context, d *schema.ResourceData, i interface{}) ([]*schema.ResourceData, error) {
 	// import ID is of the format <dataset>/<column name>
-	// note that the dataset name can also contain '/'
-	idSegments := strings.Split(d.Id(), "/")
-	if len(idSegments) < 2 {
-		return nil, fmt.Errorf("invalid import ID, supplied ID must be written as <dataset>/<column name>")
+	importID := d.Id()
+	idx := strings.Index(importID, "/")
+	if idx < 0 {
+		return nil, errors.New("invalid import ID, supplied ID must be written as <dataset>/<column name>")
 	}
-
-	dataset := strings.Join(idSegments[0:len(idSegments)-1], "/")
-	name := idSegments[len(idSegments)-1]
+	dataset := importID[:idx]
+	name := importID[idx+1:]
 
 	d.Set("name", name)
 	d.Set("dataset", dataset)

--- a/honeycombio/resource_column.go
+++ b/honeycombio/resource_column.go
@@ -87,13 +87,10 @@ func newColumn() *schema.Resource {
 
 func resourceColumnImport(ctx context.Context, d *schema.ResourceData, i interface{}) ([]*schema.ResourceData, error) {
 	// import ID is of the format <dataset>/<column name>
-	importID := d.Id()
-	idx := strings.Index(importID, "/")
-	if idx < 0 {
+	dataset, name, found := strings.Cut(d.Id(), "/")
+	if !found {
 		return nil, errors.New("invalid import ID, supplied ID must be written as <dataset>/<column name>")
 	}
-	dataset := importID[:idx]
-	name := importID[idx+1:]
 
 	d.Set("name", name)
 	d.Set("dataset", dataset)

--- a/honeycombio/resource_derived_column.go
+++ b/honeycombio/resource_derived_column.go
@@ -3,7 +3,6 @@ package honeycombio
 import (
 	"context"
 	"errors"
-	"fmt"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -51,14 +50,13 @@ func newDerivedColumn() *schema.Resource {
 
 func resourceDerivedColumnImport(ctx context.Context, d *schema.ResourceData, i interface{}) ([]*schema.ResourceData, error) {
 	// import ID is of the format <dataset>/<derived column alias>
-	// note that the dataset name can also contain '/'
-	idSegments := strings.Split(d.Id(), "/")
-	if len(idSegments) < 2 {
-		return nil, fmt.Errorf("invalid import ID, supplied ID must be written as <dataset>/<derived column alias>")
+	importID := d.Id()
+	idx := strings.Index(importID, "/")
+	if idx < 0 {
+		return nil, errors.New("invalid import ID, supplied ID must be written as <dataset>/<derived column alias>")
 	}
-
-	dataset := strings.Join(idSegments[0:len(idSegments)-1], "/")
-	alias := idSegments[len(idSegments)-1]
+	dataset := importID[:idx]
+	alias := importID[idx+1:]
 
 	d.Set("alias", alias)
 	d.Set("dataset", dataset)

--- a/honeycombio/resource_derived_column.go
+++ b/honeycombio/resource_derived_column.go
@@ -50,13 +50,10 @@ func newDerivedColumn() *schema.Resource {
 
 func resourceDerivedColumnImport(ctx context.Context, d *schema.ResourceData, i interface{}) ([]*schema.ResourceData, error) {
 	// import ID is of the format <dataset>/<derived column alias>
-	importID := d.Id()
-	idx := strings.Index(importID, "/")
-	if idx < 0 {
+	dataset, alias, found := strings.Cut(d.Id(), "/")
+	if !found {
 		return nil, errors.New("invalid import ID, supplied ID must be written as <dataset>/<derived column alias>")
 	}
-	dataset := importID[:idx]
-	alias := importID[idx+1:]
 
 	d.Set("alias", alias)
 	d.Set("dataset", dataset)

--- a/honeycombio/resource_slo.go
+++ b/honeycombio/resource_slo.go
@@ -3,7 +3,6 @@ package honeycombio
 import (
 	"context"
 	"errors"
-	"fmt"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -69,14 +68,10 @@ the column evaluation should consistently return nil, true, or false, as these a
 
 func resourceSLOImport(ctx context.Context, d *schema.ResourceData, i interface{}) ([]*schema.ResourceData, error) {
 	// import ID is of the format <dataset>/<SLO ID>
-	// note that the dataset name can also contain '/'
-	idSegments := strings.Split(d.Id(), "/")
-	if len(idSegments) < 2 {
-		return nil, fmt.Errorf("invalid import ID, supplied ID must be written as <dataset>/<SLO ID>")
+	dataset, id, found := strings.Cut(d.Id(), "/")
+	if !found {
+		return nil, errors.New("invalid import ID, supplied ID must be written as <dataset>/<SLO ID>")
 	}
-
-	dataset := strings.Join(idSegments[0:len(idSegments)-1], "/")
-	id := idSegments[len(idSegments)-1]
 
 	d.Set("dataset", dataset)
 	d.SetId(id)

--- a/internal/provider/burn_alert_resource.go
+++ b/internal/provider/burn_alert_resource.go
@@ -198,18 +198,14 @@ func (r *burnAlertResource) ValidateConfig(ctx context.Context, req resource.Val
 
 func (r *burnAlertResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	// import ID is of the format <dataset>/<BurnAlert ID>
-	// note that the dataset name can also contain '/'
-	idSegments := strings.Split(req.ID, "/")
-	if len(idSegments) < 2 {
+	dataset, id, found := strings.Cut(req.ID, "/")
+	if !found {
 		resp.Diagnostics.AddError(
 			"Invalid Import ID",
 			"The supplied ID must be written as <dataset>/<BurnAlert ID>.",
 		)
 		return
 	}
-
-	id := idSegments[len(idSegments)-1]
-	dataset := strings.Join(idSegments[0:len(idSegments)-1], "/")
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &models.BurnAlertResourceModel{
 		ID:      types.StringValue(id),

--- a/internal/provider/trigger_resource.go
+++ b/internal/provider/trigger_resource.go
@@ -373,18 +373,14 @@ func (r *triggerResource) Delete(ctx context.Context, req resource.DeleteRequest
 
 func (r *triggerResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	// import ID is of the format <dataset>/<trigger ID>
-	// note that the dataset name can also contain '/'
-	idSegments := strings.Split(req.ID, "/")
-	if len(idSegments) < 2 {
+	dataset, id, found := strings.Cut(req.ID, "/")
+	if !found {
 		resp.Diagnostics.AddError(
 			"Invalid Import ID",
 			"The supplied ID must be wrtten as <dataset>/<trigger ID>.",
 		)
 		return
 	}
-
-	id := idSegments[len(idSegments)-1]
-	dataset := strings.Join(idSegments[0:len(idSegments)-1], "/")
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &models.TriggerResourceModel{
 		ID:      types.StringValue(id),


### PR DESCRIPTION
Some columns and derived columns have slashes in the name. Prior to this change, trying to import either with slashes in the name would result in a message like:

```shell
$ terraform import 'honeycombio_column.test' 'test/my/column/name'
honeycombio_column.test: Importing from ID "test/my/column/name"...
honeycombio_column.test: Import prepared!
  Prepared honeycombio_column for import
honeycombio_column.test: Refreshing state... [id=test/my/column/name]
╷
│ Error: Cannot import non-existent remote object
│
│ While attempting to import an existing object to "honeycombio_column.test", the provider detected that no object exists with the given id. Only pre-existing objects can be imported; check that the id is correct
│ and that it is associated with the provider's configured region or endpoint, or use "terraform apply" to create a new remote object for this resource.
╵
```

Most (all?) other resources are imported by ID, but this subtle change in splitting does the trick here.