### PR TITLE
r/trigger: re-introduce query_json for deeper validation

### DIFF
--- a/client/trigger.go
+++ b/client/trigger.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 )
@@ -127,6 +128,33 @@ func TriggerThresholdOps() []TriggerThresholdOp {
 		TriggerThresholdOpLessThan,
 		TriggerThresholdOpLessThanOrEqual,
 	}
+}
+
+func (t *Trigger) MarshalJSON() ([]byte, error) {
+	// aliased type to avoid stack overflows due to recursion
+	type ATrigger Trigger
+
+	if t.QueryID != "" && t.Query != nil {
+		// we can't sent both to the API, so favour QueryID
+		// this doesn't work in the general case, but this
+		// client is now purpose-built for the Terraform provider
+		a := &ATrigger{
+			ID:                     t.ID,
+			Name:                   t.Name,
+			Description:            t.Description,
+			Disabled:               t.Disabled,
+			QueryID:                t.QueryID,
+			AlertType:              t.AlertType,
+			Threshold:              t.Threshold,
+			Frequency:              t.Frequency,
+			Recipients:             t.Recipients,
+			EvaluationScheduleType: t.EvaluationScheduleType,
+			EvaluationSchedule:     t.EvaluationSchedule,
+		}
+		return json.Marshal(&struct{ *ATrigger }{ATrigger: a})
+	}
+
+	return json.Marshal(&struct{ *ATrigger }{ATrigger: (*ATrigger)(t)})
 }
 
 func (s *triggers) List(ctx context.Context, dataset string) ([]Trigger, error) {

--- a/docs/resources/trigger.md
+++ b/docs/resources/trigger.md
@@ -86,17 +86,12 @@ data "honeycombio_query_specification" "example" {
   }
 }
 
-resource "honeycombio_query" "example" {
-  dataset    = var.dataset
-  query_json = data.honeycombio_query_specification.example.json
-}
-
 resource "honeycombio_trigger" "example" {
   name        = "Requests are slower than usual"
   description = "Average duration of all requests for the last 10 minutes."
 
-  query_id = honeycombio_query.example.id
-  dataset  = var.dataset
+  query_json = data.honeycombio_query_specification.example.json
+  dataset    = var.dataset
 
   frequency = 600 // in seconds, 10 minutes
 
@@ -133,7 +128,10 @@ The following arguments are supported:
 
 * `name` - (Required) Name of the trigger.
 * `dataset` - (Required) The dataset this trigger is associated with.
-* `query_id` - (Required) The ID of the Query that the Trigger will execute.
+* `query_id` - (Optional) The ID of the Query that the Trigger will execute. Conflicts with `query_json`.
+* `query_json` - (Optional) The Query Specfication JSON for the Trigger to execute.
+Providing the Query Specification as JSON -- as opposed to a Query ID -- enables additional validation during the validate and plan stages.
+Conflicts with `query_id`.
 * `threshold` - (Required) A configuration block (described below) describing the threshold of the trigger.
 * `description` - (Optional) Description of the trigger.
 * `disabled` - (Optional) The state of the trigger. If true, the trigger will not be run. Defaults to false.
@@ -146,6 +144,8 @@ When the time is within the scheduled window the trigger will be run at the spec
 Outside of the window, the trigger will not be run.
 If no schedule is specified, the trigger will be run at the specified frequency at all times.
 * `recipient` - (Optional) Zero or more configuration blocks (described below) with the recipients to notify when the trigger fires.
+
+One of `query_id` or `query_json` are required.
 
 -> **NOTE** The query used in a Trigger must follow a strict subset: the query must contain *exactly one* calcuation and may only contain `calculation`, `filter`, `filter_combination` and `breakdowns` fields.
 The query's duration cannot be more than four times the trigger frequency (i.e. `duration <= frequency*4`).

--- a/internal/models/triggers.go
+++ b/internal/models/triggers.go
@@ -9,6 +9,7 @@ type TriggerResourceModel struct {
 	Description        types.String                     `tfsdk:"description"`
 	Disabled           types.Bool                       `tfsdk:"disabled"`
 	QueryID            types.String                     `tfsdk:"query_id"`
+	QueryJson          types.String                     `tfsdk:"query_json"`
 	AlertType          types.String                     `tfsdk:"alert_type"`
 	Frequency          types.Int64                      `tfsdk:"frequency"`
 	Threshold          []TriggerThresholdModel          `tfsdk:"threshold"`


### PR DESCRIPTION
In [v0.2.0](https://github.com/honeycombio/terraform-provider-honeycombio/blob/main/CHANGELOG.md#020-jan-27-2022) we dropped `query_json` from `r/trigger` to smooth out few a gnarly bugs associated with the Plugin SDK. With that change the ability to more deeply validate that a Trigger's query met the requirements was sadly lost.

Since then, `r/trigger` has been re-written in the new Plugin Framework and with it we got the ability to determine if the configuration was building via Query ID or Query JSON. This change takes advantage of that ability and re-introduces deeper validation for Trigger query's so long as you use `query_json` in place of `query_id`