### PR TITLE
fix(limits): separately test min-max vs header+jitter cases

### DIFF
--- a/client/v2/limits_test.go
+++ b/client/v2/limits_test.go
@@ -109,7 +109,7 @@ func TestClient_rateLimitBackoff(t *testing.T) {
 
 	t.Run("without supported rate limit header jitter is between min and max", func(t *testing.T) {
 		w := httptest.NewRecorder()
-		w.WriteHeader(http.StatusInternalServerError)
+		w.WriteHeader(http.StatusTooManyRequests)
 
 		min = 200 * time.Millisecond
 		max = 900 * time.Millisecond

--- a/client/v2/limits_test.go
+++ b/client/v2/limits_test.go
@@ -100,16 +100,27 @@ func TestClient_rateLimitBackoff(t *testing.T) {
 
 		min = 100 * time.Millisecond
 		max = 500 * time.Millisecond
-		r := rateLimitBackoff(min, max, w.Result())
+		assert.Greater(t,
+			rateLimitBackoff(min, max, w.Result()),
+			60*time.Second,
+			"expected backoff to be 60sec+jitter",
+		)
+	})
 
-		if assert.Greater(t, r, 60*time.Second, "expected backoff to be 60sec+") {
-			assert.WithinRange(t,
-				time.Now().Add(r-60*time.Second),
-				time.Now().Add(min),
-				time.Now().Add(max),
-				"jitter not applied correctly",
-			)
-		}
+	t.Run("without supported rate limit header jitter is between min and max", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		w.WriteHeader(http.StatusInternalServerError)
+
+		min = 200 * time.Millisecond
+		max = 900 * time.Millisecond
+
+		now := time.Now().UTC()
+		assert.WithinRange(t,
+			now.Add(rateLimitBackoff(min, max, w.Result())),
+			now.Add(min),
+			now.Add(max),
+			"expected backoff to be between min and max",
+		)
 	})
 }
 


### PR DESCRIPTION
I conflated the logic while hastily adding a test for jitter in #519.

This fixes that flakey test by separating the two paths.