### PR TITLE
chore(ci): don't highlight skipped tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -119,7 +119,7 @@ jobs:
         uses: test-summary/action@v2
         with:
           paths: "*-report.xml"
-          show: "fail, skip"
+          show: "fail"
 
   test-eu:
     name: Test EU
@@ -214,4 +214,4 @@ jobs:
         uses: test-summary/action@v2
         with:
           paths: "*-report.xml"
-          show: "fail, skip"
+          show: "fail"


### PR DESCRIPTION
Skipped tests are about to become more common as we have some features that only work in E&S vs Classic teams.

No need to highlight on the CI summary page.