### PR TITLE
fix(r/slo): recommend using lifecycle argument to avoid conflicts during derived column updates

### DIFF
--- a/docs/resources/slo.md
+++ b/docs/resources/slo.md
@@ -28,7 +28,7 @@ resource "honeycombio_slo" "slo" {
 }
 ```
 
--> **Note** As [Derived Columns](derived_column.md) cannot be deleted while in it is recommended to use the [create_before_destroy](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#create_before_destroy) lifecycle argument on your SLI resources as shown in the example above.
+-> **Note** As [Derived Columns](derived_column.md) cannot be renamed or deleted while in use, it is recommended to use the [create_before_destroy](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#create_before_destroy) lifecycle argument on your SLI resources as shown in the example above.
 This way you will avoid running into conflicts if the Derived Column needs to be recreated.
 
 ## Argument Reference

--- a/docs/resources/slo.md
+++ b/docs/resources/slo.md
@@ -12,6 +12,10 @@ resource "honeycombio_derived_column" "request_latency_sli" {
 
   # heredoc also works
   expression = file("../sli/sli.request_latency.honeycomb")
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "honeycombio_slo" "slo" {
@@ -23,6 +27,9 @@ resource "honeycombio_slo" "slo" {
   time_period       = 30
 }
 ```
+
+-> **Note** As [Derived Columns](derived_column.md) cannot be deleted while in it is recommended to use the [create_before_destroy](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#create_before_destroy) lifecycle argument on your SLI resources as shown in the example above.
+This way you will avoid running into conflicts if the Derived Column needs to be recreated.
 
 ## Argument Reference
 


### PR DESCRIPTION
Derived Columns cannot be removed while in use, which makes renaming a DC used as an SLI a bit of a footgun where you likely run into a `409 Conflict` on apply.

This updates the documented example to follow and recommend this practise.