### PR TITLE
fix: column-related test flakes

### DIFF
--- a/honeycombio/resource_column_test.go
+++ b/honeycombio/resource_column_test.go
@@ -1,18 +1,17 @@
 package honeycombio
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/honeycombio/terraform-provider-honeycombio/internal/helper/test"
 )
 
 func TestAccHoneycombioColumn_basic(t *testing.T) {
 	dataset := testAccDataset()
-	keyName := acctest.RandomWithPrefix("duration_ms_test")
+	keyName := test.RandomStringWithPrefix("test.", 10)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 testAccPreCheck(t),
@@ -20,7 +19,15 @@ func TestAccHoneycombioColumn_basic(t *testing.T) {
 		IDRefreshName:            "honeycombio_column.test",
 		Steps: []resource.TestStep{
 			{
-				Config: testAccColumnConfig(keyName, dataset),
+				Config: fmt.Sprintf(`
+resource "honeycombio_column" "test" {
+  name        = "%s"
+  type        = "float"
+  hidden      = false
+  description = "Duration of the trace"
+
+  dataset = "%s"
+}`, keyName, dataset),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("honeycombio_column.test", "name", keyName),
 					resource.TestCheckResourceAttr("honeycombio_column.test", "type", "float"),
@@ -35,28 +42,5 @@ func TestAccHoneycombioColumn_basic(t *testing.T) {
 				ImportStateVerify: true,
 			},
 		},
-		CheckDestroy: resource.ComposeTestCheckFunc(
-			func(s *terraform.State) error {
-				// ensure column is removed on destroy
-				client := testAccClient(t)
-				_, err := client.Columns.GetByKeyName(context.Background(), dataset, keyName)
-				if err == nil {
-					return fmt.Errorf("column %q was not deleted on destroy", keyName)
-				}
-				return nil
-			},
-		),
 	})
-}
-
-func testAccColumnConfig(keyName, dataset string) string {
-	return fmt.Sprintf(`
-resource "honeycombio_column" "test" {
-  name        = "%s"
-  type        = "float"
-  hidden      = false
-  description = "Duration of the trace"
-
-  dataset = "%s"
-}`, keyName, dataset)
 }

--- a/honeycombio/resource_derived_column_test.go
+++ b/honeycombio/resource_derived_column_test.go
@@ -53,8 +53,8 @@ resource "honeycombio_derived_column" "invalid_column_in_expression" {
   expression  = "LOG10($invalid_column)"
 
   dataset = "%s"
-}`, alias, dataset),
-				ExpectError: regexp.MustCompile(`Error: unknown column name: invalid_column`),
+}`, test.RandomStringWithPrefix("test.", 10), dataset),
+				ExpectError: regexp.MustCompile(`unknown column`),
 			},
 		},
 	})


### PR DESCRIPTION
With some server-side changes, these two tests have become a bit flakey.

This tidies them up by removing the arguably-unnecessary "destroy check", and ensures that the name used for a bad DC is unique to avoid a false-conflict.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208480919302578