### PR TITLE
r/board: add SLO support

### DIFF
--- a/client/board.go
+++ b/client/board.go
@@ -57,6 +57,8 @@ type Board struct {
 	Links BoardLinks `json:"links,omitempty"`
 	// A list of queries displayed on the board, in order of appearance.
 	Queries []BoardQuery `json:"queries"`
+	// A list of SLO IDs to be added to the board
+	SLOs []string `json:"slos"`
 }
 
 // BoardStyle determines how a Board should be displayed within the Honeycomb UI.

--- a/docs/resources/board.md
+++ b/docs/resources/board.md
@@ -100,8 +100,9 @@ The following arguments are supported:
 * `column_layout` - (Optional) the number of columns to layout on the board, either `multi` (the default) or `single`. Only `visual` style boards (see below) have a column layout.
 * `style` - (Optional) Deprecated: All Boards are now displayed as `visual` style. How the board should be displayed in the UI, either `visual` (the default) or `list`.
 * `query` - (Optional) Zero or more configurations blocks (described below) with the queries of the board.
+* `slo` - (Optional) Up to six configuration blocks (described below) to place SLOs on the board.
 
-Each board configuration may have zero or more `query` blocks, which accepts the following arguments:
+Each board configuration may have zero or more `query` blocks, which accept the following arguments:
 
 * `query_id` - (Required) The ID of the Query to run.
 * `query_annotation_id` - (Optional) The ID of the Query Annotation to associate with this query.
@@ -119,6 +120,10 @@ Currently supported toggles are:
 
   See [Graph Settings](https://docs.honeycomb.io/working-with-your-data/graph-settings/) in the documentation for more information on any individual setting.
 * `query_style` - (Optional) How the query should be displayed within the board, either `graph` (the default), `table` or `combo`.
+
+Each board configuration may have up to six `slo` blocks, which take the following arguments:
+
+* `id` - (Required) The ID of the SLO to place on the board.
 
 ## Attribute Reference
 

--- a/internal/provider/slos_data_source_test.go
+++ b/internal/provider/slos_data_source_test.go
@@ -111,7 +111,7 @@ data "honeycombio_slos" "exact" {
 }
 `, dataset, testPrefix),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.honeycombio_slos.all", "ids.#", "3"),
+					resource.TestCheckResourceAttr("data.honeycombio_slos.all", "ids.#", "5"),
 					resource.TestCheckResourceAttr("data.honeycombio_slos.regex", "ids.#", "2"),
 					resource.TestCheckResourceAttr("data.honeycombio_slos.exact", "ids.#", "1"),
 				),

--- a/internal/provider/slos_data_source_test.go
+++ b/internal/provider/slos_data_source_test.go
@@ -111,7 +111,7 @@ data "honeycombio_slos" "exact" {
 }
 `, dataset, testPrefix),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.honeycombio_slos.all", "ids.#", "5"),
+					resource.TestCheckResourceAttr("data.honeycombio_slos.all", "ids.#", "3"),
 					resource.TestCheckResourceAttr("data.honeycombio_slos.regex", "ids.#", "2"),
 					resource.TestCheckResourceAttr("data.honeycombio_slos.exact", "ids.#", "1"),
 				),


### PR DESCRIPTION
Adds support to place SLOs on boards.

Following the board's existing `query {}` blocks, this adds `slo {}` and takes an ID.

SLOs on Board are under active development and do not yet have an order but are visually displayed by their creation date. Future releases will support ordered placement.