### PR TITLE
feat(client): improve V1 api client retry behaviour

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -238,25 +238,6 @@ func (c *Client) newRequest(ctx context.Context, method, path string, body any) 
 	return req, nil
 }
 
-// retryHTTPCheck provides a callback for Client.CheckRetry which
-// will retry both rate limit (429) and server (5xx) errors.
-func (c *Client) retryHTTPCheck(ctx context.Context, resp *http.Response, err error) (bool, error) {
-	if ctx.Err() != nil {
-		return false, ctx.Err()
-	}
-	if err != nil {
-		return true, err
-	}
-
-	if resp != nil {
-		if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500 {
-			return true, nil
-		}
-	}
-
-	return false, nil
-}
-
 // urlEncodeDataset sanitizes the dataset name for when it is used as part of
 // the URL.
 func urlEncodeDataset(dataset string) string {

--- a/client/client.go
+++ b/client/client.go
@@ -19,6 +19,8 @@ import (
 
 	cleanhttp "github.com/hashicorp/go-cleanhttp"
 	retryablehttp "github.com/hashicorp/go-retryablehttp"
+
+	"github.com/honeycombio/terraform-provider-honeycombio/client/internal/limits"
 )
 
 const (
@@ -128,13 +130,13 @@ func NewClientWithConfig(config *Config) (*Client, error) {
 	}
 
 	client.httpClient = &retryablehttp.Client{
-		Backoff:      retryablehttp.DefaultBackoff,
-		CheckRetry:   client.retryHTTPCheck,
+		Backoff:      limits.RetryHTTPBackoff,
+		CheckRetry:   limits.RetryHTTPCheck,
 		ErrorHandler: retryablehttp.PassthroughErrorHandler,
 		HTTPClient:   cfg.HTTPClient,
 		RetryWaitMin: 200 * time.Millisecond,
-		RetryWaitMax: 10 * time.Second,
-		RetryMax:     15,
+		RetryWaitMax: time.Minute,
+		RetryMax:     30,
 	}
 
 	if config.Debug {

--- a/client/internal/limits/limits_test.go
+++ b/client/internal/limits/limits_test.go
@@ -1,4 +1,4 @@
-package v2
+package limits
 
 import (
 	"net/http"


### PR DESCRIPTION
With rate limit feedback headers now standard across the V1 and V2 APIs, this tiny refactor has the V1 API client share the retry logic with the V2 API client ✨ 