### PR TITLE
fix: client - guard against nil resp during retry check

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -237,8 +237,12 @@ func (c *Client) retryHTTPCheck(ctx context.Context, resp *http.Response, err er
 		return false, ctx.Err()
 	}
 
-	if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode == http.StatusBadGateway || resp.StatusCode == http.StatusGatewayTimeout {
-		return true, nil
+	if resp != nil {
+		if resp.StatusCode == http.StatusTooManyRequests ||
+			resp.StatusCode == http.StatusBadGateway ||
+			resp.StatusCode == http.StatusGatewayTimeout {
+			return true, nil
+		}
 	}
 
 	return false, nil


### PR DESCRIPTION
Received a report of a panic during apply (#490).

My best guess looking at the stack trace is that the response was not able to get created and made its way into `retryHTTPCheck` as `nil`. This should guard against that in future.

- Closes #490 

