### PR TITLE
chore(ci): display test summary output

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,7 +57,9 @@ jobs:
         env:
           HONEYCOMB_API_KEY: ${{ secrets.HONEYCOMB_API_KEY }}
           HONEYCOMB_DATASET: testacc
-        run: ./scripts/setup-testsuite-dataset
+        run: |
+          go install github.com/jstemmer/go-junit-report/v2@latest
+          ./scripts/setup-testsuite-dataset
 
       - name: Run client acceptance tests
         timeout-minutes: 10
@@ -66,7 +68,7 @@ jobs:
           HONEYCOMB_KEY_ID: ${{ secrets.HONEYCOMB_KEY_ID }}
           HONEYCOMB_KEY_SECRET: ${{ secrets.HONEYCOMB_KEY_SECRET }}
           HONEYCOMB_DATASET: testacc
-        run: go test -v -coverprofile=client-coverage.txt -covermode=atomic ./client/...
+        run: go test -v -coverprofile=client-coverage.txt -covermode=atomic ./client/... | go-junit-report -set-exit-code > client-report.xml
 
       - uses: hashicorp/setup-terraform@v3
         with:
@@ -82,7 +84,7 @@ jobs:
           HONEYCOMB_DATASET: testacc
           TF_ACC: 1
           TF_ACC_TERRAFORM_VERSION: ${{ env.TERRAFORM_VERSION }}
-        run: go test -v -coverprofile=tf-coverage.txt -covermode=atomic ./internal/... ./honeycombio/...
+        run: go test -v -coverprofile=tf-coverage.txt -covermode=atomic ./internal/... ./honeycombio/... | go-junit-report -set-exit-code > provider-report.xml
 
       - name: Cleanup Dangling Resources
         if: ${{ always() }}
@@ -93,6 +95,12 @@ jobs:
           HONEYCOMB_KEY_SECRET: ${{ secrets.HONEYCOMB_KEY_SECRET }}
           HONEYCOMB_DATASET: testacc
         run: make sweep
+
+      - name: Test Summary
+        if: always()
+        uses: test-summary/action@v2
+        with:
+          paths: "*-report.xml"
 
       - name: Generate Coverage Report
         uses: codecov/codecov-action@v4.5.0
@@ -123,7 +131,9 @@ jobs:
           HONEYCOMB_API_ENDPOINT: https://api.eu1.honeycomb.io
           HONEYCOMB_API_KEY: ${{ secrets.HONEYCOMB_API_KEY_EU }}
           HONEYCOMB_DATASET: testacc
-        run: ./scripts/setup-testsuite-dataset
+        run: |
+          go install github.com/jstemmer/go-junit-report/v2@latest
+          ./scripts/setup-testsuite-dataset
 
       - name: Run client acceptance tests
         timeout-minutes: 10
@@ -133,7 +143,7 @@ jobs:
           HONEYCOMB_KEY_ID: ${{ secrets.HONEYCOMB_KEY_ID_EU }}
           HONEYCOMB_KEY_SECRET: ${{ secrets.HONEYCOMB_KEY_SECRET_EU }}
           HONEYCOMB_DATASET: testacc
-        run: go test -v -coverprofile=client-coverage.txt -covermode=atomic ./client/...
+        run: go test -v -coverprofile=client-coverage.txt -covermode=atomic ./client/... | go-junit-report -set-exit-code > client-report.xml
 
       - uses: hashicorp/setup-terraform@v3
         with:
@@ -150,7 +160,7 @@ jobs:
           HONEYCOMB_DATASET: testacc
           TF_ACC: 1
           TF_ACC_TERRAFORM_VERSION: ${{ env.TERRAFORM_VERSION }}
-        run: go test -v -coverprofile=tf-coverage.txt -covermode=atomic ./internal/... ./honeycombio/...
+        run: go test -v -coverprofile=tf-coverage.txt -covermode=atomic ./internal/... ./honeycombio/... | go-junit-report -set-exit-code > provider-report.xml
 
       - name: Cleanup Dangling Resources
         if: ${{ always() }}
@@ -162,6 +172,12 @@ jobs:
           HONEYCOMB_KEY_SECRET: ${{ secrets.HONEYCOMB_KEY_SECRET_EU }}
           HONEYCOMB_DATASET: testacc
         run: make sweep
+
+      - name: Test Summary
+        if: always()
+        uses: test-summary/action@v2
+        with:
+          paths: "*-report.xml"
 
       - name: Generate Coverage Report
         uses: codecov/codecov-action@v4.5.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -144,7 +144,7 @@ jobs:
           HONEYCOMB_KEY_ID: ${{ secrets.HONEYCOMB_KEY_ID_EU }}
           HONEYCOMB_KEY_SECRET: ${{ secrets.HONEYCOMB_KEY_SECRET_EU }}
           HONEYCOMB_DATASET: testacc
