### PR TITLE
rel: 0.28.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.28.2 (Dec 20, 2024)
+
+BUGFIXES:
+
+* fix(r/trigger): handle state error with equivalent query_json (#593)
+
 # 0.28.1 (Nov 15, 2024)
 
 BUGFIXES:


### PR DESCRIPTION
This preps the CHANGELOG for the v0.28.2 patch release. This is *not* destined for `main`, but instead to `rel-0282` which I forked off the `v0.28.1` tag and cherry-picked cafa068 into it.

Following the successful publishing of v0.28.2 I'll cherry-pick this CHANGELOG commit onto `main`