### PR TITLE
fix(r/burn_alert): handle existing remote description with default description value

### DIFF
--- a/client/burn_alert.go
+++ b/client/burn_alert.go
@@ -46,7 +46,7 @@ type BurnAlert struct {
 	ExhaustionMinutes                     *int                    `json:"exhaustion_minutes,omitempty"`
 	BudgetRateWindowMinutes               *int                    `json:"budget_rate_window_minutes,omitempty"`
 	BudgetRateDecreaseThresholdPerMillion *int                    `json:"budget_rate_decrease_threshold_per_million,omitempty"`
-	Description                           string                  `json:"description,omitempty"`
+	Description                           string                  `json:"description"`
 	SLO                                   SLORef                  `json:"slo"`
 	CreatedAt                             time.Time               `json:"created_at,omitempty"`
 	UpdatedAt                             time.Time               `json:"updated_at,omitempty"`

--- a/internal/provider/burn_alert_resource_test.go
+++ b/internal/provider/burn_alert_resource_test.go
@@ -519,6 +519,10 @@ resource "honeycombio_burn_alert" "test" {
 					require.NoError(t, err, "failed to update burn alert")
 				},
 				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccEnsureBurnAlertExists(t, "honeycombio_burn_alert.test", burnAlert),
+					resource.TestCheckResourceAttr("honeycombio_burn_alert.test", "description", ""),
+				),
 			},
 		},
 	})

--- a/internal/provider/burn_alert_resource_test.go
+++ b/internal/provider/burn_alert_resource_test.go
@@ -575,7 +575,7 @@ func testAccEnsureSuccessBudgetRateAlert(t *testing.T, burnAlert *client.BurnAle
 	)
 }
 
-func testAccEnsureBurnAlertExists(t *testing.T, name string, burnAlert *client.BurnAlert) resource.TestCheckFunc {
+func testAccEnsureBurnAlertExists(t *testing.T, name string, burnAlert *client.BurnAlert) resource.TestCheckFunc { //nolint:unparam
 	return func(s *terraform.State) error {
 		resourceState, ok := s.RootModule().Resources[name]
 		if !ok {


### PR DESCRIPTION
When upgrading to 0.28.0, if you have an existing burn alert that had a description set (via the UI, most likely) but the description was yet to be added to HCL config you will get the following error:

```
Error: Provider produced inconsistent result after apply
        
        When applying changes to honeycombio_burn_alert.test, provider
        "provider[\"registry.terraform.io/hashicorp/honeycombio\"]" produced an
        unexpected new value: .description: was cty.StringVal(""), but now
        cty.StringVal("test description").
```

Fix is to ensure we send the empty string when we marshal our JSON