### PR TITLE
chore(ci): remove paths-ignore from CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,10 +3,6 @@ name: CI
 on:
   workflow_dispatch:
   push:
-    paths-ignore:
-      - README.md
-      - CHANGELOG.md
-      - CONTRIBUTING.md
   schedule:
     # run CI nightly at 00:11UTC
     - cron: "11 0 * * *"


### PR DESCRIPTION
While "optimal" to have these in place, they end up meaning that the CI workflow doesn't run but it is required for merge -- preventing non-repo-Admins from merging release PRs (mostly notably).

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208551821723692