### PR TITLE
chore: adjust linter config. after golangci-lint update

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,7 +6,7 @@ issues:
           linters:
               - errcheck
               - unparam
-          # disabling both of these for the SDKv2-based code as it's idomatic for the SDK
+          # disabling these for the SDKv2-based code as it's idomatic and things are being migrated to the Framework
         - path: honeycombio/*
           text: "Error return value of `d.Set` is not checked"
         - path: honeycombio/*

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,6 +11,8 @@ issues:
           text: "Error return value of `d.Set` is not checked"
         - path: honeycombio/*
           text: "type assertion must be checked"
+        - path: honeycombio/*
+          text: "right hand must be only type assertion"
 
 linters-settings:
     goimports:
@@ -31,9 +33,9 @@ linters:
         - nilerr
         - predeclared
         - staticcheck
-        - tenv
         - testifylint
         - unconvert
+        - usetesting
         - unparam
         - unused
         - govet


### PR DESCRIPTION
A new version of `golangci-lint` was released which brought improved linters and failed the nightly build ([link](https://github.com/honeycombio/terraform-provider-honeycombio/actions/runs/13319868520)).

All of the linting errors were in the SDKv2 provider which we are slowly moving away from and has been working fine, so I'm choosing to just ignore the lints here.

As a bonus, swapped the deprecated `tenv` linter for it's replacement `usetesting`.

