### PR TITLE
feat(slo): add md slo support for resource slo

### DIFF
--- a/docs/resources/slo.md
+++ b/docs/resources/slo.md
@@ -21,7 +21,7 @@ resource "honeycombio_derived_column" "request_latency_sli" {
 resource "honeycombio_slo" "slo" {
   name              = "Latency SLO"
   description       = "example of an SLO"
-  dataset           = var.dataset
+  datasets          = [var.dataset]
   sli               = honeycombio_derived_column.request_latency_sli.alias
   target_percentage = 99.9
   time_period       = 30
@@ -37,7 +37,11 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the SLO.
 * `description` - (Optional) A description of the SLO's intent and context.
-* `dataset` - (Required) The dataset this SLO is created in. Must be the same dataset as the SLI unless the SLI's dataset is `"__all__"`.
+* `dataset` - (Deprecated, conflicts with `datasets`) The dataset this SLO is created in. Must be the same dataset as the SLI unless the SLI's dataset is `"__all__"`.
+  * If `dataset` is not configured, `datasets` must be configured. 
+* `datasets` - (Required, conflicts with `dataset`) Array of datasets the SLO is evaluated on.
+  * If `datasets` is not configured, `dataset` must be configured.
+  * Must be >= 1 and <= 10. 
 * `sli` - (Required) The alias of the Derived Column that will be used as the SLI to indicate event success.
 The derived column used as the SLI must be in the same dataset as the SLO. Additionally,
 the column evaluation should consistently return nil, true, or false, as these are the only valid values for an SLI.


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
https://app.asana.com/0/1205961717360815/1207770326676046/f

## Short description of the changes
Adds multi-dataset support for resource/slo. Deprecates the `dataset` argument and adds `datasets` to replace it. These arguments conflict with each other where at least one of these arguments are required however. 

## How to verify that this has the expected result
Added unit tests, but you can also verify manually by creating a TF file that uses the datasets argument with at least 1 dataset and verify creating/updating/deleting works without needing to use `dataset` argument:
![Screenshot 2025-03-19 at 4 13 26 PM](https://github.com/user-attachments/assets/daa93ce3-98a2-4c4d-93b3-eaac53cde85b)
 