### PR TITLE
fix: read of null definition causes panic (#504)

### DIFF
--- a/honeycombio/resource_dataset_definition.go
+++ b/honeycombio/resource_dataset_definition.go
@@ -75,6 +75,12 @@ func resourceDatasetDefinitionRead(ctx context.Context, d *schema.ResourceData, 
 
 	name := d.Get("name").(string)
 	column := extractDatasetDefinitionColumnByName(dd, name)
+	if column == nil {
+		// Definition used to be set but was removed without TF knowning about it,
+		// so we're trying to read a definition that has a "null" value.
+		d.SetId("")
+		return nil
+	}
 
 	d.SetId(strconv.Itoa(hashcode.String(fmt.Sprintf("%s-%s", dataset, name))))
 	d.Set("name", name)

--- a/scripts/setup-testsuite-dataset
+++ b/scripts/setup-testsuite-dataset
@@ -44,7 +44,7 @@ create_dataset_if_missing () {
       log "error creating dataset \"$name\""
     fi
 
-    log "created dataset \"$name}\""
+    log "created dataset \"${name}\""
   fi
 }
 


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes a null pointer panic when TF tries to refresh a dataset definition that's been removed. In this case, `extractDatasetDefinitionColumnByName` returns `nil` (ie, the API returned a `null` for that definition), which needs to be handled.

- Closes #504
