### PR TITLE
fix(r/dataset): changing a dataset's name requires replacement

### DIFF
--- a/internal/provider/dataset_resource.go
+++ b/internal/provider/dataset_resource.go
@@ -77,6 +77,9 @@ func (*datasetResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 				Validators: []validator.String{
 					stringvalidator.LengthBetween(1, 255),
 				},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"slug": schema.StringAttribute{
 				Description: "The slug of the Dataset.",


### PR DESCRIPTION
Changing a Dataset's name in place is not supported by the API or the UI.

- Introduced by #535 


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209390209039954