### PR TITLE
chore: improve V2 API error reporting

### DIFF
--- a/client/errors_test.go
+++ b/client/errors_test.go
@@ -206,22 +206,28 @@ func TestErrors_JSONAPI(t *testing.T) {
 	}{
 		{
 			name: "single error",
-			code: http.StatusConflict,
+			code: http.StatusUnauthorized,
 			body: jsonapi.ErrorsPayload{
 				Errors: []*jsonapi.ErrorObject{
 					{
-						Status: "409",
-						Title:  "limit reached",
-						Code:   "failed-precondition/limit-reached",
+						Status: "401",
+						Title:  "invalid API key",
+						Code:   "unauthenticated/invalid-key",
+						Source: &jsonapi.ErrorSource{
+							Header: "Authorization",
+						},
 					},
 				},
 			},
 			expectedOutput: client.DetailedError{
-				Status: 409,
-				Type:   "failed-precondition/limit-reached",
-				Title:  "limit reached",
+				Status: 401,
+				Type:   "unauthenticated/invalid-key",
+				Title:  "invalid API key",
 				Details: []client.ErrorTypeDetail{
-					{Description: "limit reached"},
+					{
+						Description: "invalid API key",
+						Field:       "Authorization header",
+					},
 				},
 			},
 		},

--- a/client/errors_test.go
+++ b/client/errors_test.go
@@ -211,17 +211,18 @@ func TestErrors_JSONAPI(t *testing.T) {
 				Errors: []*jsonapi.ErrorObject{
 					{
 						Status: "409",
-						Title:  "Conflict",
-						Detail: "The resource already exists.",
-						Code:   "/errors/conflict",
+						Title:  "limit reached",
+						Code:   "failed-precondition/limit-reached",
 					},
 				},
 			},
 			expectedOutput: client.DetailedError{
-				Status:  409,
-				Type:    "/errors/conflict",
-				Message: "The resource already exists.",
-				Title:   "Conflict",
+				Status: 409,
+				Type:   "failed-precondition/limit-reached",
+				Title:  "limit reached",
+				Details: []client.ErrorTypeDetail{
+					{Description: "limit reached"},
+				},
 			},
 		},
 		{
@@ -231,25 +232,35 @@ func TestErrors_JSONAPI(t *testing.T) {
 				Errors: []*jsonapi.ErrorObject{
 					{
 						Status: "422",
-						Code:   "/errors/validation-failed",
-						Title:  "The provided input is invalid.",
+						Code:   "validation-failed/invalid",
+						Title:  "field is invalid",
+						Detail: "must be no greater than 10",
+						Source: &jsonapi.ErrorSource{
+							Pointer: "/data/attributes/age",
+						},
 					},
 					{
 						Status: "422",
-						Code:   "/errors/validation-failed",
-						Title:  "The provided input is invalid.",
+						Code:   "validation-failed/invalid",
+						Title:  "field is invalid",
+						Detail: "the length must be between 1 and 10",
+						Source: &jsonapi.ErrorSource{
+							Pointer: "/data/attributes/name",
+						},
 					},
 				},
 			},
 			expectedOutput: client.DetailedError{
 				Status: 422,
-				Title:  "The provided input is invalid.",
+				Title:  "field is invalid",
 				Details: []client.ErrorTypeDetail{
 					{
-						Code: "/errors/validation-failed",
+						Description: "must be no greater than 10",
+						Field:       "/data/attributes/age",
 					},
 					{
-						Code: "/errors/validation-failed",
+						Description: "the length must be between 1 and 10",
+						Field:       "/data/attributes/name",
 					},
 				},
 			},

--- a/client/v2/client_test.go
+++ b/client/v2/client_test.go
@@ -122,6 +122,14 @@ func TestClient_AuthInfo(t *testing.T) {
 		var de hnyclient.DetailedError
 		require.ErrorAs(t, err, &de)
 		assert.Equal(t, http.StatusUnauthorized, de.Status)
+		assert.Equal(t, "", de.Message)
+		assert.Equal(t, "invalid API key", de.Title)
+		assert.Equal(t, "unauthenticated/invalid-key", de.Type)
+		if assert.Len(t, de.Details, 1) {
+			assert.Equal(t, "Authorization header", de.Details[0].Field)
+			assert.Equal(t, "invalid API key", de.Details[0].Description)
+		}
+		assert.Equal(t, "Authorization header - invalid API key", de.Error())
 	})
 }
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/google/go-querystring v1.1.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-retryablehttp v0.7.7
-	github.com/hashicorp/jsonapi v1.3.1
+	github.com/hashicorp/jsonapi v1.3.2-0.20240802183744-2490a9451c3d
 	github.com/hashicorp/terraform-plugin-framework v1.11.0
 	github.com/hashicorp/terraform-plugin-go v0.23.0
 	github.com/hashicorp/terraform-plugin-mux v0.16.0

--- a/go.sum
+++ b/go.sum
@@ -73,8 +73,8 @@ github.com/hashicorp/hc-install v0.7.0 h1:Uu9edVqjKQxxuD28mR5TikkKDd/p55S8vzPC16
 github.com/hashicorp/hc-install v0.7.0/go.mod h1:ELmmzZlGnEcqoUMKUuykHaPCIR1sYLYX+KSggWSKZuA=
 github.com/hashicorp/hcl/v2 v2.21.0 h1:lve4q/o/2rqwYOgUg3y3V2YPyD1/zkCLGjIV74Jit14=
 github.com/hashicorp/hcl/v2 v2.21.0/go.mod h1:62ZYHrXgPoX8xBnzl8QzbWq4dyDsDtfCRgIq1rbJEvA=
-github.com/hashicorp/jsonapi v1.3.1 h1:GtPvnmcWgYwCuDGvYT5VZBHcUyFdq9lSyCzDjn1DdPo=
-github.com/hashicorp/jsonapi v1.3.1/go.mod h1:kWfdn49yCjQvbpnvY1dxxAuAFzISwrrMDQOcu6NsFoM=
+github.com/hashicorp/jsonapi v1.3.2-0.20240802183744-2490a9451c3d h1:kIMRkf4AL9Zqjlc8aQD2jWBHWri88ncgERDSeln+Ya8=
+github.com/hashicorp/jsonapi v1.3.2-0.20240802183744-2490a9451c3d/go.mod h1:kWfdn49yCjQvbpnvY1dxxAuAFzISwrrMDQOcu6NsFoM=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/terraform-exec v0.21.0 h1:uNkLAe95ey5Uux6KJdua6+cv8asgILFVWkd/RG0D2XQ=


### PR DESCRIPTION
Improves V2 API call error reporting/handling by making use of the JSON:API `source` field ([doc](https://jsonapi.org/format/#error-objects)) in error responses now being sent by the Honeycomb API.

Future work will skip converting these into the RFC7807 'Problem Detail' struct shared with the V1 client and convert them to Terraform diagnostics directly. 