### PR TITLE
fix: generate random URLs for webhook-like recipients

### DIFF
--- a/client/marker_test.go
+++ b/client/marker_test.go
@@ -29,7 +29,7 @@ func TestMarkers(t *testing.T) {
 		data := &client.Marker{
 			Message:   fmt.Sprintf("Test run at %v", time.Now()),
 			Type:      test.RandomStringWithPrefix("test.", 8),
-			URL:       "http://example.com",
+			URL:       test.RandomURL(),
 			StartTime: time.Now().Unix(),
 		}
 		m, err = c.Markers.Create(ctx, dataset, data)

--- a/client/recipient_test.go
+++ b/client/recipient_test.go
@@ -95,7 +95,7 @@ func TestRecipientsWebhooksandMSTeams(t *testing.T) {
 				Type: client.RecipientTypeWebhook,
 				Details: client.RecipientDetails{
 					WebhookName:   test.RandomStringWithPrefix("test.", 10),
-					WebhookURL:    "https://example.com",
+					WebhookURL:    test.RandomURL(),
 					WebhookSecret: "secret",
 				},
 			},
@@ -105,7 +105,7 @@ func TestRecipientsWebhooksandMSTeams(t *testing.T) {
 				Type: client.RecipientTypeMSTeams,
 				Details: client.RecipientDetails{
 					WebhookName: test.RandomStringWithPrefix("test.", 10),
-					WebhookURL:  "https://corp.office.com/webhook",
+					WebhookURL:  test.RandomURL(),
 				},
 			},
 			expectErr: true, // creation of new MSTeams recipients is not allowed
@@ -115,7 +115,7 @@ func TestRecipientsWebhooksandMSTeams(t *testing.T) {
 				Type: client.RecipientTypeMSTeamsWorkflow,
 				Details: client.RecipientDetails{
 					WebhookName: test.RandomStringWithPrefix("test.", 10),
-					WebhookURL:  "https://mycorp.westus.logic.azure.com/workflows/12345",
+					WebhookURL:  test.RandomURL(),
 				},
 			},
 		},

--- a/honeycombio/data_source_recipient_test.go
+++ b/honeycombio/data_source_recipient_test.go
@@ -62,14 +62,14 @@ func TestAccDataSourceHoneycombioRecipient_basic(t *testing.T) {
 			Details: honeycombio.RecipientDetails{
 				WebhookName:   test.RandomStringWithPrefix("test.", 16),
 				WebhookSecret: test.RandomString(20),
-				WebhookURL:    "https://my.webhook.dev.corp.io",
+				WebhookURL:    test.RandomURLWithDomain("dev.corp.io"),
 			},
 		},
 		{
 			Type: honeycombio.RecipientTypeMSTeamsWorkflow,
 			Details: honeycombio.RecipientDetails{
 				WebhookName: test.RandomStringWithPrefix("test.", 16),
-				WebhookURL:  "https://mycorp.westus.logic.azure.com/workflows/12345",
+				WebhookURL:  test.RandomURL(),
 			},
 		},
 	}
@@ -124,14 +124,14 @@ func TestAccDataSourceHoneycombioRecipient_basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.honeycombio_recipient.test", "name", testRecipients[6].Details.WebhookName),
 					resource.TestCheckResourceAttr("data.honeycombio_recipient.test", "secret", testRecipients[6].Details.WebhookSecret),
-					resource.TestCheckResourceAttr("data.honeycombio_recipient.test", "url", "https://my.webhook.dev.corp.io"),
+					resource.TestCheckResourceAttr("data.honeycombio_recipient.test", "url", testRecipients[6].Details.WebhookURL),
 				),
 			},
 			{
 				Config: testAccRecipientWithFilterValue("msteams", "name", testRecipients[7].Details.WebhookName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.honeycombio_recipient.test", "name", testRecipients[7].Details.WebhookName),
-					resource.TestCheckResourceAttr("data.honeycombio_recipient.test", "url", "https://mycorp.westus.logic.azure.com/workflows/12345"),
+					resource.TestCheckResourceAttr("data.honeycombio_recipient.test", "url", testRecipients[7].Details.WebhookURL),
 				),
 			},
 			{

--- a/honeycombio/recipients_test.go
+++ b/honeycombio/recipients_test.go
@@ -23,8 +23,8 @@ func TestAccHoneycombMSTeamsRecipient(t *testing.T) {
 					Config: fmt.Sprintf(`
 resource "honeycombio_msteams_workflow_recipient" "test" {
   name = "%s"
-  url  = "https://example.com"
-}`, test.RandomStringWithPrefix("test.", 10)),
+  url  = "%s"
+}`, test.RandomStringWithPrefix("test.", 10), test.RandomURL()),
 				},
 			},
 		})
@@ -39,7 +39,7 @@ resource "honeycombio_msteams_workflow_recipient" "test" {
 					Config: `
 resource "honeycombio_msteams_recipient" "test" {
   name = "test"
-  url  = "https://example.com"
+  url  = "https://nope.example.com"
 }`,
 					ExpectError: regexp.MustCompile(`Creating new MSTeams recipients is no longer possible`),
 				},

--- a/internal/helper/test/strings.go
+++ b/internal/helper/test/strings.go
@@ -3,6 +3,7 @@ package test
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"math/rand"
 )
 
@@ -42,4 +43,14 @@ func MinifyJSON(s string) (string, error) {
 		return "", err
 	}
 	return buffer.String(), nil
+}
+
+// RandomURL generates a random URL in 'example.com' for testing purposes.
+func RandomURL() string {
+	return RandomURLWithDomain("example.com")
+}
+
+// RandomURLWithDomain generates a random URL in the provided domain.
+func RandomURLWithDomain(domain string) string {
+	return fmt.Sprintf("https://%s.%s/%s", RandomString(10), domain, RandomString(10))
 }


### PR DESCRIPTION
The nightly "smoke test" failed last evening for two reasons:

1) we had an API-side bug when deleting certain shapes of recipients (now fixed)
2) because of the above, there were recipients that were considered duplicates as their Webhook URLs matched (affects Webhook and MSTeams* recipients). In the name of moving toward being able to run these tests concurrently, this fixes that duplicate issue.
