### PR TITLE
feat(Board, SLO): Bump up max number of SLOs on a board to 24

### DIFF
--- a/honeycombio/resource_board.go
+++ b/honeycombio/resource_board.go
@@ -148,7 +148,7 @@ See [Graph Settings](https://docs.honeycomb.io/working-with-your-data/graph-sett
 				Type:        schema.TypeSet,
 				Optional:    true,
 				Description: "An SLO to added to the board.",
-				MaxItems:    6,
+				MaxItems:    24,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"id": {


### PR DESCRIPTION
## Short description of the changes

- Bump up max number of slos on a board from 6 to 24 to match new UI changes 