### PR TITLE
chore(r/query): improve doc for derived_column

### DIFF
--- a/docs/resources/query.md
+++ b/docs/resources/query.md
@@ -38,6 +38,12 @@ data "honeycombio_query_specification" "example" {
     op     = "exists"
   }
 
+}
+
+resource "honeycombio_query" "example" {
+  dataset    = var.dataset
+  query_json = data.honeycombio_query_specification.example.json
+
   lifecycle {
     replace_triggered_by = [
       // re-create the query if the derived column is changed
@@ -45,11 +51,6 @@ data "honeycombio_query_specification" "example" {
       honeycombio_derived_column.duration_ms_log10
     ]
   }
-}
-
-resource "honeycombio_query" "example" {
-  dataset    = var.dataset
-  query_json = data.honeycombio_query_specification.example.json
 }
 ```
 


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

The example in the documentation for [honeycombio_query](https://registry.terraform.io/providers/honeycombio/honeycombio/latest/docs/resources/query) has the life_cycle block on the wrong resource. Data resources don't accept "replace_triggered_by" blocks.

## Short description of the changes
Updating the documentation on [query resource](https://registry.terraform.io/providers/honeycombio/honeycombio/latest/docs/resources/query)

The lifecycle argument "replace_triggered_by" is defined only for managed resources ("resource" blocks), and is not valid for data resources.

## How to verify that this has the expected result
Updating documentation