### PR TITLE
feat(client): V2 API client ratelimit improvements

### DIFF
--- a/client/v2/limits.go
+++ b/client/v2/limits.go
@@ -1,0 +1,69 @@
+package v2
+
+import (
+	"fmt"
+	"math/rand"
+	"net/http"
+	"time"
+)
+
+const (
+	// HeaderRateLimit is the (draft07) recommended header from the IETF
+	// on rate limiting.
+	HeaderRateLimit = "RateLimit"
+	// The value of the header is formatted "limit=X, remaining=Y, reset=Z".
+	// Where:
+	//   - X is the maximum number of requests allowed in the window
+	//   - Y is the number of requests remaining in the window
+	//   - Z is the number of seconds until the limit resets
+	HeaderRateLimitFmt = "limit=%d, remaining=%d, reset=%d"
+
+	// HeaderRetryAfter is the RFC7231 header used to indicate when a client should
+	// retry requests in UTC time.
+	HeaderRetryAfter = "Retry-After"
+)
+
+var rnd *rand.Rand
+
+// init initializes the random number generator
+func init() {
+	rnd = rand.New(rand.NewSource(time.Now().UnixNano()))
+}
+
+// rateLimitBackoff calculates the backoff time for a rate limited request
+// based on the possible response headers.
+//
+// If the rate limit header is not present, the function will return a random
+// backoff time between min and max.
+func rateLimitBackoff(min, max time.Duration, r *http.Response) time.Duration {
+	// calculate some jitter for a little extra fuzziness to avoid thundering herds
+	jitter := time.Duration(rnd.Float64() * float64(max-min))
+
+	// try to get the next reset from the response headers
+	if v := r.Header.Get(HeaderRateLimit); v != "" {
+		// we currently only care about the reset time
+		_, _, reset, err := parseRateLimitHeader(v)
+		if err == nil {
+			min = time.Duration(reset) * time.Second
+		}
+	} else if v := r.Header.Get(HeaderRetryAfter); v != "" {
+		// if we can't get the ratelimit header, try the retry-after header
+		retryTime, err := time.Parse(time.RFC3339, v)
+		if err == nil {
+			min = time.Until(retryTime)
+		}
+	}
+	return min + jitter
+}
+
+// parseRateLimitHeader parses the rate limit header into its constituent parts.
+//
+// The header is expected to be in the format "limit=X, remaining=Y, reset=Z".
+// Where:
+//   - X is the maximum number of requests allowed in the window
+//   - Y is the number of requests remaining in the window
+//   - Z is the number of seconds until the limit resets
+func parseRateLimitHeader(v string) (limit, remaining, reset int, err error) {
+	_, err = fmt.Sscanf(v, HeaderRateLimitFmt, &limit, &remaining, &reset)
+	return
+}

--- a/client/v2/limits.go
+++ b/client/v2/limits.go
@@ -23,11 +23,11 @@ const (
 	HeaderRetryAfter = "Retry-After"
 )
 
-var rnd *rand.Rand
+var rng *rand.Rand
 
-// init initializes the random number generator
 func init() {
-	rnd = rand.New(rand.NewSource(time.Now().UnixNano()))
+	// initialize the random number generator
+	rng = rand.New(rand.NewSource(time.Now().UnixNano()))
 }
 
 // rateLimitBackoff calculates the backoff time for a rate limited request
@@ -38,9 +38,8 @@ func init() {
 // the function will return a random backoff time between min and max.
 func rateLimitBackoff(min, max time.Duration, r *http.Response) time.Duration {
 	// calculate some jitter for a little extra fuzziness to avoid thundering herds
-	jitter := time.Duration(rnd.Float64() * float64(max-min))
+	jitter := time.Duration(rng.Float64() * float64(max-min))
 
-	// try to get the next reset from the response headers
 	var reset time.Duration
 	if v := r.Header.Get(HeaderRateLimit); v != "" {
 		// we currently only care about the reset time
@@ -57,10 +56,9 @@ func rateLimitBackoff(min, max time.Duration, r *http.Response) time.Duration {
 	}
 
 	// only update min if the time to wait is longer
-	if reset > 0 && reset > min {
+	if reset > min {
 		min = reset
 	}
-
 	return min + jitter
 }
 

--- a/client/v2/limits_test.go
+++ b/client/v2/limits_test.go
@@ -1,0 +1,122 @@
+package v2
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClient_rateLimitBackoff(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC()
+	// init min and max to zero to remove jitter
+	min, max := time.Duration(0), time.Duration(0)
+
+	tests := []struct {
+		name          string
+		headerName    string
+		headerValue   string
+		expectedValue time.Duration
+	}{
+		{
+			name:          "no header",
+			expectedValue: min,
+		},
+		{
+			name:          "invalid ratelimit header",
+			headerName:    HeaderRateLimit,
+			headerValue:   "foobar",
+			expectedValue: min,
+		},
+		{
+			name:          "invalid retry-after header",
+			headerName:    HeaderRetryAfter,
+			headerValue:   "three hours from now",
+			expectedValue: min,
+		},
+		{
+			name:          "ratelimit header",
+			headerName:    HeaderRateLimit,
+			headerValue:   "limit=100, remaining=50, reset=60",
+			expectedValue: 60 * time.Second,
+		},
+		{
+			name:          "retry-after header",
+			headerName:    HeaderRetryAfter,
+			headerValue:   now.Add(2 * time.Minute).UTC().Format(time.RFC3339),
+			expectedValue: 2 * time.Minute,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			w.Header().Add(tc.headerName, tc.headerValue)
+			w.WriteHeader(http.StatusTooManyRequests)
+
+			r := rateLimitBackoff(min, max, w.Result())
+			assert.WithinDuration(t,
+				now.Add(tc.expectedValue),
+				now.Add(r),
+				time.Second,
+			)
+		})
+	}
+}
+
+func TestClient_parseRateLimitHeader(t *testing.T) {
+	t.Parallel()
+
+	type expect struct {
+		limit     int
+		remaining int
+		reset     int
+	}
+	tests := []struct {
+		name      string
+		header    string
+		expect    expect
+		expectErr bool
+	}{
+		{
+			name:      "empty",
+			expectErr: true,
+		},
+		{
+			name:      "invalid",
+			header:    "foobar",
+			expectErr: true,
+		},
+		{
+			name:   "valid",
+			header: "limit=100, remaining=50, reset=60",
+			expect: expect{
+				limit:     100,
+				remaining: 50,
+				reset:     60,
+			},
+		},
+		{
+			name:      "valid but missing reset",
+			header:    "limit=100, remaining=50",
+			expectErr: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			limit, remaining, reset, err := parseRateLimitHeader(tc.header)
+			if tc.expectErr {
+				require.Error(t, err, "expected an error")
+				return
+			}
+			require.NoError(t, err, "expected no error")
+			assert.Equal(t, tc.expect.limit, limit, "limit doesn't match")
+			assert.Equal(t, tc.expect.remaining, remaining, "remaining doesn't match")
+			assert.Equal(t, tc.expect.reset, reset, "reset doesn't match")
+		})
+	}
+}


### PR DESCRIPTION
This change teaches the V2 API client to respond to HTTP429s by backing off using the Ratelimit headers in the API's response.

- Closes #511 
