### PR TITLE
chore(ci): remove codecov

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,7 +65,6 @@ jobs:
           HONEYCOMB_DATASET: testacc
         run: |
           go test -v ./client/... \
-            -coverprofile=client-coverage.txt \
             -covermode=atomic | \
             go-junit-report \
             -set-exit-code \
@@ -87,7 +86,6 @@ jobs:
           TF_ACC_TERRAFORM_VERSION: ${{ env.TERRAFORM_VERSION }}
         run: |
           go test -v ./internal/... ./honeycombio/... \
-            -coverprofile=tf-coverage.txt \
             -covermode=atomic | \
             go-junit-report \
             -set-exit-code \
@@ -121,11 +119,6 @@ jobs:
         with:
           paths: "*-report.xml"
           show: "fail, skip"
-
-      - name: Generate Coverage Report
-        uses: codecov/codecov-action@v4.6.0
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
 
   test-eu:
     name: Test EU
@@ -164,7 +157,6 @@ jobs:
           HONEYCOMB_DATASET: testacc
         run: |
           go test -v ./client/... \
-            -coverprofile=client-coverage.txt \
             -covermode=atomic | \
             go-junit-report \
             -set-exit-code \
@@ -187,7 +179,6 @@ jobs:
           TF_ACC_TERRAFORM_VERSION: ${{ env.TERRAFORM_VERSION }}
         run: |
           go test -v ./internal/... ./honeycombio/... \
-            -coverprofile=tf-coverage.txt \
             -covermode=atomic | \
             go-junit-report \
             -set-exit-code \
@@ -222,8 +213,3 @@ jobs:
         with:
           paths: "*-report.xml"
           show: "fail, skip"
-
-      - name: Generate Coverage Report
-        uses: codecov/codecov-action@v4.6.0
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![OSS Lifecycle](https://img.shields.io/osslifecycle/honeycombio/terraform-provider-honeycombio)](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md)
 [![CI](https://github.com/honeycombio/terraform-provider-honeycombio/workflows/CI/badge.svg)](https://github.com/honeycombio/terraform-provider-honeycombio/actions)
-[![codecov](https://codecov.io/gh/honeycombio/terraform-provider-honeycombio/branch/main/graph/badge.svg)](https://codecov.io/gh/honeycombio/terraform-provider-honeycombio)
 [![Terraform Registry](https://img.shields.io/github/v/release/honeycombio/terraform-provider-honeycombio?color=5e4fe3&label=Terraform%20Registry&logo=terraform&sort=semver)](https://registry.terraform.io/providers/honeycombio/honeycombio/latest)
 
 A Terraform provider for Honeycomb.io.


### PR DESCRIPTION
We inherited codecov when we took this project over from the community, but haven't found it useful and decided to remove it from the project.

As followup once this is landed I'll remove the secret from the project's secrets.