### PR TITLE
fix(client): retry on server errors

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -237,7 +237,7 @@ func (c *Client) newRequest(ctx context.Context, method, path string, body any) 
 }
 
 // retryHTTPCheck provides a callback for Client.CheckRetry which
-// will retry both rate limit (429) and server gateway (502, 504) errors.
+// will retry both rate limit (429) and server (500, 502, 503, 504) errors.
 func (c *Client) retryHTTPCheck(ctx context.Context, resp *http.Response, err error) (bool, error) {
 	if ctx.Err() != nil {
 		return false, ctx.Err()
@@ -248,7 +248,9 @@ func (c *Client) retryHTTPCheck(ctx context.Context, resp *http.Response, err er
 
 	if resp != nil {
 		if resp.StatusCode == http.StatusTooManyRequests ||
+			resp.StatusCode == http.StatusInternalServerError ||
 			resp.StatusCode == http.StatusBadGateway ||
+			resp.StatusCode == http.StatusServiceUnavailable ||
 			resp.StatusCode == http.StatusGatewayTimeout {
 			return true, nil
 		}


### PR DESCRIPTION
Have the V1 API Client retry on 500-class errors like the V2 client.