### PR TITLE
fix(query): clean up generated queryspec output

### DIFF
--- a/client/query_spec.go
+++ b/client/query_spec.go
@@ -60,7 +60,7 @@ type QuerySpec struct {
 
 // Encode returns the JSON string representation of the QuerySpec.
 func (qs *QuerySpec) Encode() (string, error) {
-	b, err := json.MarshalIndent(qs, "", "  ")
+	b, err := json.Marshal(qs)
 	if err != nil {
 		return "", err
 	}

--- a/honeycombio/data_source_query_specification_test.go
+++ b/honeycombio/data_source_query_specification_test.go
@@ -22,14 +22,7 @@ output "query_json" {
 }
 `,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckOutput("query_json", `{
-  "calculations": [
-    {
-      "op": "COUNT"
-    }
-  ],
-  "time_range": 7200
-}`),
+					resource.TestCheckOutput("query_json", `{"calculations":[{"op":"COUNT"}],"time_range":7200}`),
 				),
 			},
 		},
@@ -123,80 +116,7 @@ output "query_json" {
 }`
 
 // Note: By default go encodes `<` and `>` for html, hence the `\u003e`
-const expectedJSON string = `{
-  "calculations": [
-    {
-      "op": "AVG",
-      "column": "duration_ms"
-    },
-    {
-      "op": "P99",
-      "column": "duration_ms"
-    }
-  ],
-  "filters": [
-    {
-      "column": "trace.parent_id",
-      "op": "does-not-exist"
-    },
-    {
-      "column": "duration_ms",
-      "op": "\u003e",
-      "value": 0
-    },
-    {
-      "column": "duration_ms",
-      "op": "\u003c",
-      "value": 100
-    },
-    {
-      "column": "app.tenant",
-      "op": "=",
-      "value": "ThatSpecialTenant"
-    },
-    {
-      "column": "app.database.shard",
-      "op": "not-in",
-      "value": [
-        347338,
-        837359
-      ]
-    },
-    {
-      "column": "app.region.name",
-      "op": "in",
-      "value": [
-        "us-west-1",
-        "us-west-2"
-      ]
-    }
-  ],
-  "filter_combination": "OR",
-  "breakdowns": [
-    "column_1"
-  ],
-  "orders": [
-    {
-      "op": "AVG",
-      "column": "duration_ms"
-    },
-    {
-      "column": "column_1"
-    }
-  ],
-  "havings": [
-    {
-      "calculate_op": "P99",
-      "column": "duration_ms",
-      "op": "\u003e",
-      "value": 1000
-    }
-  ],
-  "limit": 250,
-  "time_range": 7200,
-  "start_time": 1577836800,
-  "granularity": 30
-}`
+const expectedJSON string = `{"calculations":[{"op":"AVG","column":"duration_ms"},{"op":"P99","column":"duration_ms"}],"filters":[{"column":"trace.parent_id","op":"does-not-exist"},{"column":"duration_ms","op":">","value":0},{"column":"duration_ms","op":"<","value":100},{"column":"app.tenant","op":"=","value":"ThatSpecialTenant"},{"column":"app.database.shard","op":"not-in","value":[347338,837359]},{"column":"app.region.name","op":"in","value":["us-west-1","us-west-2"]}],"filter_combination":"OR","breakdowns":["column_1"],"orders":[{"op":"AVG","column":"duration_ms"},{"column":"column_1"}],"havings":[{"calculate_op":"P99","column":"duration_ms","op":">","value":1000}],"limit":250,"time_range":7200,"start_time":1577836800,"granularity":30}`
 
 func TestAccDataSourceHoneycombioQuery_validationChecks(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
@@ -431,21 +351,7 @@ data "honeycombio_query_specification" "test" {
 }
 
 func TestAccDataSourceHoneycombioQuery_zerovalue(t *testing.T) {
-	properZeroValueJSON := `{
-  "calculations": [
-    {
-      "op": "COUNT"
-    }
-  ],
-  "filters": [
-    {
-      "column": "duration_ms",
-      "op": "\u003e",
-      "value": 0
-    }
-  ],
-  "time_range": 7200
-}`
+	properZeroValueJSON := `{"calculations":[{"op":"COUNT"}],"filters":[{"column":"duration_ms","op":">","value":0}],"time_range":7200}`
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 testAccPreCheck(t),

--- a/honeycombio/data_source_query_specification_test.go
+++ b/honeycombio/data_source_query_specification_test.go
@@ -351,7 +351,7 @@ data "honeycombio_query_specification" "test" {
 }
 
 func TestAccDataSourceHoneycombioQuery_zerovalue(t *testing.T) {
-	properZeroValueJSON := `{"calculations":[{"op":"COUNT"}],"filters":[{"column":"duration_ms","op":">","value":0}],"time_range":7200}`
+	properZeroValueJSON := `{"calculations":[{"op":"COUNT"}],"filters":[{"column":"duration_ms","op":"\u003e","value":0}],"time_range":7200}`
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 testAccPreCheck(t),

--- a/honeycombio/data_source_query_specification_test.go
+++ b/honeycombio/data_source_query_specification_test.go
@@ -101,8 +101,7 @@ func TestAccDataSourceHoneycombioQuery_basic(t *testing.T) {
   "time_range": 7200,
   "start_time": 1577836800,
   "granularity": 30
-}
-`)
+}`)
 	require.NoError(t, err)
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 testAccPreCheck(t),
@@ -413,8 +412,7 @@ data "honeycombio_query_specification" "test" {
     op     = "not-in"
     value  = "fzz,bzz"
   }
-}
-`,
+}`,
 			},
 		},
 	})
