### PR TITLE
chore: update dependabot commit message prefix

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,6 +7,9 @@ updates:
       interval: "daily"
     labels:
       - dependencies
+    commit-message:
+      prefix: "maint"
+      include: "scope"
     groups:
       hashicorp:
         patterns:
@@ -17,3 +20,6 @@ updates:
       interval: "daily"
     labels:
       - dependencies
+    commit-message:
+      prefix: "maint"
+      include: "scope"


### PR DESCRIPTION
Matches internal conventional commit standard
