### PR TITLE
fix(docs): incorrect formatting trigger example

### DIFF
--- a/docs/resources/trigger.md
+++ b/docs/resources/trigger.md
@@ -55,7 +55,7 @@ resource "honeycombio_trigger" "example" {
 ```
 
 ### Example with PagerDuty Recipient and Severity
-```
+```hcl
 variable "dataset" {
   type = string
 }


### PR DESCRIPTION
I noticed that the [current docs](https://registry.terraform.io/providers/honeycombio/honeycombio/latest/docs/resources/trigger#example-with-pagerduty-recipient-and-severity) have a malformed second example for Triggers.

This properly tags the code block as HCL which fixes the issue. You can test yourself by copying and pasting the full file into the HashiCorp [Doc Preview Tool](https://registry.terraform.io/tools/doc-preview)