### PR TITLE
fix: webhook recipient test

### DIFF
--- a/internal/provider/webhook_recipient_resource_test.go
+++ b/internal/provider/webhook_recipient_resource_test.go
@@ -65,11 +65,17 @@ resource "honeycombio_webhook_recipient" "test" {
 	t.Run("happy path custom webhook", func(t *testing.T) {
 		name := test.RandomStringWithPrefix("test.", 20)
 		url := test.RandomURL()
-		body := `<<EOT
+		createBody := `<<EOT
 		{
 			"name": " {{ .Name }}",
 			"id": " {{ .ID }}",
 			"description": " {{ .Description }}",
+		}
+		EOT`
+		updateBody := `<<EOT
+		{
+			"name": " {{ .Name }}",
+			"id": " {{ .ID }}"
 		}
 		EOT`
 
@@ -88,7 +94,7 @@ resource "honeycombio_webhook_recipient" "test" {
 	  type   = "trigger"
       body = %s
     }
-}`, name, url, body),
+}`, name, url, createBody),
 					Check: resource.ComposeAggregateTestCheckFunc(
 						testAccEnsureRecipientExists(t, "honeycombio_webhook_recipient.test"),
 						resource.TestCheckResourceAttrSet("honeycombio_webhook_recipient.test", "id"),
@@ -111,7 +117,7 @@ resource "honeycombio_webhook_recipient" "test" {
 	  type   = "trigger"
       body = %s
     }
-}`, name, url, body),
+}`, name, url, updateBody),
 					Check: resource.ComposeAggregateTestCheckFunc(
 						testAccEnsureRecipientExists(t, "honeycombio_webhook_recipient.test"),
 						resource.TestCheckResourceAttrSet("honeycombio_webhook_recipient.test", "id"),


### PR DESCRIPTION
## Short description of the changes

We're seeing a 500 error that I believe is caused by the update in this test not actually updating the template. CI on this branch didn't cause the same 500 so I'd like to merge it in to avoid spamming ourselves with 500s when this test suite runs. I think there's still more to consider about why this is happening both on the TF side and the API side but this is a bandaid for the noise.

