### PR TITLE
fix(ci): extend 'go test' timeout to 20 min

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -33,6 +34,7 @@ jobs:
     name: Test US
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     concurrency:
       group: hnytf-testacc-us
     env:
@@ -123,6 +125,7 @@ jobs:
     name: Test EU
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     concurrency:
       group: hnytf-testacc-eu
     env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,6 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    timeout-minutes: 5
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -34,7 +33,6 @@ jobs:
     name: Test US
     needs: build
     runs-on: ubuntu-latest
-    timeout-minutes: 20
     concurrency:
       group: hnytf-testacc-us
     env:
@@ -86,6 +84,7 @@ jobs:
           TF_ACC_TERRAFORM_VERSION: ${{ env.TERRAFORM_VERSION }}
         run: |
           go test -v ./internal/... ./honeycombio/... \
+            -timeout=20m \
             -covermode=atomic | \
             go-junit-report \
             -set-exit-code \
@@ -124,7 +123,6 @@ jobs:
     name: Test EU
     needs: build
     runs-on: ubuntu-latest
-    timeout-minutes: 20
     concurrency:
       group: hnytf-testacc-eu
     env:
@@ -179,6 +177,7 @@ jobs:
           TF_ACC_TERRAFORM_VERSION: ${{ env.TERRAFORM_VERSION }}
         run: |
           go test -v ./internal/... ./honeycombio/... \
+            -timeout=20m \
             -covermode=atomic | \
             go-junit-report \
             -set-exit-code \

--- a/.github/workflows/validate-examples.yml
+++ b/.github/workflows/validate-examples.yml
@@ -3,10 +3,6 @@ name: Validate Examples
 on:
     workflow_dispatch:
     push:
-        paths-ignore:
-            - README.md
-            - CHANGELOG.md
-            - CONTRIBUTING.md
 
 jobs:
     validate:
@@ -24,6 +20,11 @@ jobs:
 
             - name: Build
               run: go build -o /tmp/providers/terraform-provider-honeycombio
+
+            - name: Setup Terraform
+              uses: hashicorp/setup-terraform@v3
+              with:
+                  terraform_wrapper: false
 
             - name: Validate examples
               env:


### PR DESCRIPTION
We've had some CI runs fail with timeouts against the EU region: likely the increased latency just having things take that much longer.

A previous attempt to extend the timeout of the integration test step in the GHA Workflow forgot that the default timeout for `go test` is 10 minutes 🙃. This extends that to 20 for the provider's integration tests and adjusts the GHA `timeout-minutes` values (as the default is 360 minutes)

Fly by fix for the "Validate Examples" job which started failing due to the update to `ubuntu-latest` from what I can tell (which no longer has `terraform` installed by default)
