### PR TITLE
maint(ci): setup-go - re-enable cache

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"
-          cache: false # https://github.com/golangci/golangci-lint-action/issues/807
+          cache: true
 
       - name: Lint
         uses: golangci/golangci-lint-action@v5.1.0


### PR DESCRIPTION
Now that golanglint-ci action has been upgraded to 5.x (#466) we can re-enable the setup-go's management of the build cache.