@@ -460,8 +458,7 @@ data "honeycombio_query_specification" "test" {
 
 output "query_json" {
   value = data.honeycombio_query_specification.test.json
-}
-`,
+}`,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckOutput("query_json", expected),
 				),

--- a/honeycombio/data_source_query_specification_test.go
+++ b/honeycombio/data_source_query_specification_test.go
@@ -116,7 +116,7 @@ output "query_json" {
 }`
 
 // Note: By default go encodes `<` and `>` for html, hence the `\u003e`
-const expectedJSON string = `{"calculations":[{"op":"AVG","column":"duration_ms"},{"op":"P99","column":"duration_ms"}],"filters":[{"column":"trace.parent_id","op":"does-not-exist"},{"column":"duration_ms","op":">","value":0},{"column":"duration_ms","op":"<","value":100},{"column":"app.tenant","op":"=","value":"ThatSpecialTenant"},{"column":"app.database.shard","op":"not-in","value":[347338,837359]},{"column":"app.region.name","op":"in","value":["us-west-1","us-west-2"]}],"filter_combination":"OR","breakdowns":["column_1"],"orders":[{"op":"AVG","column":"duration_ms"},{"column":"column_1"}],"havings":[{"calculate_op":"P99","column":"duration_ms","op":">","value":1000}],"limit":250,"time_range":7200,"start_time":1577836800,"granularity":30}`
+const expectedJSON string = `{"calculations":[{"op":"AVG","column":"duration_ms"},{"op":"P99","column":"duration_ms"}],"filters":[{"column":"trace.parent_id","op":"does-not-exist"},{"column":"duration_ms","op":"\u003e","value":0},{"column":"duration_ms","op":"\u003c","value":100},{"column":"app.tenant","op":"=","value":"ThatSpecialTenant"},{"column":"app.database.shard","op":"not-in","value":[347338,837359]},{"column":"app.region.name","op":"in","value":["us-west-1","us-west-2"]}],"filter_combination":"OR","breakdowns":["column_1"],"orders":[{"op":"AVG","column":"duration_ms"},{"column":"column_1"}],"havings":[{"calculate_op":"P99","column":"duration_ms","op":"\u003e","value":1000}],"limit":250,"time_range":7200,"start_time":1577836800,"granularity":30}`
 
 func TestAccDataSourceHoneycombioQuery_validationChecks(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{

--- a/honeycombio/data_source_query_specification_test.go
+++ b/honeycombio/data_source_query_specification_test.go
@@ -31,6 +31,7 @@ output "query_json" {
 }
 
 func TestAccDataSourceHoneycombioQuery_basic(t *testing.T) {
+	// Note: By default go encodes `<` and `>` for html, hence the `\u003e`
 	expected, err := MinifyJSON(`
 {
   "calculations": [
@@ -406,6 +407,7 @@ data "honeycombio_query_specification" "test" {
     op     = "in"
     value  = "foo,bar"
   }
+
   filter {
     column = "app.tenant"
     op     = "not-in"
@@ -430,8 +432,8 @@ func TestAccDataSourceHoneycombioQuery_zerovalue(t *testing.T) {
   "filters": [
     {
       "column": "duration_ms",
-       "op": "\u003e",
-       "value": 0
+      "op": "\u003e",
+      "value": 0
     }
   ],
   "time_range": 7200

--- a/honeycombio/helpers_test.go
+++ b/honeycombio/helpers_test.go
@@ -1,6 +1,8 @@
 package honeycombio
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -50,4 +52,14 @@ func testCheckOutputDoesNotContain(name, contains string) resource.TestCheckFunc
 
 		return nil
 	}
+}
+
+// MinifyJSON minifies a JSON string removing all whitespace and newlines
+func MinifyJSON(s string) (string, error) {
+	var buffer bytes.Buffer
+	err := json.Compact(&buffer, []byte(s))
+	if err != nil {
+		return "", err
+	}
+	return buffer.String(), nil
 }


### PR DESCRIPTION
## Which problem is this PR solving?

Currently, this happens: 

1. Import a query resource, like:
```
import {
  id = "system_stats/abc123"
  to = honeycombio_query.kafka_disk_usage
}
```

2. You get this, which is technically correct, but a bit ugly, and will upset pickier linters:
```
❯ cat generated_resources.tf
# __generated__ by Terraform
# Please review these resources and move them into your main configuration files.

# __generated__ by Terraform from "system_stats/abc123"
resource "honeycombio_query" "kafka_disk_usage" {
  dataset    = "system_stats"
  query_json = "{\n  \"calculations\": [\n    {\n      \"op\": \"MIN\",\n      \"column\": \"disk_percent_free\"\n    }\n  ],\n  \"filters\": [\n    {\n      \"column\": \"host_group\",\n      \"op\": \"=\",\n      \"value\": \"kafka\"\n    },\n    {\n      \"column\": \"environment\",\n      \"op\": \"=\",\n      \"value\": \"dogfood\"\n    }\n  ],\n  \"breakdowns\": [\n    \"hostname\"\n  ],\n  \"orders\": [\n    {\n      \"op\": \"MIN\",\n      \"column\": \"disk_percent_free\"\n    }\n  ],\n  \"limit\": 1000,\n  \"time_range\": 1200\n}"
}
```

whereas the actual plan outputs this:
```
Terraform will perform the following actions:

  # honeycombio_query.kafka_disk_usage will be imported
  # (config will be generated)
    resource "honeycombio_query" "kafka_disk_usage" {
        dataset    = "system_stats"
        id         = "abc123"
        query_json = jsonencode(
            {
                breakdowns   = [
                    "hostname",
                ]
                calculations = [
                    {
                        column = "disk_percent_free"
                        op     = "MIN"
                    },
                ]
                filters      = [
                    {
                        column = "host_group"
                        op     = "="
                        value  = "kafka"
                    },
                    {
                        column = "environment"
                        op     = "="
                        value  = "dogfood"
                    },
                ]
                limit        = 1000
                orders       = [
                    {
                        column = "disk_percent_free"
                        op     = "MIN"
                    },
                ]
                time_range   = 1200
            }
        )
    }

Plan: 1 to import, 0 to add, 0 to change, 0 to destroy.
```

## Short description of the changes
Now, it'll output this:
```
# __generated__ by Terraform
# Please review these resources and move them into your main configuration files.

# __generated__ by Terraform from "system_stats/xyz345"
resource "honeycombio_query" "kafka_disk_usage" {
  dataset = "system_stats"
  query_json = jsonencode({
    breakdowns = ["hostname"]
    calculations = [{
      column = "disk_percent_free"
      op     = "MIN"
    }]
    filters = [{
      column = "host_group"
      op     = "="
      value  = "kafka"
      }, {
      column = "environment"
      op     = "="
      value  = "dogfood"
    }]
    limit = 1000
    orders = [{
      column = "disk_percent_free"
      op     = "MIN"
    }]
    time_range = 1200
  })
}
```

which is much nicer.

## How to verify that this has the expected result
Passed unit tests and worked locally.