### PR TITLE
chore: cleanup static environment ID in favour of new functionality

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,7 +64,6 @@ jobs:
           HONEYCOMB_KEY_ID: ${{ secrets.HONEYCOMB_KEY_ID }}
           HONEYCOMB_KEY_SECRET: ${{ secrets.HONEYCOMB_KEY_SECRET }}
           HONEYCOMB_DATASET: testacc
-          HONEYCOMB_ENVIRONMENT_ID: hcaen_01j1d7t02zf7wgw7q89z3t60vf # TODO: remove and do a lookup or create in tests
         run: go test -v -coverprofile=client-coverage.txt -covermode=atomic ./client/...
 
       - uses: hashicorp/setup-terraform@v3
@@ -79,7 +78,6 @@ jobs:
           HONEYCOMB_KEY_ID: ${{ secrets.HONEYCOMB_KEY_ID }}
           HONEYCOMB_KEY_SECRET: ${{ secrets.HONEYCOMB_KEY_SECRET }}
           HONEYCOMB_DATASET: testacc
-          HONEYCOMB_ENVIRONMENT_ID: hcaen_01j1d7t02zf7wgw7q89z3t60vf # TODO: remove and do a lookup or create in tests
           TF_ACC: 1
           TF_ACC_TERRAFORM_VERSION: ${{ env.TERRAFORM_VERSION }}
         run: go test -v -coverprofile=tf-coverage.txt -covermode=atomic ./internal/... ./honeycombio/...
@@ -121,7 +119,6 @@ jobs:
           HONEYCOMB_KEY_ID: ${{ secrets.HONEYCOMB_KEY_ID_EU }}
           HONEYCOMB_KEY_SECRET: ${{ secrets.HONEYCOMB_KEY_SECRET_EU }}
           HONEYCOMB_DATASET: testacc
-          HONEYCOMB_ENVIRONMENT_ID: hcben_01hvp28qbgzaeebbz29qvbb7gt # TODO: remove and do a lookup or create in tests
         run: go test -v -coverprofile=client-coverage.txt -covermode=atomic ./client/...
 
       - uses: hashicorp/setup-terraform@v3
@@ -137,7 +134,6 @@ jobs:
           HONEYCOMB_KEY_ID: ${{ secrets.HONEYCOMB_KEY_ID_EU }}
           HONEYCOMB_KEY_SECRET: ${{ secrets.HONEYCOMB_KEY_SECRET_EU }}
           HONEYCOMB_DATASET: testacc
-          HONEYCOMB_ENVIRONMENT_ID: hcben_01hvp28qbgzaeebbz29qvbb7gt # TODO: remove and do a lookup or create in tests
           TF_ACC: 1
           TF_ACC_TERRAFORM_VERSION: ${{ env.TERRAFORM_VERSION }}
         run: go test -v -coverprofile=tf-coverage.txt -covermode=atomic ./internal/... ./honeycombio/...

--- a/client/v2/api_keys_test.go
+++ b/client/v2/api_keys_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"os"
 	"testing"
 	"time"
 
