### PR TITLE
chore(docs): standardize use of notes

### DIFF
--- a/docs/data-sources/column.md
+++ b/docs/data-sources/column.md
@@ -2,7 +2,7 @@
 
 The `honeycombio_column` data source retrieves the details of a single column in a dataset.
 
--> **Note** Terraform will fail unless a column is returned by the search. Ensure that your search is specific enough to return a column.
+~> **Warning** Terraform will fail unless a column is returned by the search. Ensure that your search is specific enough to return a column.
 If you want to match multiple columns, use the `honeycombio_columns` data source instead.
 
 ## Example Usage

--- a/docs/data-sources/derived_column.md
+++ b/docs/data-sources/derived_column.md
@@ -2,7 +2,7 @@
 
 The `honeycombio_derived_column` data source retrieves the details of a single derived column.
 
--> **Note** Terraform will fail unless a derived column is returned by the search. Ensure that your search is specific enough to return a derived column.
+~> **Warning** Terraform will fail unless a derived column is returned by the search. Ensure that your search is specific enough to return a derived column.
 If you want to match multiple derived columns, use the `honeycombio_derived_columns` data source instead.
 
 ## Example Usage

--- a/docs/data-sources/environment.md
+++ b/docs/data-sources/environment.md
@@ -3,7 +3,7 @@
 The `honeycombio_environment` data source retrieves the details of a single Environment.
 If you want to retrieve multiple Environments, use the `honeycombio_environments` data source instead.
 
--> **NOTE** This data source requires the provider be configured with a Management Key with `environments:read` in the configured scopes.
+-> This data source requires the provider be configured with a Management Key with `environments:read` in the configured scopes.
 
 
 ## Example Usage

--- a/docs/data-sources/environments.md
+++ b/docs/data-sources/environments.md
@@ -2,7 +2,7 @@
 
 The Environments data source retrieves the Team's environments.
 
--> **NOTE** This data source requires the provider be configured with a Management Key with `environments:read` in the configured scopes.
+-> This data source requires the provider be configured with a Management Key with `environments:read` in the configured scopes.
 
 ## Example Usage
 

