### PR TITLE
fix(r/trigger): handle dynamic evaluation schedule

### DIFF
--- a/internal/models/notification_recipients.go
+++ b/internal/models/notification_recipients.go
@@ -12,10 +12,6 @@ type NotificationRecipientModel struct {
 	Details types.List   `tfsdk:"notification_details"` // NotificationRecipientDetailsModel
 }
 
-type NotificationRecipientDetailsModel struct {
-	PDSeverity types.String `tfsdk:"pagerduty_severity"`
-}
-
 var NotificationRecipientAttrType = map[string]attr.Type{
 	"id":     types.StringType,
 	"type":   types.StringType,
@@ -23,6 +19,10 @@ var NotificationRecipientAttrType = map[string]attr.Type{
 	"notification_details": types.ListType{ElemType: types.ObjectType{
 		AttrTypes: NotificationRecipientDetailsAttrType,
 	}},
+}
+
+type NotificationRecipientDetailsModel struct {
+	PDSeverity types.String `tfsdk:"pagerduty_severity"`
 }
 
 var NotificationRecipientDetailsAttrType = map[string]attr.Type{

--- a/internal/models/triggers.go
+++ b/internal/models/triggers.go
@@ -1,20 +1,23 @@
 package models
 
-import "github.com/hashicorp/terraform-plugin-framework/types"
+import (
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
 
 type TriggerResourceModel struct {
-	ID                 types.String                     `tfsdk:"id"`
-	Name               types.String                     `tfsdk:"name"`
-	Dataset            types.String                     `tfsdk:"dataset"`
-	Description        types.String                     `tfsdk:"description"`
-	Disabled           types.Bool                       `tfsdk:"disabled"`
-	QueryID            types.String                     `tfsdk:"query_id"`
-	QueryJson          types.String                     `tfsdk:"query_json"`
-	AlertType          types.String                     `tfsdk:"alert_type"`
-	Frequency          types.Int64                      `tfsdk:"frequency"`
-	Threshold          []TriggerThresholdModel          `tfsdk:"threshold"`
-	Recipients         types.Set                        `tfsdk:"recipient"` // NotificationRecipientModel
-	EvaluationSchedule []TriggerEvaluationScheduleModel `tfsdk:"evaluation_schedule"`
+	ID                 types.String `tfsdk:"id"`
+	Name               types.String `tfsdk:"name"`
+	Dataset            types.String `tfsdk:"dataset"`
+	Description        types.String `tfsdk:"description"`
+	Disabled           types.Bool   `tfsdk:"disabled"`
+	QueryID            types.String `tfsdk:"query_id"`
+	QueryJson          types.String `tfsdk:"query_json"`
+	AlertType          types.String `tfsdk:"alert_type"`
+	Frequency          types.Int64  `tfsdk:"frequency"`
+	Threshold          types.List   `tfsdk:"threshold"`           // TriggerThresholdModel
+	Recipients         types.Set    `tfsdk:"recipient"`           // NotificationRecipientModel
+	EvaluationSchedule types.List   `tfsdk:"evaluation_schedule"` // TriggerEvaluationScheduleModel
 }
 
 type TriggerThresholdModel struct {
@@ -23,8 +26,20 @@ type TriggerThresholdModel struct {
 	ExceededLimit types.Int64   `tfsdk:"exceeded_limit"`
 }
 
+var TriggerThresholdAttrType = map[string]attr.Type{
+	"op":             types.StringType,
+	"value":          types.Float64Type,
+	"exceeded_limit": types.Int64Type,
+}
+
 type TriggerEvaluationScheduleModel struct {
 	DaysOfWeek []types.String `tfsdk:"days_of_week"`
 	StartTime  types.String   `tfsdk:"start_time"`
 	EndTime    types.String   `tfsdk:"end_time"`
+}
+
+var TriggerEvaluationScheduleAttrType = map[string]attr.Type{
+	"days_of_week": types.ListType{ElemType: types.StringType},
+	"start_time":   types.StringType,
+	"end_time":     types.StringType,
 }

--- a/internal/provider/notification_recipients.go
+++ b/internal/provider/notification_recipients.go
@@ -241,7 +241,6 @@ func notificationRecipientDetailsToList(ctx context.Context, details *client.Not
 		diags.Append(d...)
 		result, d = types.ListValueFrom(ctx, types.ObjectType{AttrTypes: models.NotificationRecipientDetailsAttrType}, []attr.Value{objVal})
 		diags.Append(d...)
-
 	} else {
 		result = types.ListNull(types.ObjectType{AttrTypes: models.NotificationRecipientDetailsAttrType})
 	}


### PR DESCRIPTION
`r/trigger` had two nested blocks using structs instead of `types.List` which would cause a Value Conversion error if using a `dynamic` block.

- Closes #537 