### PR TITLE
fix(r/derived_column): don't run validation parser in debug mode

### DIFF
--- a/honeycombio/resource_derived_column.go
+++ b/honeycombio/resource_derived_column.go
@@ -43,7 +43,7 @@ func newDerivedColumn() *schema.Resource {
 							return nil, []error{fmt.Errorf("expected type of %s to be string", k)}
 						}
 
-						if _, err := dcparser.ANTLRParse(v, true); err != nil {
+						if _, err := dcparser.ANTLRParse(v, false); err != nil {
 							return nil, []error{fmt.Errorf("invalid derived column syntax: %s", err)}
 						}
 


### PR DESCRIPTION
No need to run the parser in debug mode: it did only print to stderr when running the provider in debug mode, but it's unnecessary output.