### PR TITLE
fix(r/slo): force re-creation of SLO on SLI change

### DIFF
--- a/honeycombio/resource_slo.go
+++ b/honeycombio/resource_slo.go
@@ -46,6 +46,7 @@ func newSLO() *schema.Resource {
 			"sli": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 				Description: `The alias of the Derived Column that will be used as the SLI to indicate event success.
 The derived column used as the SLI must be in the same dataset as the SLO. Additionally,
 the column evaluation should consistently return nil, true, or false, as these are the only valid values for an SLI.`,

--- a/honeycombio/resource_slo_test.go
+++ b/honeycombio/resource_slo_test.go
@@ -7,11 +7,10 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
-
 	"github.com/stretchr/testify/require"
 
 	honeycombio "github.com/honeycombio/terraform-provider-honeycombio/client"
+	"github.com/honeycombio/terraform-provider-honeycombio/internal/helper/test"
 )
 
 func TestAccHoneycombioSLO_basic(t *testing.T) {
@@ -107,7 +106,7 @@ func sloAccTestSetup(t *testing.T) (string, string) {
 	dataset := testAccDataset()
 
 	sli, err := c.DerivedColumns.Create(ctx, dataset, &honeycombio.DerivedColumn{
-		Alias:      "sli." + acctest.RandString(8),
+		Alias:      test.RandomStringWithPrefix("test.", 8),
 		Expression: "BOOL(1)",
 	})
 	require.NoError(t, err)


### PR DESCRIPTION
Renaming a DC in use as an SLI is denied as it is in use. In an effort make it easier, we'll more or less match the UI behaviour and re-create an SLO if it's SLI changes.