### PR TITLE
chore: r/dataset_definition - add log_severity and log_message

### DIFF
--- a/client/dataset_definitions.go
+++ b/client/dataset_definitions.go
@@ -47,6 +47,8 @@ type DatasetDefinition struct {
 	AnnotationType *DefinitionColumn `json:"annotation_type,omitempty"`
 	LinkTraceID    *DefinitionColumn `json:"link_trace_id,omitempty"`
 	LinkSpanID     *DefinitionColumn `json:"link_span_id,omitempty"`
+	LogMessage     *DefinitionColumn `json:"log_message,omitempty"`
+	LogSeverity    *DefinitionColumn `json:"log_severity,omitempty"`
 	Status         *DefinitionColumn `json:"status,omitempty"`
 	TraceID        *DefinitionColumn `json:"trace_id,omitempty"`
 	User           *DefinitionColumn `json:"user,omitempty"`
@@ -72,6 +74,8 @@ func DatasetDefinitionFields() []string {
 		"annotation_type",
 		"link_trace_id",
 		"link_span_id",
+		"log_message",
+		"log_severity",
 		"status",
 		"trace_id",
 		"user",
@@ -92,6 +96,8 @@ func DatasetDefinitionDefaults() map[string][]string {
 		"annotation_type": {"meta.annotation_type"},
 		"link_trace_id":   {"trace.link.trace_id"},
 		"link_span_id":    {"trace.link.span_id", "trace.span_id"},
+		"log_message":     {"body"},
+		"log_severity":    {"severity"},
 		"status":          {"response.status_code", "http.status_code", "elb_status_code"},
 		"trace_id":        {"http.status_code", "trace.trace_id", "traceId"},
 		"user":            {"user.id", "user.email", "request.user.id", "request.user.username"},
@@ -117,6 +123,8 @@ func (s *datasetDefinitions) ResetAll(ctx context.Context, dataset string) error
 		AnnotationType: EmptyDatasetDefinition(),
 		LinkTraceID:    EmptyDatasetDefinition(),
 		LinkSpanID:     EmptyDatasetDefinition(),
+		LogMessage:     EmptyDatasetDefinition(),
+		LogSeverity:    EmptyDatasetDefinition(),
 		Status:         EmptyDatasetDefinition(),
 		TraceID:        EmptyDatasetDefinition(),
 		User:           EmptyDatasetDefinition(),

--- a/client/dataset_definitions_test.go
+++ b/client/dataset_definitions_test.go
@@ -39,8 +39,9 @@ func TestDatasetDefinitions(t *testing.T) {
 		{KeyName: "request.user.username", Type: client.ToPtr(client.ColumnTypeString)},
 		{KeyName: "trace.link.trace_id", Type: client.ToPtr(client.ColumnTypeString)},
 		{KeyName: "trace.link.span_id", Type: client.ToPtr(client.ColumnTypeString)},
+		{KeyName: "body", Type: client.ToPtr(client.ColumnTypeString)},
+		{KeyName: "severity", Type: client.ToPtr(client.ColumnTypeString)},
 	} {
-		//nolint:errcheck
 		// ignore errors, we don't care if the column already exists
 		c.Columns.Create(ctx, dataset, &col)
 	}
@@ -55,7 +56,6 @@ func TestDatasetDefinitions(t *testing.T) {
 	require.NoError(t, err)
 
 	// reset all defs and remove test helpers at end of test run
-	//nolint:errcheck
 	t.Cleanup(func() {
 		c.DatasetDefinitions.ResetAll(ctx, dataset)
 		c.Columns.Delete(ctx, dataset, testCol.ID)
@@ -79,6 +79,8 @@ func TestDatasetDefinitions(t *testing.T) {
 		assert.Contains(t, definitionDefaults["annotation_type"], result.AnnotationType.Name)
 		assert.Contains(t, definitionDefaults["link_trace_id"], result.LinkTraceID.Name)
 		assert.Contains(t, definitionDefaults["link_span_id"], result.LinkSpanID.Name)
+		assert.Contains(t, definitionDefaults["log_message"], result.LogMessage.Name)
+		assert.Contains(t, definitionDefaults["log_severity"], result.LogSeverity.Name)
 		assert.Contains(t, definitionDefaults["status"], result.Status.Name)
 		assert.Contains(t, definitionDefaults["trace_id"], result.TraceID.Name)
 		assert.Contains(t, definitionDefaults["user"], result.User.Name)

--- a/docs/resources/dataset_definitions.md
+++ b/docs/resources/dataset_definitions.md
@@ -33,6 +33,8 @@ Definition Name    | Description
 `annotation_type`  | Metadata: Annotation Type
 `link_span_id`     | Metadata: Link Span ID
 `link_trace_id`    | Metadata: Link Trace ID
+`log_message`      | Log Event Message
+`log_severity`     | Log Event Severity
 `name`             | Name
 `parent_id`        | Parent Span ID
 `route`            | Route

--- a/honeycombio/resource_dataset_definition.go
+++ b/honeycombio/resource_dataset_definition.go
@@ -151,6 +151,10 @@ func extractDatasetDefinitionColumnByName(dd *honeycombio.DatasetDefinition, nam
 		return dd.LinkTraceID
 	case "link_span_id":
 		return dd.LinkSpanID
+	case "log_message":
+		return dd.LogMessage
+	case "log_severity":
+		return dd.LogSeverity
 	case "status":
 		return dd.Status
 	case "trace_id":
@@ -188,6 +192,10 @@ func expandDatasetDefinition(name, value string) *honeycombio.DatasetDefinition 
 		definition.LinkTraceID = &honeycombio.DefinitionColumn{Name: value}
 	case "link_span_id":
 		definition.LinkSpanID = &honeycombio.DefinitionColumn{Name: value}
+	case "log_message":
+		definition.LogMessage = &honeycombio.DefinitionColumn{Name: value}
+	case "log_severity":
+		definition.LogSeverity = &honeycombio.DefinitionColumn{Name: value}
 	case "status":
 		definition.Status = &honeycombio.DefinitionColumn{Name: value}
 	case "trace_id":


### PR DESCRIPTION
Adds the two new log-related dataset definitions to `r/dataset_definition`.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208492094472237