--- a/docs/data-sources/query_result.md
+++ b/docs/data-sources/query_result.md
@@ -3,7 +3,7 @@
 The `query_result` data source allows you to execute Honeycomb queries via the [Query Data API](https://docs.honeycomb.io/api/query-results/).
 As this data source is a wrapper around the Query Data API all of its [documented restrictions](https://docs.honeycomb.io/api/query-results/#api-restrictions) apply.
 
-~> **NOTE:** Use of this data source requires a Honeycomb Enterprise plan.
+-> Use of this data source requires a Honeycomb Enterprise plan.
 
 ## Example Usage
 

--- a/docs/data-sources/recipient.md
+++ b/docs/data-sources/recipient.md
@@ -4,7 +4,7 @@
 
 The ID of an existing recipient can be used when adding recipients to triggers or burn alerts.
 
--> **Note** Terraform will fail unless exactly one recipient is returned by the search. Ensure that your search is specific enough to return a single recipient ID only.
+~> **Warning** Terraform will fail unless exactly one recipient is returned by the search. Ensure that your search is specific enough to return a single recipient ID only.
 If you want to match multiple recipients, use the `honeycombio_recipients` data source instead.
 
 ## Example Usage

--- a/docs/data-sources/trigger_recipient.md
+++ b/docs/data-sources/trigger_recipient.md
@@ -2,7 +2,7 @@
 
 Search the triggers of a dataset for a trigger recipient. The ID of the existing trigger recipient can be used when adding trigger recipients to new triggers.
 
--> **Deprecated** Use the `honeycombio_recipient` data source instead.
+!> **Deprecated** Use the `honeycombio_recipient` data source instead.
 
 ## Example Usage
 

--- a/docs/resources/api_key.md
+++ b/docs/resources/api_key.md
@@ -3,7 +3,7 @@
 Creates a Honeycomb API Key.
 For more information about API Keys, check out [Best Practices for API Keys](https://docs.honeycomb.io/get-started/best-practices/api-keys/).
 
--> **NOTE** This resource requires the provider be configured with a Management Key with `api-keys:write` in the configured scopes.
+-> This resource requires the provider be configured with a Management Key with `api-keys:write` in the configured scopes.
 
 ## Example Usage
 

--- a/docs/resources/column.md
+++ b/docs/resources/column.md
@@ -3,9 +3,7 @@
 Provides a Honeycomb Column resource.
 This can be used to create, update, and delete columns in a dataset.
 
--> **Note**: deleting a column is a destructive and irreversible operation which also removes the data in the column.
-
--> **Note**: prior to version 0.13.0 of the provider, columns were *not* deleted on destroy but left in place and only removed from state.
+~> **Warning** Deleting a column is a destructive and irreversible operation which also removes the data in the column.
 
 ## Example Usage
 

--- a/docs/resources/dataset.md
+++ b/docs/resources/dataset.md
@@ -2,7 +2,7 @@
 
 Creates a Dataset in an Environment.
 
--> **Note**: prior to version 0.27.0 of the provider, datasets were *not* deleted on destroy but left in place and only removed from state.
+~> **Warning** Prior to version 0.27.0 of the provider, datasets were *not* deleted on destroy but left in place and only removed from state.
 
 ## Example Usage
 

--- a/docs/resources/dataset_definitions.md
+++ b/docs/resources/dataset_definitions.md
@@ -2,7 +2,7 @@
 
 Dataset Definitions define the fields in your Dataset that have special meaning.
 
--> **Note** Some Dataset Definitions are automatically set when a dataset is created or first receives an event.
+-> Some Dataset Definitions are automatically set when a dataset is created or first receives an event.
 
 ## Example Usage
 

--- a/docs/resources/environment.md
+++ b/docs/resources/environment.md
@@ -2,7 +2,7 @@
 
 Creates a Honeycomb Environment.
 
--> **NOTE** This resource requires the provider be configured with a Management Key with `environments:write` in the configured scopes.
+-> This resource requires the provider be configured with a Management Key with `environments:write` in the configured scopes.
 
 ## Example Usage
 

--- a/docs/resources/marker.md
+++ b/docs/resources/marker.md
@@ -2,7 +2,8 @@
 
 Creates a marker. For more information about markers, check out [Annotate the timeline with Markers](https://docs.honeycomb.io/working-with-your-data/customizing-your-query/markers/).
 
--> **Note** Destroying or replacing this resource will not delete the previously created marker. This is intentional to preserve the markers. At this time, it is not possible to remove markers using this provider.
+-> Destroying or replacing this resource will not delete the previously created marker.
+This is intentional to preserve the markers.
 
 ## Example Usage
 

--- a/docs/resources/marker_setting.md
+++ b/docs/resources/marker_setting.md
@@ -1,6 +1,7 @@
 # Resource: honeycombio_marker_setting
 
-Creates a marker setting. For more information about marker settings, check out the [Marker Settings API](https://docs.honeycomb.io/api/marker-settings/).
+Creates a marker setting.
+For more information on marker settings, check out the [Marker Settings API](https://docs.honeycomb.io/api/marker-settings/).
 
 ## Example Usage
 

--- a/docs/resources/msteams_recipient.md
+++ b/docs/resources/msteams_recipient.md
@@ -2,7 +2,7 @@
 
 `honeycombio_msteams_recipient` allows you to define and manage an MSTeams recipient that can be used by Triggers or BurnAlerts notifications.
 
--> **NOTE** Microsoft has deprecated Office 365 Connectors.
+!> **Deprecated** Microsoft has deprecated Office 365 Connectors.
   This resource will no longer allow creation of new recipients.
   It is recommended you recreate your Teams recipients with the `honeycombio_msteams_workflow_recipient` resource.
 

--- a/docs/resources/query.md
+++ b/docs/resources/query.md
@@ -4,7 +4,7 @@ Creates a Query scoped to a Dataset or Environment.
 
 Queries can be used by Triggers and Boards, or be executed via the [Query Data API](https://docs.honeycomb.io/api/query-results/).
 
--> **Note** Queries are immutable and can not be deleted -- only created or read.
+-> Queries are immutable and can not be deleted -- only created or read.
   Any changes will result in a new query object being created.
 
 ## Example Usage

--- a/docs/resources/query_annotation.md
+++ b/docs/resources/query_annotation.md
@@ -2,7 +2,7 @@
 
 Creates a query annotation in a dataset.
 
--> **Note** A query annotation points to a specific query. Any change to the query will result in a new query ID and the annotation will no longer apply.
+-> A query annotation points to a specific query. Any change to the query will result in a new query ID and the annotation will no longer apply.
 If you use the "honeycombio_query_specification" to determine the `query_id` parameter (as in the example below), Terraform will destroy the old query annotation and create a new one.
 If this is wrong for your use case, please open an issue in [honeycombio/terraform-provider-honeycombio](https://github.com/honeycombio/terraform-provider-honeycombio).
 


### PR DESCRIPTION
Noticed while browsing the provider docs that the use of "callouts" (largely used for notes) is a bit inconsistent.

This change attempts to fix that, while using the available yellow and red [callouts](https://developer.hashicorp.com/terraform/registry/providers/docs#callouts) for warnings and deprecation notices.