### PR TITLE
fix(ci): downgrade go-releaser

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -35,7 +35,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6.0.0
         with:
           distribution: goreleaser
-          version: "~> v2"
+          version: "~> v1"
           args: release --clean
         env:
           # GitHub sets this automatically


### PR DESCRIPTION
Just encountered an error trying to release v0.24.0 ([link](https://github.com/honeycombio/terraform-provider-honeycombio/actions/runs/9518838459/job/26240664325)).

Downgrading go-releaser to get this out the door.

Related: https://github.com/goreleaser/goreleaser/issues/4914