-        run: go test -v -coverprofile=client-coverage.txt -covermode=atomic ./client/... | go-junit-report -set-exit-code > client-report.xml
+        run: go test -v -coverprofile=client-coverage.txt -covermode=atomic ./client/... | go-junit-report -iocopy -set-exit-code > client-report.xml
 
       - uses: hashicorp/setup-terraform@v3
         with:
@@ -161,7 +161,7 @@ jobs:
           HONEYCOMB_DATASET: testacc
           TF_ACC: 1
           TF_ACC_TERRAFORM_VERSION: ${{ env.TERRAFORM_VERSION }}
-        run: go test -v -coverprofile=tf-coverage.txt -covermode=atomic ./internal/... ./honeycombio/... | go-junit-report -set-exit-code > provider-report.xml
+        run: go test -v -coverprofile=tf-coverage.txt -covermode=atomic ./internal/... ./honeycombio/... | go-junit-report -iocopy -set-exit-code > provider-report.xml
 
       - name: Cleanup Dangling Resources
         if: ${{ always() }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,11 +96,12 @@ jobs:
           HONEYCOMB_DATASET: testacc
         run: make sweep
 
-      - name: Test Summary
+      - name: Generate Test Summary
         if: always()
         uses: test-summary/action@v2
         with:
           paths: "*-report.xml"
+          show: "fail, skip"
 
       - name: Generate Coverage Report
         uses: codecov/codecov-action@v4.5.0
@@ -173,11 +174,12 @@ jobs:
           HONEYCOMB_DATASET: testacc
         run: make sweep
 
-      - name: Test Summary
+      - name: Generate Test Summary
         if: always()
         uses: test-summary/action@v2
         with:
           paths: "*-report.xml"
+          show: "fail, skip"
 
       - name: Generate Coverage Report
         uses: codecov/codecov-action@v4.5.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,7 +68,14 @@ jobs:
           HONEYCOMB_KEY_ID: ${{ secrets.HONEYCOMB_KEY_ID }}
           HONEYCOMB_KEY_SECRET: ${{ secrets.HONEYCOMB_KEY_SECRET }}
           HONEYCOMB_DATASET: testacc
-        run: go test -v -coverprofile=client-coverage.txt -covermode=atomic ./client/... | go-junit-report -set-exit-code > client-report.xml
+        run: |
+          go test -v ./client/... \
+            -coverprofile=client-coverage.txt \
+            -covermode=atomic | \
+            go-junit-report \
+            -set-exit-code \
+            -iocopy \
+            -out client-report.xml
 
       - uses: hashicorp/setup-terraform@v3
         with:
@@ -84,7 +91,14 @@ jobs:
           HONEYCOMB_DATASET: testacc
           TF_ACC: 1
           TF_ACC_TERRAFORM_VERSION: ${{ env.TERRAFORM_VERSION }}
-        run: go test -v -coverprofile=tf-coverage.txt -covermode=atomic ./internal/... ./honeycombio/... | go-junit-report -set-exit-code > provider-report.xml
+        run: |
+          go test -v ./internal/... ./honeycombio/... \
+            -coverprofile=tf-coverage.txt \
+            -covermode=atomic | \
+            go-junit-report \
+            -set-exit-code \
+            -iocopy \
+            -out provider-report.xml
 
       - name: Cleanup Dangling Resources
         if: ${{ always() }}
@@ -144,7 +158,14 @@ jobs:
           HONEYCOMB_KEY_ID: ${{ secrets.HONEYCOMB_KEY_ID_EU }}
           HONEYCOMB_KEY_SECRET: ${{ secrets.HONEYCOMB_KEY_SECRET_EU }}
           HONEYCOMB_DATASET: testacc
-        run: go test -v -coverprofile=client-coverage.txt -covermode=atomic ./client/... | go-junit-report -iocopy -set-exit-code > client-report.xml
+        run: |
+          go test -v ./client/... \
+            -coverprofile=client-coverage.txt \
+            -covermode=atomic | \
+            go-junit-report \
+            -set-exit-code \
+            -iocopy \
+            -out client-report.xml
 
       - uses: hashicorp/setup-terraform@v3
         with:
@@ -161,7 +182,14 @@ jobs:
           HONEYCOMB_DATASET: testacc
           TF_ACC: 1
           TF_ACC_TERRAFORM_VERSION: ${{ env.TERRAFORM_VERSION }}
-        run: go test -v -coverprofile=tf-coverage.txt -covermode=atomic ./internal/... ./honeycombio/... | go-junit-report -iocopy -set-exit-code > provider-report.xml
+        run: |
+          go test -v ./internal/... ./honeycombio/... \
+            -coverprofile=tf-coverage.txt \
+            -covermode=atomic | \
+            go-junit-report \
+            -set-exit-code \
+            -iocopy \
+            -out provider-report.xml
 
       - name: Cleanup Dangling Resources
         if: ${{ always() }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,14 +68,7 @@ jobs:
           HONEYCOMB_KEY_ID: ${{ secrets.HONEYCOMB_KEY_ID }}
           HONEYCOMB_KEY_SECRET: ${{ secrets.HONEYCOMB_KEY_SECRET }}
           HONEYCOMB_DATASET: testacc
-        run: |
-          go test -v ./client/... \
-            -coverprofile=client-coverage.txt \
-            -covermode=atomic | \
-            go-junit-report \
-            -set-exit-code \
-            -iocopy \
-            -out client-report.xml
+        run: go test -v -coverprofile=client-coverage.txt -covermode=atomic ./client/... | go-junit-report -set-exit-code > client-report.xml
 
       - uses: hashicorp/setup-terraform@v3
         with:
@@ -91,14 +84,7 @@ jobs:
           HONEYCOMB_DATASET: testacc
           TF_ACC: 1
           TF_ACC_TERRAFORM_VERSION: ${{ env.TERRAFORM_VERSION }}
-        run: |
-          go test -v ./internal/... ./honeycombio/... \
-            -coverprofile=tf-coverage.txt \
-            -covermode=atomic | \
-            go-junit-report \
-            -set-exit-code \
-            -iocopy \
-            -out provider-report.xml
+        run: go test -v -coverprofile=tf-coverage.txt -covermode=atomic ./internal/... ./honeycombio/... | go-junit-report -set-exit-code > provider-report.xml
 
       - name: Cleanup Dangling Resources
         if: ${{ always() }}
@@ -158,14 +144,7 @@ jobs:
           HONEYCOMB_KEY_ID: ${{ secrets.HONEYCOMB_KEY_ID_EU }}
           HONEYCOMB_KEY_SECRET: ${{ secrets.HONEYCOMB_KEY_SECRET_EU }}
           HONEYCOMB_DATASET: testacc
-        run: |
-          go test -v ./client/... \
-            -coverprofile=client-coverage.txt \
-            -covermode=atomic | \
-            go-junit-report \
-            -set-exit-code \
-            -iocopy \
-            -out client-report.xml
+        run: go test -v -coverprofile=client-coverage.txt -covermode=atomic ./client/... | go-junit-report -iocopy -set-exit-code > client-report.xml
 
       - uses: hashicorp/setup-terraform@v3
         with:
@@ -182,14 +161,7 @@ jobs:
           HONEYCOMB_DATASET: testacc
           TF_ACC: 1
           TF_ACC_TERRAFORM_VERSION: ${{ env.TERRAFORM_VERSION }}
-        run: |
-          go test -v ./internal/... ./honeycombio/... \
-            -coverprofile=tf-coverage.txt \
-            -covermode=atomic | \
-            go-junit-report \
-            -set-exit-code \
-            -iocopy \
-            -out provider-report.xml
+        run: go test -v -coverprofile=tf-coverage.txt -covermode=atomic ./internal/... ./honeycombio/... | go-junit-report -iocopy -set-exit-code > provider-report.xml
 
       - name: Cleanup Dangling Resources
         if: ${{ always() }}

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,8 @@
 
 terraform-provider-honeycombio*
 
-coverage.txt
+*-coverage.txt
+*-report.xml
 
 .idea
 .env

--- a/client/v2/api_keys_test.go
+++ b/client/v2/api_keys_test.go
@@ -107,7 +107,7 @@ func TestClient_APIKeys_Pagination(t *testing.T) {
 
 		items, err := pager.Next(ctx)
 		require.NoError(t, err)
-		assert.Len(t, items, defaultPageSize+1, "incorrect number of items")
+		assert.Len(t, items, defaultPageSize, "incorrect number of items")
 		assert.True(t, pager.HasNext(), "should have more pages")
 		keys = append(keys, items...)
 

--- a/client/v2/api_keys_test.go
+++ b/client/v2/api_keys_test.go
@@ -107,7 +107,7 @@ func TestClient_APIKeys_Pagination(t *testing.T) {
 
 		items, err := pager.Next(ctx)
 		require.NoError(t, err)
-		assert.Len(t, items, defaultPageSize, "incorrect number of items")
+		assert.Len(t, items, defaultPageSize+1, "incorrect number of items")
 		assert.True(t, pager.HasNext(), "should have more pages")
 		keys = append(keys, items...)
 


### PR DESCRIPTION
In an attempt to make the test output from the client and two provider instances more readable when tests fail, this sets up the [test-summary action](https://github.com/test-summary/action) to parse the any failures generated by the test suite and have them show up on the 'Summary' page of the workflow run ([example](https://github.com/honeycombio/terraform-provider-honeycombio/actions/runs/10180218386)):

![Screenshot 2024-07-31 at 08 33 23](https://github.com/user-attachments/assets/e3bae37c-e19c-4a4c-be13-e15f261238d1)

Currently showing failed and skipped tests in the summaries.