### PR TITLE
feat: slack channel regex accepts channel id

### DIFF
--- a/docs/resources/slack_recipient.md
+++ b/docs/resources/slack_recipient.md
@@ -14,7 +14,7 @@ resource "honeycombio_slack_recipient" "alerts" {
 
 The following arguments are supported:
 
-* `channel` - (Required) The Slack channel or username to send the notification to. Must begin with `#` or `@`.
+* `channel` - (Required) The Slack channel or username to send the notification to. Must begin with `#` or `@` or be a valid channel id e.g. `CABC123DEF.
 
 ## Attribute Reference
 

--- a/honeycombio/resource_slack_recipient.go
+++ b/honeycombio/resource_slack_recipient.go
@@ -11,6 +11,8 @@ import (
 	honeycombio "github.com/honeycombio/terraform-provider-honeycombio/client"
 )
 
+var channelRegex = regexp.MustCompile(`^#.*|^@.*|^(C|D|G)[A-Z0-9]{6,}$`)
+
 func newSlackRecipient() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceSlackRecipientCreate,
@@ -27,7 +29,7 @@ func newSlackRecipient() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				Description:  "The Slack channel or username to send the notification to. Must begin with `#` or `@`.",
-				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^(#|@).+`), "channel must begin with `#` or `@`"),
+				ValidateFunc: validation.StringMatch(channelRegex, "channel must begin with `#` or `@` or be a valid channel id e.g. `CABC123DEF`"),
 			},
 		},
 	}

--- a/honeycombio/resource_slack_recipient.go
+++ b/honeycombio/resource_slack_recipient.go
@@ -28,7 +28,7 @@ func newSlackRecipient() *schema.Resource {
 			"channel": {
 				Type:         schema.TypeString,
 				Required:     true,
-				Description:  "The Slack channel or username to send the notification to. Must begin with `#` or `@`.",
+				Description:  "The Slack channel or username to send the notification to. Must begin with `#` or `@` or be a valid channel id e.g. `CABC123DEF.",
 				ValidateFunc: validation.StringMatch(channelRegex, "channel must begin with `#` or `@` or be a valid channel id e.g. `CABC123DEF`"),
 			},
 		},


### PR DESCRIPTION
## Which problem is this PR solving?

- Closes #533

## Short description of the changes
Updates the Slack channel regex to include channel ids in addition to channels/users beginning with `#` or `@`