@@ -18,15 +17,14 @@ import (
 func TestClient_APIKeys(t *testing.T) {
 	ctx := context.Background()
 	c := newTestClient(t)
-	// TODO: use the environments API
-	testEnvironmentID := os.Getenv("HONEYCOMB_ENVIRONMENT_ID")
+	env := newTestEnvironment(ctx, t, c)
 
 	// create a new key
 	k, err := c.APIKeys.Create(ctx, &APIKey{
 		Name:    helper.ToPtr("test key"),
 		KeyType: "ingest",
 		Environment: &Environment{
-			ID: testEnvironmentID,
+			ID: env.ID,
 		},
 		Permissions: &APIKeyPermissions{
 			CreateDatasets: true,
@@ -77,8 +75,7 @@ func TestClient_APIKeys(t *testing.T) {
 func TestClient_APIKeys_Pagination(t *testing.T) {
 	ctx := context.Background()
 	c := newTestClient(t)
-	// TODO: use the environments API
-	testEnvironmentID := os.Getenv("HONEYCOMB_ENVIRONMENT_ID")
+	env := newTestEnvironment(ctx, t, c)
 
 	// create a bunch of keys
 	numKeys := int(math.Floor(1.5 * float64(defaultPageSize)))
@@ -88,7 +85,7 @@ func TestClient_APIKeys_Pagination(t *testing.T) {
 			Name:    helper.ToPtr(fmt.Sprintf("test.%d", i)),
 			KeyType: "ingest",
 			Environment: &Environment{
-				ID: testEnvironmentID,
+				ID: env.ID,
 			},
 		})
 		require.NoError(t, err)

--- a/internal/provider/api_key_resource_test.go
+++ b/internal/provider/api_key_resource_test.go
@@ -11,8 +11,9 @@ import (
 
 func TestAcc_APIKeyResource(t *testing.T) {
 	t.Parallel()
-
-	envID := testAccEnvironment()
+	ctx := context.Background()
+	c := testAccV2Client(t)
+	env := testAccEnvironment(ctx, t, c)
 
 	t.Run("happy path", func(t *testing.T) {
 		resource.Test(t, resource.TestCase{
@@ -20,27 +21,27 @@ func TestAcc_APIKeyResource(t *testing.T) {
 			ProtoV5ProviderFactories: testAccProtoV5MuxServerFactory,
 			Steps: []resource.TestStep{
 				{
-					Config: testAccConfigBasicAPIKeyTest("test key", "false", envID),
+					Config: testAccConfigBasicAPIKeyTest("test key", "false", env.ID),
 					Check: resource.ComposeAggregateTestCheckFunc(
 						testAccEnsureAPIKeyExists(t, "honeycombio_api_key.test"),
 						resource.TestCheckResourceAttrSet("honeycombio_api_key.test", "id"),
 						resource.TestCheckResourceAttrSet("honeycombio_api_key.test", "secret"),
 						resource.TestCheckResourceAttr("honeycombio_api_key.test", "name", "test key"),
 						resource.TestCheckResourceAttr("honeycombio_api_key.test", "type", "ingest"),
-						resource.TestCheckResourceAttr("honeycombio_api_key.test", "environment_id", envID),
+						resource.TestCheckResourceAttr("honeycombio_api_key.test", "environment_id", env.ID),
 						resource.TestCheckResourceAttr("honeycombio_api_key.test", "disabled", "false"),
 						resource.TestCheckResourceAttr("honeycombio_api_key.test", "permissions.0.create_datasets", "true"),
 					),
 				},
 				{ // now update the name and disabled state
-					Config: testAccConfigBasicAPIKeyTest("updated test key", "true", envID),
+					Config: testAccConfigBasicAPIKeyTest("updated test key", "true", env.ID),
 					Check: resource.ComposeAggregateTestCheckFunc(
 						testAccEnsureAPIKeyExists(t, "honeycombio_api_key.test"),
 						resource.TestCheckResourceAttrSet("honeycombio_api_key.test", "id"),
 						resource.TestCheckResourceAttrSet("honeycombio_api_key.test", "secret"),
 						resource.TestCheckResourceAttr("honeycombio_api_key.test", "name", "updated test key"),
 						resource.TestCheckResourceAttr("honeycombio_api_key.test", "type", "ingest"),
-						resource.TestCheckResourceAttr("honeycombio_api_key.test", "environment_id", envID),
+						resource.TestCheckResourceAttr("honeycombio_api_key.test", "environment_id", env.ID),
 						resource.TestCheckResourceAttr("honeycombio_api_key.test", "disabled", "true"),
 						resource.TestCheckResourceAttr("honeycombio_api_key.test", "permissions.0.create_datasets", "true"),
 					),
@@ -61,14 +62,14 @@ resource "honeycombio_api_key" "test" {
   type = "ingest"
 
   environment_id = "%s"
-}`, envID),
+}`, env.ID),
 					Check: resource.ComposeAggregateTestCheckFunc(
 						testAccEnsureAPIKeyExists(t, "honeycombio_api_key.test"),
 						resource.TestCheckResourceAttrSet("honeycombio_api_key.test", "id"),
 						resource.TestCheckResourceAttrSet("honeycombio_api_key.test", "secret"),
 						resource.TestCheckResourceAttr("honeycombio_api_key.test", "name", "test key"),
 						resource.TestCheckResourceAttr("honeycombio_api_key.test", "type", "ingest"),
-						resource.TestCheckResourceAttr("honeycombio_api_key.test", "environment_id", envID),
+						resource.TestCheckResourceAttr("honeycombio_api_key.test", "environment_id", env.ID),
 						resource.TestCheckResourceAttr("honeycombio_api_key.test", "disabled", "false"),
 					),
 				},

--- a/internal/provider/environment_data_source_test.go
+++ b/internal/provider/environment_data_source_test.go
@@ -6,32 +6,12 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/stretchr/testify/require"
-
-	v2client "github.com/honeycombio/terraform-provider-honeycombio/client/v2"
-	"github.com/honeycombio/terraform-provider-honeycombio/internal/helper"
-	"github.com/honeycombio/terraform-provider-honeycombio/internal/helper/test"
 )
 
 func TestAcc_EnvironmentDataSource(t *testing.T) {
 	ctx := context.Background()
 	c := testAccV2Client(t)
-
-	env, err := c.Environments.Create(ctx, &v2client.Environment{
-		Name:        test.RandomStringWithPrefix("test.", 20),
-		Description: helper.ToPtr("test environment"),
-	})
-	require.NoError(t, err)
-
-	t.Cleanup(func() {
-		c.Environments.Update(ctx, &v2client.Environment{
-			ID: env.ID,
-			Settings: &v2client.EnvironmentSettings{
-				DeleteProtected: helper.ToPtr(false),
-			},
-		})
-		c.Environments.Delete(ctx, env.ID)
-	})
+	env := testAccEnvironment(ctx, t, c)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 testAccPreCheckV2API(t),

--- a/internal/provider/environments_data_source_test.go
+++ b/internal/provider/environments_data_source_test.go
@@ -6,11 +6,8 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/stretchr/testify/require"
 
 	v2client "github.com/honeycombio/terraform-provider-honeycombio/client/v2"
-	"github.com/honeycombio/terraform-provider-honeycombio/internal/helper"
-	"github.com/honeycombio/terraform-provider-honeycombio/internal/helper/test"
 )
 
 func TestAcc_EnvironmentsDatasource(t *testing.T) {
@@ -21,30 +18,12 @@ func TestAcc_EnvironmentsDatasource(t *testing.T) {
 	// create a bunch of environments
 	testEnvs := make([]*v2client.Environment, numEnvs+1)
 	for i := 0; i < numEnvs; i++ {
-		e, err := c.Environments.Create(ctx, &v2client.Environment{
-			Name: test.RandomStringWithPrefix("test.", 20),
-		})
-		require.NoError(t, err)
+		e := testAccEnvironment(ctx, t, c)
 		testEnvs[i] = e
 	}
 	// one additional with a different prefix for filter testing
-	e, err := c.Environments.Create(ctx, &v2client.Environment{
-		Name: "test." + test.RandomString(20),
-	})
-	require.NoError(t, err)
+	e := testAccEnvironment(ctx, t, c)
 	testEnvs[numEnvs] = e
-
-	t.Cleanup(func() {
-		for _, e := range testEnvs {
-			c.Environments.Update(ctx, &v2client.Environment{
-				ID: e.ID,
-				Settings: &v2client.EnvironmentSettings{
-					DeleteProtected: helper.ToPtr(false),
-				},
-			})
-			c.Environments.Delete(ctx, e.ID)
-		}
-	})
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 testAccPreCheckV2API(t),


### PR DESCRIPTION
A follow-up to #501 and #496, this cleans up the various environment-related TODOs.