### PR TITLE
fix(r/trigger): handle state error with equivalent query_json

### DIFF
--- a/internal/provider/trigger_resource.go
+++ b/internal/provider/trigger_resource.go
@@ -297,17 +297,9 @@ func (r *triggerResource) Create(ctx context.Context, req resource.CreateRequest
 		state.QueryJson = types.StringNull()
 	} else {
 		state.QueryID = types.StringNull()
-
-		json, err := trigger.Query.Encode()
-		if err != nil {
-			resp.Diagnostics.AddAttributeError(
-				path.Root("query_json"),
-				"failed to encode query_json",
-				err.Error(),
-			)
-		} else {
-			state.QueryJson = types.StringValue(json)
-		}
+		// store the plan's query JSON in state so it matches the config and rely on the plan modifier
+		// to handle the rest when we read it back
+		state.QueryJson = plan.QueryJson
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
@@ -450,17 +442,9 @@ func (r *triggerResource) Update(ctx context.Context, req resource.UpdateRequest
 		state.QueryJson = types.StringNull()
 	} else {
 		state.QueryID = types.StringNull()
-
-		json, err := trigger.Query.Encode()
-		if err != nil {
-			resp.Diagnostics.AddAttributeError(
-				path.Root("query_json"),
-				"failed to encode query_json",
-				err.Error(),
-			)
-		} else {
-			state.QueryJson = types.StringValue(json)
-		}
+		// store the plan's query JSON in state so it matches the config and rely on the plan modifier
+		// to handle the rest when we read it back
+		state.QueryJson = plan.QueryJson
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)

--- a/internal/provider/trigger_resource_test.go
+++ b/internal/provider/trigger_resource_test.go
@@ -785,6 +785,43 @@ resource "honeycombio_trigger" "test" {
 	})
 }
 
+func TestAcc_TriggerResource_QueryJSONHandlesEquivQuerySpecs(t *testing.T) {
+	dataset := testAccDataset()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 testAccPreCheck(t),
+		ProtoV5ProviderFactories: testAccProtoV5MuxServerFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+data "honeycombio_query_specification" "test" {
+  calculation {
+    op     = "COUNT"
+  }
+
+  filter_combination = "AND"
+
+  time_range = 1200
+}
+
+resource honeycombio_trigger "test" {
+  name    = "test trigger"
+  dataset = "%s"
+
+  threshold {
+    op    = ">"
+    value = 100
+  }
+
+  frequency = data.honeycombio_query_specification.test.time_range / 2
+
+  query_json = data.honeycombio_query_specification.test.json
+}`, dataset),
+			},
+		},
+	})
+}
+
 func testAccConfigBasicTriggerTest(dataset, name, pdseverity string) string {
 	email := test.RandomEmail()
 	pdKey := test.RandomString(32)


### PR DESCRIPTION
## Which problem is this PR solving?

We received a bug report when using "r/trigger"'s `query_json` attribute handling properly handling equivalent query specifications (e.g. filter order changed, or the default "AND" filter combination was provided).

The error looked something like this:

```
Error: Provider produced inconsistent result after apply

When applying changes to honeycombio_trigger.example, provider
"provider[\"registry.terraform.io/honeycombio/honeycombio\"]" produced an
unexpected new value: .query_json: was
cty.StringVal("{\"calculations\":[{\"op\":\"COUNT\"}],\"filters\":[{\"column\":\"http.status_code\",\"op\":\"\\u003e=\",\"value\":400},{\"column\":\"trace.parent_id\",\"op\":\"does-not-exist\"}],\"filter_combination\":\"AND\",\"time_range\":900}"),
but now
cty.StringVal("{\"calculations\":[{\"op\":\"COUNT\"}],\"filters\":[{\"column\":\"http.status_code\",\"op\":\"\\u003e=\",\"value\":400},{\"column\":\"trace.parent_id\",\"op\":\"does-not-exist\"}],\"time_range\":900}").

This is a bug in the provider, which should be reported in the provider's own issue tracker.
```

The 'fix' here is to use the same approach "r/query" takes with `query_json` and use the planned value while relying on the planmodifier to manage unnecessary diffs.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208967572142360