### PR TITLE
chore: tidy up lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,6 +5,7 @@ issues:
         - path: '(.+)_test\.go'
           linters:
               - errcheck
+              - unparam
           # disabling both of these for the SDKv2-based code as it's idomatic for the SDK
         - path: honeycombio/*
           text: "Error return value of `d.Set` is not checked"

--- a/client/board_test.go
+++ b/client/board_test.go
@@ -27,7 +27,6 @@ func TestBoards(t *testing.T) {
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		//nolint:errcheck
 		c.Columns.Delete(ctx, dataset, column.ID)
 	})
 
@@ -55,7 +54,6 @@ func TestBoards(t *testing.T) {
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		//nolint:errcheck
 		c.SLOs.Delete(ctx, dataset, slo.ID)
 		c.DerivedColumns.Delete(ctx, dataset, sli.ID)
 	})

--- a/client/burn_alert_test.go
+++ b/client/burn_alert_test.go
@@ -37,7 +37,6 @@ func TestBurnAlerts(t *testing.T) {
 	require.NoError(t, err)
 
 	// remove SLO and SLI at the end of the test run
-	//nolint:errcheck
 	t.Cleanup(func() {
 		c.SLOs.Delete(ctx, dataset, slo.ID)
 		c.DerivedColumns.Delete(ctx, dataset, sli.ID)

--- a/client/column_test.go
+++ b/client/column_test.go
@@ -131,7 +131,6 @@ func createRandomTestColumns(
 	})
 	require.NoError(t, err)
 
-	//nolint:errcheck
 	t.Cleanup(func() {
 		c.Columns.Delete(ctx, dataset, floatCol.ID)
 		c.Columns.Delete(ctx, dataset, col1.ID)

--- a/client/slo_test.go
+++ b/client/slo_test.go
@@ -30,7 +30,6 @@ func TestSLOs(t *testing.T) {
 
 	// remove SLI DC at end of test run
 	t.Cleanup(func() {
-		//nolint:errcheck
 		c.DerivedColumns.Delete(ctx, dataset, sli.ID)
 	})
 

--- a/honeycombio/data_source_recipient_test.go
+++ b/honeycombio/data_source_recipient_test.go
@@ -80,7 +80,6 @@ func TestAccDataSourceHoneycombioRecipient_basic(t *testing.T) {
 		// update ID for removal later
 		testRecipients[i].ID = rcpt.ID
 	}
-	//nolint:errcheck
 	t.Cleanup(func() {
 		// remove Recipients at the of the test run
 		for _, r := range testRecipients {

--- a/honeycombio/data_source_recipients_test.go
+++ b/honeycombio/data_source_recipients_test.go
@@ -49,7 +49,6 @@ func TestAccDataSourceHoneycombioRecipients_basic(t *testing.T) {
 		// update ID for removal later
 		testRecipients[i].ID = rcpt.ID
 	}
-	//nolint:errcheck
 	t.Cleanup(func() {
 		// remove Recipients at the of the test run
 		for _, r := range testRecipients {

--- a/honeycombio/data_source_trigger_recipient_test.go
+++ b/honeycombio/data_source_trigger_recipient_test.go
@@ -39,7 +39,6 @@ func TestAccDataSourceHoneycombioTriggerRecipient_basic(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	//nolint:errcheck
 	t.Cleanup(func() {
 		c.Triggers.Delete(ctx, dataset, trigger.ID)
 	})

--- a/honeycombio/resource_board_test.go
+++ b/honeycombio/resource_board_test.go
@@ -218,7 +218,6 @@ func TestAccBoard_withSLOs(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	//nolint:errcheck
 	t.Cleanup(func() {
 		// remove SLOs, and SLIs at end of test run
 		c.SLOs.Delete(ctx, dataset, slo1.ID)
@@ -384,7 +383,6 @@ resource "honeycombio_board" "test" {
 }`, dataset)
 }
 
-//nolint:unparam
 func testAccCheckBoardExists(t *testing.T, name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		resourceState, ok := s.RootModule().Resources[name]

--- a/honeycombio/resource_slo.go
+++ b/honeycombio/resource_slo.go
@@ -86,12 +86,7 @@ func resourceSLOCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 	}
 
 	dataset := d.Get("dataset").(string)
-	s, err := expandSLO(d)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	s, err = client.SLOs.Create(ctx, dataset, s)
+	s, err := client.SLOs.Create(ctx, dataset, expandSLO(d))
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -138,12 +133,7 @@ func resourceSLOUpdate(ctx context.Context, d *schema.ResourceData, meta interfa
 	}
 
 	dataset := d.Get("dataset").(string)
-	s, err := expandSLO(d)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	s, err = client.SLOs.Update(ctx, dataset, s)
+	s, err := client.SLOs.Update(ctx, dataset, expandSLO(d))
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -167,9 +157,8 @@ func resourceSLODelete(ctx context.Context, d *schema.ResourceData, meta interfa
 	return nil
 }
 
-//nolint:unparam
-func expandSLO(d *schema.ResourceData) (*honeycombio.SLO, error) {
-	s := &honeycombio.SLO{
+func expandSLO(d *schema.ResourceData) *honeycombio.SLO {
+	return &honeycombio.SLO{
 		ID:               d.Id(),
 		Name:             d.Get("name").(string),
 		Description:      d.Get("description").(string),
@@ -177,5 +166,4 @@ func expandSLO(d *schema.ResourceData) (*honeycombio.SLO, error) {
 		TargetPerMillion: helper.FloatToPPM(d.Get("target_percentage").(float64)),
 		SLI:              honeycombio.SLIRef{Alias: d.Get("sli").(string)},
 	}
-	return s, nil
 }

--- a/honeycombio/resource_slo_test.go
+++ b/honeycombio/resource_slo_test.go
@@ -112,7 +112,6 @@ func sloAccTestSetup(t *testing.T) (string, string) {
 	})
 	require.NoError(t, err)
 
-	//nolint:errcheck
 	t.Cleanup(func() {
 		// remove SLI DC at end of test run
 		c.DerivedColumns.Delete(ctx, dataset, sli.ID)

--- a/internal/provider/burn_alert_resource_test.go
+++ b/internal/provider/burn_alert_resource_test.go
@@ -439,7 +439,6 @@ func TestAcc_BurnAlertResource_HandlesRecipientChangedOutsideOfTerraform(t *test
 	})
 	require.NoError(t, err, "failed to create test recipient")
 	t.Cleanup(func() {
-		//nolint:errcheck
 		c.Recipients.Delete(ctx, rcpt.ID)
 	})
 
@@ -575,7 +574,7 @@ func testAccEnsureSuccessBudgetRateAlert(t *testing.T, burnAlert *client.BurnAle
 	)
 }
 
-func testAccEnsureBurnAlertExists(t *testing.T, name string, burnAlert *client.BurnAlert) resource.TestCheckFunc { //nolint:unparam
+func testAccEnsureBurnAlertExists(t *testing.T, name string, burnAlert *client.BurnAlert) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		resourceState, ok := s.RootModule().Resources[name]
 		if !ok {
@@ -691,7 +690,6 @@ func burnAlertAccTestSetup(t *testing.T) (string, string) {
 		SLI:              client.SLIRef{Alias: sli.Alias},
 	})
 	require.NoError(t, err)
-	//nolint:errcheck
 	t.Cleanup(func() {
 		// remove SLO, SLI DC at end of test run
 		c.SLOs.Delete(ctx, dataset, slo.ID)

--- a/internal/provider/dataset_resource_test.go
+++ b/internal/provider/dataset_resource_test.go
@@ -209,7 +209,7 @@ resource "honeycombio_dataset" "test" {
 }`, name, description, jsonDepth, protected)
 }
 
-func testAccEnsureDatasetExists(t *testing.T, name string) resource.TestCheckFunc { //nolint:unparam
+func testAccEnsureDatasetExists(t *testing.T, name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {

--- a/internal/provider/derived_column_data_source_test.go
+++ b/internal/provider/derived_column_data_source_test.go
@@ -29,7 +29,6 @@ func TestAcc_DerivedColumnDataSource(t *testing.T) {
 	// update ID for removal later
 	testColumn.ID = col.ID
 	t.Cleanup(func() {
-		//nolint:errcheck
 		c.DerivedColumns.Delete(ctx, dataset, testColumn.ID)
 	})
 

--- a/internal/provider/derived_columns_data_source_test.go
+++ b/internal/provider/derived_columns_data_source_test.go
@@ -41,7 +41,6 @@ func TestAcc_DerivedColumnsDataSource(t *testing.T) {
 	t.Cleanup(func() {
 		// remove DCs at the of the test run
 		for _, col := range testColumns {
-			//nolint:errcheck
 			c.DerivedColumns.Delete(ctx, dataset, col.ID)
 		}
 	})

--- a/internal/provider/slo_data_source_test.go
+++ b/internal/provider/slo_data_source_test.go
@@ -33,7 +33,6 @@ func TestAcc_SLODataSource(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	//nolint:errcheck
 	t.Cleanup(func() {
 		c.SLOs.Delete(ctx, dataset, slo.ID)
 		c.DerivedColumns.Delete(ctx, dataset, sli.ID)

--- a/internal/provider/slos_data_source_test.go
+++ b/internal/provider/slos_data_source_test.go
@@ -73,7 +73,6 @@ func TestAcc_SLOsDataSource(t *testing.T) {
 		testData[i].SLO.ID = slo.ID
 	}
 
-	//nolint:errcheck
 	t.Cleanup(func() {
 		// remove SLOs at the of the test run
 		for _, tc := range testData {

--- a/internal/provider/trigger_resource_test.go
+++ b/internal/provider/trigger_resource_test.go
@@ -152,7 +152,6 @@ func TestAcc_TriggerResourceUpdateRecipientByID(t *testing.T) {
 	t.Cleanup(func() {
 		// remove recipients at the of the test run
 		for _, col := range testRecipients {
-			//nolint:errcheck
 			c.DerivedColumns.Delete(ctx, dataset, col.ID)
 		}
 	})
@@ -532,7 +531,6 @@ func TestAcc_TriggerResourceHandlesRecipientChangedOutsideOfTerraform(t *testing
 	})
 	require.NoError(t, err, "failed to create test recipient")
 	t.Cleanup(func() {
-		//nolint:errcheck
 		c.Recipients.Delete(ctx, rcpt.ID)
 	})
 

--- a/internal/provider/webhook_recipient_resource_test.go
+++ b/internal/provider/webhook_recipient_resource_test.go
@@ -102,7 +102,7 @@ resource "honeycombio_webhook_recipient" "test" {
 	})
 }
 
-func testAccEnsureRecipientExists(t *testing.T, name string) resource.TestCheckFunc { //nolint:unparam
+func testAccEnsureRecipientExists(t *testing.T, name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {


### PR DESCRIPTION
`unparam` felt a bit extra in tests, so disabled it for test files and then cleaned up all the `nolint` directives