### PR TITLE
chore: address new linter errors

### DIFF
--- a/client/burn_alert_test.go
+++ b/client/burn_alert_test.go
@@ -206,7 +206,7 @@ func TestBurnAlerts(t *testing.T) {
 			results, err := c.BurnAlerts.ListForSLO(ctx, dataset, slo.ID)
 			require.NoError(t, err, "failed to list burn alerts for SLO")
 
-			assert.NotZero(t, len(results))
+			assert.NotEmpty(t, results)
 			assert.Equal(t, burnAlert.ID, results[0].ID, "newly created BurnAlert not in list of SLO's burn alerts")
 		})
 

--- a/client/v2/client.go
+++ b/client/v2/client.go
@@ -220,18 +220,18 @@ func (c *Client) retryHTTPCheck(
 // use a linear backoff for all status codes except 429, which will
 // attempt to use the rate limit headers to determine the backoff time
 func (c *Client) retryHTTPBackoff(
-	min, max time.Duration,
+	mini, maxi time.Duration,
 	attemptNum int,
 	r *http.Response,
 ) time.Duration {
 	if r != nil && r.StatusCode == http.StatusTooManyRequests {
-		return rateLimitBackoff(min, max, r)
+		return rateLimitBackoff(mini, maxi, r)
 	}
 
 	// if we've not been rate limited, use a linear backoff
 	// but increase the minimum and maximum backoff times
 	// and hand it off to retryablehttp.LinearJitterBackoff
-	min = 500 * time.Millisecond
-	max = 950 * time.Millisecond
-	return retryablehttp.LinearJitterBackoff(min, max, attemptNum, r)
+	mini = 500 * time.Millisecond
+	maxi = 950 * time.Millisecond
+	return retryablehttp.LinearJitterBackoff(mini, maxi, attemptNum, r)
 }

--- a/client/v2/limits.go
+++ b/client/v2/limits.go
@@ -32,10 +32,10 @@ const (
 // The function will first try to get the reset time from the rate limit header.
 //
 // If the rate limit header is not present, or the reset time is in the past,
-// the function will return a random backoff time between min and max.
-func rateLimitBackoff(min, max time.Duration, r *http.Response) time.Duration {
+// the function will return a random backoff time between mini and maxi.
+func rateLimitBackoff(mini, maxi time.Duration, r *http.Response) time.Duration {
 	// calculate some jitter for a little extra fuzziness to avoid thundering herds
-	jitter := time.Duration(rand.Float64() * float64(max-min))
+	jitter := time.Duration(rand.Float64() * float64(maxi-mini))
 
 	var reset time.Duration
 	if v := r.Header.Get(HeaderRateLimit); v != "" {
@@ -57,10 +57,10 @@ func rateLimitBackoff(min, max time.Duration, r *http.Response) time.Duration {
 	}
 
 	// only update min if the time to wait is longer
-	if reset > min {
-		min = reset
+	if reset > mini {
+		mini = reset
 	}
-	return min + jitter
+	return mini + jitter
 }
 
 // parseRateLimitHeader parses the rate limit header into its constituent parts.

--- a/internal/helper/validation/precision_at_most.go
+++ b/internal/helper/validation/precision_at_most.go
@@ -55,9 +55,9 @@ func (validator precisionAtMostValidator) ValidateFloat64(ctx context.Context, r
 }
 
 // Float64PrecisionAtMost returns an AttributeValidator which ensures that any configured
-// attribute value has a precision which is at most the given max
-func Float64PrecisionAtMost(m int64) validator.Float64 {
+// attribute value has a precision which is at most the given value
+func Float64PrecisionAtMost(v int64) validator.Float64 {
 	return precisionAtMostValidator{
-		max: m,
+		max: v,
 	}
 }

--- a/internal/helper/validation/precision_at_most.go
+++ b/internal/helper/validation/precision_at_most.go
@@ -56,8 +56,8 @@ func (validator precisionAtMostValidator) ValidateFloat64(ctx context.Context, r
 
 // Float64PrecisionAtMost returns an AttributeValidator which ensures that any configured
 // attribute value has a precision which is at most the given max
-func Float64PrecisionAtMost(max int64) validator.Float64 {
+func Float64PrecisionAtMost(m int64) validator.Float64 {
 	return precisionAtMostValidator{
-		max: max,
+		max: m,
 	}
 }


### PR DESCRIPTION
A new version `golangci-lint` came out and alerted us to some fresh lint errors in the nightly CI run ([link](https://github.com/honeycombio/terraform-provider-honeycombio/actions/runs/10396679826)).

I'm not in love with `min` -> `mini` and `max` -> `maxi` so happy to take naming suggestions #nameingishard