### PR TITLE
chore: limit integration test concurrency

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,6 +39,8 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    concurrency:
+      group: hnytf-testacc-us
     env:
       TERRAFORM_VERSION: "1.0.11"
     steps:
@@ -92,6 +94,8 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    concurrency:
+      group: hnytf-testacc-eu
     env:
       TERRAFORM_VERSION: "1.0.11"
     steps:


### PR DESCRIPTION
Limit integration test runs with [concurrency groups](https://docs.github.com/en/actions/using-jobs/using-concurrency).

Not currently using `cancel-in-progress` until [sweepers](https://github.com/honeycombio/terraform-provider-honeycombio/issues/446) are implemented and it's confirmed that they can run when receiving a cancellation signal.