### PR TITLE
chore(ci): add environment sweeper

### DIFF
--- a/internal/provider/api_key_resource_test.go
+++ b/internal/provider/api_key_resource_test.go
@@ -10,7 +10,6 @@ import (
 )
 
 func TestAcc_APIKeyResource(t *testing.T) {
-	t.Parallel()
 	ctx := context.Background()
 	c := testAccV2Client(t)
 	env := testAccEnvironment(ctx, t, c)

--- a/internal/provider/honeycombio_sweeper_test.go
+++ b/internal/provider/honeycombio_sweeper_test.go
@@ -57,6 +57,12 @@ func getEnvironmentSweeper(name string) *resource.Sweeper {
 			for _, e := range envs {
 				if strings.HasPrefix(e.Name, SweeperTargetPrefix) {
 					log.Printf("[DEBUG] deleting environment %s (%s)", e.Name, e.ID)
+					c.Environments.Update(ctx, &v2client.Environment{
+						ID: e.ID,
+						Settings: &v2client.EnvironmentSettings{
+							DeleteProtected: client.ToPtr(false),
+						},
+					})
 					err = c.Environments.Delete(ctx, e.ID)
 					if err != nil {
 						log.Printf("[ERROR] could not delete environment %s: %s", e.ID, err)

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -123,8 +123,6 @@ func testAccV2Client(t *testing.T) *v2client.Client {
 // TestAcc_Configuration verifies that the provider is correctly
 // configured with the supported configuration permutations.
 func TestAcc_Configuration(t *testing.T) {
-	// t.Parallel() - not parallelized due to environment variable manipulation
-
 	t.Run("v1 and v2 clients", func(t *testing.T) {
 		resource.Test(t, resource.TestCase{
 			ProtoV5ProviderFactories: testAccProtoV5MuxServerFactory,

--- a/internal/provider/query_resource_test.go
+++ b/internal/provider/query_resource_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 func TestAcc_QueryResource(t *testing.T) {
-	t.Parallel()
 	ctx := context.Background()
 	dataset := testAccDataset()
 	c := testAccClient(t)
@@ -103,7 +102,6 @@ EOT
 func TestAcc_QueryResourceUpgradeFromVersion022(t *testing.T) {
 	t.Skip("mysteriously broken and under investigation")
 
-	t.Parallel()
 	ctx := context.Background()
 	dataset := testAccDataset()
 	c := testAccClient(t)
@@ -144,7 +142,6 @@ func TestAcc_QueryResourceUpgradeFromVersion022(t *testing.T) {
 // TestAcc_QueryResourceEquivalentQuerySpecSupressed tests the  behavior of the
 // resource when an equivalent query is suppressed by the plan modifier.
 func TestAcc_QueryResourceEquivalentQuerySpecSupressed(t *testing.T) {
-	t.Parallel()
 	dataset := testAccDataset()
 
 	resource.Test(t, resource.TestCase{

--- a/internal/provider/trigger_resource_test.go
+++ b/internal/provider/trigger_resource_test.go
@@ -501,8 +501,6 @@ func TestAcc_TriggerResourceHandlesRecipientChangedOutsideOfTerraform(t *testing
 }
 
 func TestAcc_TriggerResourceValidatesQueryJSON(t *testing.T) {
-	t.Parallel()
-
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 testAccPreCheck(t),
 		ProtoV5ProviderFactories: testAccProtoV5MuxServerFactory,


### PR DESCRIPTION
We just had a CI failure because of an Environment ([link](https://github.com/honeycombio/terraform-provider-honeycombio/actions/runs/10215780292/attempts/2)) left behind by a previous failed run.

This adds a sweeper for Environments: removing any Environment beginning with `test.`

