### PR TITLE
chore(ci): notify in Slack if scheduled CI run fails

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -108,7 +108,7 @@ jobs:
           payload: |
             {
               "username": "Terraform Provider CI",
-              "text": ":rotating_light: The scheduled test suite run failed for the US region.\n\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow Run>",
+              "text": ":rotating_light: The scheduled test suite run failed for the US region.\n\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs/${{ github.job }}|View Failed Job>",
               "icon_emoji": ":terraform-fall-down:"
             }
         env:
@@ -213,7 +213,7 @@ jobs:
           payload: |
             {
               "username": "Terraform Provider CI",
-              "text": ":rotating_light: The scheduled test suite run failed for the EU region.\n\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow Run>",
+              "text": ":rotating_light: The scheduled test suite run failed for the EU region.\n\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs/${{ github.job }}|View Failed Job>",
               "icon_emoji": ":terraform-fall-down:"
             }
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -108,7 +108,7 @@ jobs:
           payload: |
             {
               "username": "Terraform Provider CI",
-              "text": "The scheduled test suite run failed for the US region.\nPlease Investigate.\n\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow Run>",
+              "text": ":rotating_light: The scheduled test suite run failed for the US region.\n\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow Run>",
               "icon_emoji": ":terraform-fall-down:"
             }
         env:
@@ -213,7 +213,7 @@ jobs:
           payload: |
             {
               "username": "Terraform Provider CI",
-              "text": "The scheduled test suite run failed in the EU region.\nPlease Investigate.\n\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow Run>",
+              "text": ":rotating_light: The scheduled test suite run failed for the EU region.\n\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow Run>",
               "icon_emoji": ":terraform-fall-down:"
             }
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -100,6 +100,20 @@ jobs:
             -iocopy \
             -out provider-report.xml
 
+      - name: Notify if scheduled run fails
+        id: slack-notify
+        #if: ${{ failure() && github.event_name == 'schedule' }}
+        uses: slackapi/slack-github-action@v1.27.0
+        with:
+          payload: |
+            {
+              "username": "Terraform Provider CI"
+              "text": "The scheduled test suite run failed for the US region.\nPlease Investigate.\n\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow Run>",
+              "icon_emoji": ":terraform-fall-down:"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
       - name: Cleanup Dangling Resources
         if: ${{ always() }}
         timeout-minutes: 5
@@ -191,6 +205,20 @@ jobs:
             -iocopy \
             -out provider-report.xml
 
+      - name: Notify if scheduled run fails
+        id: slack-notify
+        if: ${{ failure() && github.event_name == 'schedule' }}
+        uses: slackapi/slack-github-action@v1.27.0
+        with:
+          payload: |
+            {
+              "username": "Terraform Provider CI"
+              "text": "The scheduled test suite run failed in the EU region.\nPlease Investigate.\n\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow Run>",
+              "icon_emoji": ":terraform-fall-down:"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
       - name: Cleanup Dangling Resources
         if: ${{ always() }}
         timeout-minutes: 5
@@ -203,7 +231,7 @@ jobs:
         run: make sweep
 
       - name: Generate Test Summary
-        if: always()
+        if: ${{ always() }}
         uses: test-summary/action@v2
         with:
           paths: "*-report.xml"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -107,7 +107,7 @@ jobs:
         with:
           payload: |
             {
-              "username": "Terraform Provider CI"
+              "username": "Terraform Provider CI",
               "text": "The scheduled test suite run failed for the US region.\nPlease Investigate.\n\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow Run>",
               "icon_emoji": ":terraform-fall-down:"
             }
@@ -212,7 +212,7 @@ jobs:
         with:
           payload: |
             {
-              "username": "Terraform Provider CI"
+              "username": "Terraform Provider CI",
               "text": "The scheduled test suite run failed in the EU region.\nPlease Investigate.\n\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow Run>",
               "icon_emoji": ":terraform-fall-down:"
             }

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -102,13 +102,13 @@ jobs:
 
       - name: Notify if scheduled run fails
         id: slack-notify
-        #if: ${{ failure() && github.event_name == 'schedule' }}
+        if: ${{ failure() && github.event_name == 'schedule' }}
         uses: slackapi/slack-github-action@v1.27.0
         with:
           payload: |
             {
               "username": "Terraform Provider CI",
-              "text": ":rotating_light: The scheduled test suite run failed for the US region.\n\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs/${{ github.job }}|View Failed Job>",
+              "text": ":rotating_light: The scheduled test suite run failed for the US region.\n\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow>",
               "icon_emoji": ":terraform-fall-down:"
             }
         env:
@@ -213,7 +213,7 @@ jobs:
           payload: |
             {
               "username": "Terraform Provider CI",
-              "text": ":rotating_light: The scheduled test suite run failed for the EU region.\n\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs/${{ github.job }}|View Failed Job>",
+              "text": ":rotating_light: The scheduled test suite run failed for the EU region.\n\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow>",
               "icon_emoji": ":terraform-fall-down:"
             }
         env:


### PR DESCRIPTION
Posts notices to our team alert Slack channel about any failure of a scheduled run (read: not manually triggered or from a PR).

Very open to changing the copy, but this felt 'fine' to me.