### PR TITLE
fix: query specification - always treat 'in','not-in' filter values as an array

### DIFF
--- a/honeycombio/data_source_query_specification.go
+++ b/honeycombio/data_source_query_specification.go
@@ -355,7 +355,8 @@ func extractFilter(d *schema.ResourceData, index int) (honeycombio.FilterSpec, e
 	valueSet := false
 	if v, ok := d.GetOk(fmt.Sprintf("filter.%d.value", index)); ok {
 		if filter.Op == honeycombio.FilterOpIn || filter.Op == honeycombio.FilterOpNotIn {
-			// if the filter operation is 'in' or 'not-in', just leave the value as a string
+			// if the filter operation is 'in' or 'not-in', leave the value as a string
+			// to be parsed into an array below
 			filter.Value = v
 		} else {
 			filter.Value = coerceValueToType(v.(string))

--- a/honeycombio/data_source_query_specification.go
+++ b/honeycombio/data_source_query_specification.go
@@ -353,49 +353,49 @@ func extractFilter(d *schema.ResourceData, index int) (honeycombio.FilterSpec, e
 	filter.Op = honeycombio.FilterOp(d.Get(fmt.Sprintf("filter.%d.op", index)).(string))
 
 	valueSet := false
-	v, vOk := d.GetOk(fmt.Sprintf("filter.%d.value", index))
-	if vOk {
-		filter.Value = coerceValueToType(v.(string))
+	if v, ok := d.GetOk(fmt.Sprintf("filter.%d.value", index)); ok {
+		if filter.Op == honeycombio.FilterOpIn || filter.Op == honeycombio.FilterOpNotIn {
+			// if the filter operation is 'in' or 'not-in', just leave the value as a string
+			filter.Value = v
+		} else {
+			filter.Value = coerceValueToType(v.(string))
+		}
 		valueSet = true
 	}
-	vs, vsOk := d.GetOk(fmt.Sprintf("filter.%d.value_string", index))
-	if vsOk {
+	if v, ok := d.GetOk(fmt.Sprintf("filter.%d.value_string", index)); ok {
 		if valueSet {
 			return filter, fmt.Errorf(multipleValuesError)
 		}
-		filter.Value = vs
+		filter.Value = v
 		valueSet = true
 	}
-	vi, viOk := d.GetOk(fmt.Sprintf("filter.%d.value_integer", index))
-	if viOk {
+	if v, ok := d.GetOk(fmt.Sprintf("filter.%d.value_integer", index)); ok {
 		if valueSet {
 			return filter, fmt.Errorf(multipleValuesError)
 		}
-		filter.Value = vi
+		filter.Value = v
 		valueSet = true
 	}
-	vf, vfOk := d.GetOk(fmt.Sprintf("filter.%d.value_float", index))
-	if vfOk {
+	if v, ok := d.GetOk(fmt.Sprintf("filter.%d.value_float", index)); ok {
 		if valueSet {
 			return filter, fmt.Errorf(multipleValuesError)
 		}
-		filter.Value = vf
+		filter.Value = v
 		valueSet = true
 	}
-	vb, vbOk := d.GetOk(fmt.Sprintf("filter.%d.value_boolean", index))
-	if vbOk {
+	if v, ok := d.GetOk(fmt.Sprintf("filter.%d.value_boolean", index)); ok {
 		if valueSet {
 			return filter, fmt.Errorf(multipleValuesError)
 		}
-		filter.Value = vb
+		filter.Value = v
 	}
 
 	if filter.Op == honeycombio.FilterOpIn || filter.Op == honeycombio.FilterOpNotIn {
-		vs, ok := filter.Value.(string)
-		if !ok {
+		if v, ok := filter.Value.(string); !ok {
 			return filter, fmt.Errorf("value must be a string if filter op is 'in' or 'not-in'")
+		} else {
+			filter.Value = strings.Split(v, ",")
 		}
-		filter.Value = strings.Split(vs, ",")
 	}
 
 	if filter.Op == honeycombio.FilterOpExists || filter.Op == honeycombio.FilterOpDoesNotExist {

--- a/honeycombio/data_source_query_specification.go
+++ b/honeycombio/data_source_query_specification.go
@@ -394,7 +394,13 @@ func extractFilter(d *schema.ResourceData, index int) (honeycombio.FilterSpec, e
 		if v, ok := filter.Value.(string); !ok {
 			return filter, fmt.Errorf("value must be a string if filter op is 'in' or 'not-in'")
 		} else {
-			filter.Value = strings.Split(v, ",")
+			// build an array from the comma-separated string
+			values := strings.Split(v, ",")
+			result := make([]interface{}, len(values))
+			for i, value := range values {
+				result[i] = coerceValueToType(value)
+			}
+			filter.Value = result
 		}
 	}
 

--- a/honeycombio/data_source_query_specification_test.go
+++ b/honeycombio/data_source_query_specification_test.go
@@ -81,6 +81,11 @@ data "honeycombio_query_specification" "test" {
         op     = "="
         value  = "ThatSpecialTenant"
     }
+    filter {
+        column = "app.database.shard"
+        op     = "not-in"
+        value  = "347338"
+    }
 
     filter_combination = "OR"
 
@@ -143,6 +148,13 @@ const expectedJSON string = `{
       "column": "app.tenant",
       "op": "=",
       "value": "ThatSpecialTenant"
+    },
+    {
+      "column": "app.database.shard",
+      "op": "not-in",
+      "value": [
+        "347338"
+      ]
     }
   ],
   "filter_combination": "OR",

--- a/honeycombio/data_source_query_specification_test.go
+++ b/honeycombio/data_source_query_specification_test.go
@@ -84,7 +84,7 @@ data "honeycombio_query_specification" "test" {
     filter {
         column = "app.database.shard"
         op     = "not-in"
-        value  = "347338"
+        value  = "347338,837359"
     }
 
     filter_combination = "OR"
@@ -153,7 +153,8 @@ const expectedJSON string = `{
       "column": "app.database.shard",
       "op": "not-in",
       "value": [
-        "347338"
+        347338,
+        837359
       ]
     }
   ],

--- a/honeycombio/data_source_query_specification_test.go
+++ b/honeycombio/data_source_query_specification_test.go
@@ -86,6 +86,11 @@ data "honeycombio_query_specification" "test" {
         op     = "not-in"
         value  = "347338,837359"
     }
+    filter {
+        column = "app.region.name"
+        op     = "in"
+        value  = "us-west-1,us-west-2"
+    }
 
     filter_combination = "OR"
 
@@ -155,6 +160,14 @@ const expectedJSON string = `{
       "value": [
         347338,
         837359
+      ]
+    },
+    {
+      "column": "app.region.name",
+      "op": "in",
+      "value": [
+        "us-west-1",
+        "us-west-2"
       ]
     }
   ],


### PR DESCRIPTION
`in`, and `not-in` filter values should always be treated as an array. This allows for the possibility of filters like `app.mything.id not-in 38374`