### PR TITLE
feat(r/burn_alert): add multi-dataset support

### DIFF
--- a/docs/resources/burn_alert.md
+++ b/docs/resources/burn_alert.md
@@ -1,13 +1,14 @@
 # Resource: honeycombio_burn_alert
 
-Creates a burn alert. 
+Creates a burn alert.
 
-For more information about burn alerts, 
+For more information about burn alerts,
 check out [Define Burn Alerts](https://docs.honeycomb.io/working-with-your-data/slos/burn-alerts).
 
 ## Example Usage
 
 ### Basic Example - Exhaustion Time Burn Alert
+
 ```hcl
 variable "dataset" {
   type = string
@@ -39,6 +40,7 @@ resource "honeycombio_burn_alert" "example_alert" {
 ```
 
 ### Basic Example - Budget Rate Burn Alert
+
 ```hcl
 variable "dataset" {
   type = string
@@ -66,6 +68,7 @@ resource "honeycombio_burn_alert" "example_alert" {
 ```
 
 ### Example - Exhaustion Time Burn Alert with PagerDuty Recipient and Severity
+
 ```hcl
 variable "dataset" {
   type = string
@@ -101,6 +104,7 @@ resource "honeycombio_burn_alert" "example_alert" {
 ```
 
 ### Example - Exhaustion Time Burn Alert with Webhook Recipient and Notification Variable
+
 ```hcl
 variable "dataset" {
   type = string
@@ -110,7 +114,7 @@ variable "slo_id" {
   type = string
 }
 
-data "honeycombio_recipient" "custom_webhook" { 
+data "honeycombio_recipient" "custom_webhook" {
     type = "webhook"
 
     detail_filter {
@@ -119,7 +123,7 @@ data "honeycombio_recipient" "custom_webhook" {
     }
 }
 
-resource "honeycombio_burn_alert" "example_alert" { 
+resource "honeycombio_burn_alert" "example_alert" {
     exhaustion_minutes = 60
     description        = "Burn alert description"
     dataset            = var.dataset
@@ -141,42 +145,42 @@ resource "honeycombio_burn_alert" "example_alert" {
 }
 ```
 
-
 ## Argument Reference
 
 The following arguments are supported:
-* `slo_id` - (Required) ID of the SLO this burn alert is associated with.
-* `dataset` - (Optional) The dataset this burn alert is associated with. Will be deprecated in a future release of the provider.
-* `description` - (Optional) A description for this Burn Alert.
-* `alert_type` - (Optional) Type of the burn alert. Valid values are `exhaustion_time` and `budget_rate`. 
-   Defaults to `exhaustion_time`.
-* `budget_rate_window_minutes` - (Optional) The time period, in minutes, over which a budget rate will be calculated. 
-   Must be between 60 and the associated SLO's time period.
-   Required when `alert_type` is `budget_rate`.
-   Must not be provided when `alert_type` is `exhaustion_time`.
-* `budget_rate_decrease_percent` - (Optional) The percent the budget has decreased over the budget rate window.
-   The alert will fire when this budget decrease threshold is reached.
-   Must be between 0.0001% and 100%, with no more than 4 numbers past the decimal point.
-   Required when `alert_type` is `budget_rate`.
-   Must not be provided when `alert_type` is `exhaustion_time`.
-* `exhaustion_minutes` - (Optional) The amount of time, in minutes, remaining before the SLO's error budget will be exhausted and 
-   the alert will fire.
-   Must be 0 or greater.
-   Required when `alert_type` is `exhaustion_time`.
-   Must not be provided when `alert_type` is `budget_rate`.
-* `recipient` - (Required) Zero or more configuration blocks (described below) with the recipients to notify when the alert fires.
+
+-   `slo_id` - (Required) ID of the SLO this burn alert is associated with.
+-   `dataset` - (Optional) The dataset this burn alert is associated with. Will be deprecated in a future release of the provider.
+-   `description` - (Optional) A description for this Burn Alert.
+-   `alert_type` - (Optional) Type of the burn alert. Valid values are `exhaustion_time` and `budget_rate`.
+    Defaults to `exhaustion_time`.
+-   `budget_rate_window_minutes` - (Optional) The time period, in minutes, over which a budget rate will be calculated.
+    Must be between 60 and the associated SLO's time period.
+    Required when `alert_type` is `budget_rate`.
+    Must not be provided when `alert_type` is `exhaustion_time`.
+-   `budget_rate_decrease_percent` - (Optional) The percent the budget has decreased over the budget rate window.
+    The alert will fire when this budget decrease threshold is reached.
+    Must be between 0.0001% and 100%, with no more than 4 numbers past the decimal point.
+    Required when `alert_type` is `budget_rate`.
+    Must not be provided when `alert_type` is `exhaustion_time`.
+-   `exhaustion_minutes` - (Optional) The amount of time, in minutes, remaining before the SLO's error budget will be exhausted and
+    the alert will fire.
+    Must be 0 or greater.
+    Required when `alert_type` is `exhaustion_time`.
+    Must not be provided when `alert_type` is `budget_rate`.
+-   `recipient` - (Required) Zero or more configuration blocks (described below) with the recipients to notify when the alert fires.
 
 Each burn alert configuration may have one or more `recipient` blocks, which each accept the following arguments. A recipient block can either refer to an existing recipient (a recipient that is already present in another burn alert or trigger) or a new recipient. When specifying an existing recipient, only `id` may be set. If you pass in a recipient without its ID and only include the type and target, Honeycomb will make a best effort to match to an existing recipient. To retrieve the ID of an existing recipient, refer to the [`honeycombio_recipient`](../data-sources/recipient.md) data source.
 
-* `type` - (Optional) The type of the recipient, allowed types are `email`, `pagerduty`, `msteams`, `slack` and `webhook`. Should not be used in combination with `id`.
-* `target` - (Optional) Target of the recipient, this has another meaning depending on the type of recipient (see the table below). Should not be used in combination with `id`.
-* `id` - (Optional) The ID of an already existing recipient. Should not be used in combination with `type` and `target`.
-* `notification_details` - (Optional) a block of additional details to send along with the notification. Supported details are described below.
-  * `pagerduty_severity` - (Optional) Indicates the severity of an alert and has a default value of `critical` but can be set to one of `info`, `warning`, `error`, or `critical` and must be used in combination with a PagerDuty recipient.
-  * `variable` - (Optional) Up to 10 configuration blocks with a `name` and a `value` to override the default variable value. Must be used in combination with a Webhook recipient that already has a variable with the same name configured.
+-   `type` - (Optional) The type of the recipient, allowed types are `email`, `pagerduty`, `msteams`, `slack` and `webhook`. Should not be used in combination with `id`.
+-   `target` - (Optional) Target of the recipient, this has another meaning depending on the type of recipient (see the table below). Should not be used in combination with `id`.
+-   `id` - (Optional) The ID of an already existing recipient. Should not be used in combination with `type` and `target`.
+-   `notification_details` - (Optional) a block of additional details to send along with the notification. Supported details are described below.
+    -   `pagerduty_severity` - (Optional) Indicates the severity of an alert and has a default value of `critical` but can be set to one of `info`, `warning`, `error`, or `critical` and must be used in combination with a PagerDuty recipient.
+    -   `variable` - (Optional) Up to 10 configuration blocks with a `name` and a `value` to override the default variable value. Must be used in combination with a Webhook recipient that already has a variable with the same name configured.
 
 | Type      | Target              |
-|-----------|---------------------|
+| --------- | ------------------- |
 | email     | an email address    |
 | pagerduty | _N/A_               |
 | slack     | name of the channel |
@@ -186,13 +190,13 @@ Each burn alert configuration may have one or more `recipient` blocks, which eac
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - ID of the burn alert.
+-   `id` - ID of the burn alert.
 
 ## Import
 
 Burn alerts can be imported using a combination of the dataset name and their ID, e.g.
 
-For multi-dataset burn alerts, replace dataset name with `__all__`.
+For multi-dataset burn alerts, just pass in their ID.
 
 ```
 $ terraform import honeycombio_burn_alert.my_alert my-dataset/bj9BwOb1uKz

--- a/docs/resources/burn_alert.md
+++ b/docs/resources/burn_alert.md
@@ -192,6 +192,8 @@ In addition to all arguments above, the following attributes are exported:
 
 Burn alerts can be imported using a combination of the dataset name and their ID, e.g.
 
+For multi-dataset burn alerts, replace dataset name with `__all__`.
+
 ```
 $ terraform import honeycombio_burn_alert.my_alert my-dataset/bj9BwOb1uKz
 ```

--- a/docs/resources/burn_alert.md
+++ b/docs/resources/burn_alert.md
@@ -146,7 +146,7 @@ resource "honeycombio_burn_alert" "example_alert" {
 
 The following arguments are supported:
 * `slo_id` - (Required) ID of the SLO this burn alert is associated with.
-* `dataset` - (Required) The dataset this burn alert is associated with.
+* `dataset` - (Optional) The dataset this burn alert is associated with. Will be deprecated in a future release of the provider.
 * `description` - (Optional) A description for this Burn Alert.
 * `alert_type` - (Optional) Type of the burn alert. Valid values are `exhaustion_time` and `budget_rate`. 
    Defaults to `exhaustion_time`.

--- a/docs/resources/burn_alert.md
+++ b/docs/resources/burn_alert.md
@@ -194,10 +194,17 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-Burn alerts can be imported using a combination of the dataset name and their ID, e.g.
+Burn alerts can be imported using by using their ID combined with their dataset.
+If the burn alert is a multi-dataset (MD) burn alert, the dataset is not provided.
 
-For multi-dataset burn alerts, just pass in their ID.
+### Burn Alert
 
 ```
 $ terraform import honeycombio_burn_alert.my_alert my-dataset/bj9BwOb1uKz
+```
+
+### Multi-dataset Burn Alert
+
+```
+$ terraform import honeycombio_burn_alert.my_alert bc9XwOb2yJu
 ```

--- a/docs/resources/slo.md
+++ b/docs/resources/slo.md
@@ -87,8 +87,19 @@ SLOs can be imported using a combination of the dataset name and their ID, e.g.
 
 For multi-dataset SLOs, just pass in their ID.
 
+SLOs can be imported using by using their ID combined with their dataset.
+If the SLO is a multi-dataset (MD) SLO, the dataset is not provided.
+
+### SLO
+
 ```
 $ terraform import honeycombio_slo.my_slo my-dataset/bj9BwOb1uKz
+```
+
+### Multi-dataset SLO
+
+```
+$ terraform import honeycombio_slo.my_slo bj9BwOb1uKz
 ```
 
 You can find the ID in the URL bar when visiting the SLO from the UI.

--- a/docs/resources/slo.md
+++ b/docs/resources/slo.md
@@ -3,6 +3,7 @@
 Creates a service level objective (SLO). For more information about SLOs, check out [Set Service Level Objectives (SLOs)](https://docs.honeycomb.io/working-with-your-data/slos/).
 
 ## Example Usage
+### Single Dataset SLO
 
 ```hcl
 resource "honeycombio_derived_column" "request_latency_sli" {
@@ -28,6 +29,32 @@ resource "honeycombio_slo" "slo" {
 }
 ```
 
+### Multi-Dataset SLO
+
+```hcl
+resource "honeycombio_derived_column" "request_latency_sli" {
+  alias       = "sli.request_latency"
+  description = "SLI: request latency less than 300ms"
+  dataset     = "__all__"
+
+  # heredoc also works
+  expression = file("../sli/sli.request_latency.honeycomb")
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "honeycombio_slo" "slo" {
+  name              = "Latency SLO"
+  description       = "example of an SLO"
+  datasets          = [var.dataset1, var.dataset2]
+  sli               = honeycombio_derived_column.request_latency_sli.alias
+  target_percentage = 99.9
+  time_period       = 30
+}
+```
+
 -> **Note** As [Derived Columns](derived_column.md) cannot be renamed or deleted while in use, it is recommended to use the [create_before_destroy](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#create_before_destroy) lifecycle argument on your SLI resources as shown in the example above.
 This way you will avoid running into conflicts if the Derived Column needs to be recreated.
 
@@ -37,12 +64,15 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the SLO.
 * `description` - (Optional) A description of the SLO's intent and context.
-* `dataset` - (Required) The dataset this SLO is created in. Must be the same dataset as the SLI unless the SLI's dataset is `"__all__"`.
+* `dataset` - (Optional) The dataset this SLO is created in. Must be the same dataset as the SLI unless the SLI's dataset is `"__all__"`. Conflicts with `datasets`. Will be deprecated in a future release of the provider.
+* `datasets` - (Optional) Array of datasets the SLO is evaluated on. Conflicts with `dataset`. Must have a length between 1 and 10.
 * `sli` - (Required) The alias of the Derived Column that will be used as the SLI to indicate event success.
 The derived column used as the SLI must be in the same dataset as the SLO. Additionally,
 the column evaluation should consistently return nil, true, or false, as these are the only valid values for an SLI.
 * `target_percentage` - (Required) The percentage of qualified events that you expect to succeed during the `time_period`.
 * `time_period` - (Required) The time period, in days, over which your SLO will be evaluated.
+
+~> **Note** `dataset` will be deprecated in a future release. In the meantime, you can swap `dataset` with a single value array for `datasets` to effectively evaluate to the same configuration.
 
 ## Attribute Reference
 

--- a/docs/resources/slo.md
+++ b/docs/resources/slo.md
@@ -84,6 +84,8 @@ In addition to all arguments above, the following attributes are exported:
 
 SLOs can be imported using a combination of the dataset name and their ID, e.g.
 
+For multi-dataset SLOs, replace dataset name with `__all__`.
+
 ```
 $ terraform import honeycombio_slo.my_slo my-dataset/bj9BwOb1uKz
 ```

--- a/docs/resources/slo.md
+++ b/docs/resources/slo.md
@@ -3,6 +3,7 @@
 Creates a service level objective (SLO). For more information about SLOs, check out [Set Service Level Objectives (SLOs)](https://docs.honeycomb.io/working-with-your-data/slos/).
 
 ## Example Usage
+
 ### Single Dataset SLO
 
 ```hcl
@@ -62,15 +63,15 @@ This way you will avoid running into conflicts if the Derived Column needs to be
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the SLO.
-* `description` - (Optional) A description of the SLO's intent and context.
-* `dataset` - (Optional) The dataset this SLO is created in. Must be the same dataset as the SLI unless the SLI's dataset is `"__all__"`. Conflicts with `datasets`. Will be deprecated in a future release of the provider.
-* `datasets` - (Optional) Array of datasets the SLO is evaluated on. Conflicts with `dataset`. Must have a length between 1 and 10.
-* `sli` - (Required) The alias of the Derived Column that will be used as the SLI to indicate event success.
-The derived column used as the SLI must be in the same dataset as the SLO. Additionally,
-the column evaluation should consistently return nil, true, or false, as these are the only valid values for an SLI.
-* `target_percentage` - (Required) The percentage of qualified events that you expect to succeed during the `time_period`.
-* `time_period` - (Required) The time period, in days, over which your SLO will be evaluated.
+-   `name` - (Required) The name of the SLO.
+-   `description` - (Optional) A description of the SLO's intent and context.
+-   `dataset` - (Optional) The dataset this SLO is created in. Must be the same dataset as the SLI unless the SLI's dataset is `"__all__"`. Conflicts with `datasets`. Will be deprecated in a future release of the provider.
+-   `datasets` - (Optional) Array of datasets the SLO is evaluated on. Conflicts with `dataset`. Must have a length between 1 and 10.
+-   `sli` - (Required) The alias of the Derived Column that will be used as the SLI to indicate event success.
+    The derived column used as the SLI must be in the same dataset as the SLO. Additionally,
+    the column evaluation should consistently return nil, true, or false, as these are the only valid values for an SLI.
+-   `target_percentage` - (Required) The percentage of qualified events that you expect to succeed during the `time_period`.
+-   `time_period` - (Required) The time period, in days, over which your SLO will be evaluated.
 
 ~> **Note** `dataset` will be deprecated in a future release. In the meantime, you can swap `dataset` with a single value array for `datasets` to effectively evaluate to the same configuration.
 
@@ -78,13 +79,13 @@ the column evaluation should consistently return nil, true, or false, as these a
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - ID of the SLO.
+-   `id` - ID of the SLO.
 
 ## Import
 
 SLOs can be imported using a combination of the dataset name and their ID, e.g.
 
-For multi-dataset SLOs, replace dataset name with `__all__`.
+For multi-dataset SLOs, just pass in their ID.
 
 ```
 $ terraform import honeycombio_slo.my_slo my-dataset/bj9BwOb1uKz

--- a/honeycombio/resource_slo.go
+++ b/honeycombio/resource_slo.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
-	"github.com/honeycombio/terraform-provider-honeycombio/client"
 	honeycombio "github.com/honeycombio/terraform-provider-honeycombio/client"
 	"github.com/honeycombio/terraform-provider-honeycombio/internal/helper"
 )
@@ -91,16 +90,17 @@ the column evaluation should consistently return nil, true, or false, as these a
 
 func resourceSLOImport(ctx context.Context, d *schema.ResourceData, i interface{}) ([]*schema.ResourceData, error) {
 	// import ID is of the format <dataset>/<SLO ID>
-	// To import MD SLOs, format will be __all__/<SLO ID>
+	// To import MD SLOs, just pass in the <SLO ID>
 	dataset, id, found := strings.Cut(d.Id(), "/")
+
+	// if seperator not found, we will assume its the bare id
+	// if thats the case, we need to reassign values since strings.Cut would return (id, "", false)
 	if !found {
-		return nil, errors.New("invalid import ID, supplied ID must be written as <dataset>/<SLO ID>")
+		id = dataset
+		dataset = ""
 	}
 
-	if dataset != client.EnvironmentWideSlug {
-		d.Set("dataset", dataset)
-	}
-
+	d.Set("dataset", dataset)
 	d.SetId(id)
 
 	return []*schema.ResourceData{d}, nil

--- a/honeycombio/resource_slo.go
+++ b/honeycombio/resource_slo.go
@@ -97,10 +97,10 @@ func resourceSLOImport(ctx context.Context, d *schema.ResourceData, i interface{
 	// if thats the case, we need to reassign values since strings.Cut would return (id, "", false)
 	if !found {
 		id = dataset
-		dataset = ""
+	} else {
+		d.Set("dataset", dataset)
 	}
 
-	d.Set("dataset", dataset)
 	d.SetId(id)
 
 	return []*schema.ResourceData{d}, nil

--- a/honeycombio/resource_slo.go
+++ b/honeycombio/resource_slo.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
+	"github.com/honeycombio/terraform-provider-honeycombio/client"
 	honeycombio "github.com/honeycombio/terraform-provider-honeycombio/client"
 	"github.com/honeycombio/terraform-provider-honeycombio/internal/helper"
 )
@@ -90,12 +91,16 @@ the column evaluation should consistently return nil, true, or false, as these a
 
 func resourceSLOImport(ctx context.Context, d *schema.ResourceData, i interface{}) ([]*schema.ResourceData, error) {
 	// import ID is of the format <dataset>/<SLO ID>
+	// To import MD SLOs, format will be __all__/<SLO ID>
 	dataset, id, found := strings.Cut(d.Id(), "/")
 	if !found {
 		return nil, errors.New("invalid import ID, supplied ID must be written as <dataset>/<SLO ID>")
 	}
 
-	d.Set("dataset", dataset)
+	if dataset != client.EnvironmentWideSlug {
+		d.Set("dataset", dataset)
+	}
+
 	d.SetId(id)
 
 	return []*schema.ResourceData{d}, nil

--- a/honeycombio/resource_slo.go
+++ b/honeycombio/resource_slo.go
@@ -89,11 +89,9 @@ the column evaluation should consistently return nil, true, or false, as these a
 }
 
 func resourceSLOImport(ctx context.Context, d *schema.ResourceData, i interface{}) ([]*schema.ResourceData, error) {
-	// import ID is of the format <dataset>/<SLO ID>
-	// To import MD SLOs, just pass in the <SLO ID>
 	dataset, id, found := strings.Cut(d.Id(), "/")
 
-	// if separator not found, we will assume its the bare id
+	// if dataset separator not found, we will assume its the bare id
 	// if thats the case, we need to reassign values since strings.Cut would return (id, "", false)
 	if !found {
 		id = dataset

--- a/honeycombio/resource_slo.go
+++ b/honeycombio/resource_slo.go
@@ -93,7 +93,7 @@ func resourceSLOImport(ctx context.Context, d *schema.ResourceData, i interface{
 	// To import MD SLOs, just pass in the <SLO ID>
 	dataset, id, found := strings.Cut(d.Id(), "/")
 
-	// if seperator not found, we will assume its the bare id
+	// if separator not found, we will assume its the bare id
 	// if thats the case, we need to reassign values since strings.Cut would return (id, "", false)
 	if !found {
 		id = dataset

--- a/honeycombio/resource_slo_test.go
+++ b/honeycombio/resource_slo_test.go
@@ -137,13 +137,7 @@ func TestHoneycombSLO_MD(t *testing.T) {
 				ResourceName:      "honeycombio_slo.md_test",
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateIdFunc: func(s *terraform.State) (string, error) {
-					rs, ok := s.RootModule().Resources["honeycombio_slo.md_test"]
-					if !ok {
-						return "", fmt.Errorf("resource not found in state")
-					}
-					return rs.Primary.ID, nil
-				},
+				ImportStateId:     mdSLO.ID,
 			},
 		},
 	})

--- a/honeycombio/resource_slo_test.go
+++ b/honeycombio/resource_slo_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/honeycombio/terraform-provider-honeycombio/client"
 	honeycombio "github.com/honeycombio/terraform-provider-honeycombio/client"
 	"github.com/honeycombio/terraform-provider-honeycombio/internal/helper"
 	"github.com/honeycombio/terraform-provider-honeycombio/internal/helper/test"
@@ -143,7 +142,7 @@ func TestHoneycombSLO_MD(t *testing.T) {
 					if !ok {
 						return "", fmt.Errorf("resource not found in state")
 					}
-					return fmt.Sprintf("%s/%s", client.EnvironmentWideSlug, rs.Primary.ID), nil
+					return fmt.Sprintf("%s", rs.Primary.ID), nil
 				},
 			},
 		},

--- a/honeycombio/resource_slo_test.go
+++ b/honeycombio/resource_slo_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	honeycombio "github.com/honeycombio/terraform-provider-honeycombio/client"
+	"github.com/honeycombio/terraform-provider-honeycombio/internal/helper"
+	"github.com/honeycombio/terraform-provider-honeycombio/internal/helper/test"
 )
 
 func TestAccHoneycombioSLO_basic(t *testing.T) {
@@ -26,6 +28,7 @@ func TestAccHoneycombioSLO_basic(t *testing.T) {
 				Config: testAccConfigSLO_basic(dataset, sliAlias),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSLOExists(t, "honeycombio_slo.test", slo),
+					resource.TestCheckResourceAttr("honeycombio_slo.test", "dataset", dataset),
 					resource.TestCheckResourceAttr("honeycombio_slo.test", "name", "TestAcc SLO"),
 					resource.TestCheckResourceAttr("honeycombio_slo.test", "description", "integration test SLO"),
 					resource.TestCheckResourceAttr("honeycombio_slo.test", "sli", sliAlias),
@@ -67,6 +70,73 @@ func TestAccHoneycombioSLO_RecreateOnNotFound(t *testing.T) {
 	})
 }
 
+func TestAccHoneycombioSLO_dataset_deprecation(t *testing.T) {
+	dataset, sliAlias := sloAccTestSetup(t)
+	slo := &honeycombio.SLO{}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 testAccPreCheck(t),
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfigSLO_basic(dataset, sliAlias),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSLOExists(t, "honeycombio_slo.test", slo),
+					resource.TestCheckResourceAttr("honeycombio_slo.test", "dataset", dataset),
+					resource.TestCheckResourceAttr("honeycombio_slo.test", "name", "TestAcc SLO"),
+					resource.TestCheckResourceAttr("honeycombio_slo.test", "description", "integration test SLO"),
+					resource.TestCheckResourceAttr("honeycombio_slo.test", "sli", sliAlias),
+					resource.TestCheckResourceAttr("honeycombio_slo.test", "target_percentage", "99.95"),
+					resource.TestCheckResourceAttr("honeycombio_slo.test", "time_period", "30"),
+				),
+			},
+			// update the config to swap out dataset for datasets and ensure nothing changes
+			{
+				Config: testAccConfigSLO_dataset_deprecation(dataset, sliAlias),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("honeycombio_slo.test", "datasets.#", "1"),
+					resource.TestCheckTypeSetElemAttr("honeycombio_slo.md_test", "datasets.*", dataset),
+				),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+func TestHoneycombSLO_MD(t *testing.T) {
+	client := testAccClient(t)
+	if client.IsClassic(context.Background()) {
+		t.Skip("MD SLOs are not supported in classic")
+	}
+	dataset1, dataset2, mdSLI := mdSLOAccTestSetup(t)
+
+	mdSLO := &honeycombio.SLO{}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 testAccPreCheck(t),
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfigSLO_md(dataset1.Slug, dataset2.Slug, mdSLI.Alias),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSLOExists(t, "honeycombio_slo.md_test", mdSLO),
+					resource.TestCheckResourceAttr("honeycombio_slo.md_test", "name", "TestAcc MD SLO"),
+					resource.TestCheckNoResourceAttr("honeycombio_slo.md_test", "dataset"),
+					resource.TestCheckResourceAttr("honeycombio_slo.md_test", "datasets.#", "2"),
+					resource.TestCheckTypeSetElemAttr("honeycombio_slo.md_test", "datasets.*", dataset1.Slug),
+					resource.TestCheckTypeSetElemAttr("honeycombio_slo.md_test", "datasets.*", dataset2.Slug),
+					resource.TestCheckResourceAttr("honeycombio_slo.md_test", "description", "integration test MD SLO"),
+					resource.TestCheckResourceAttr("honeycombio_slo.md_test", "sli", mdSLI.Alias),
+					resource.TestCheckResourceAttr("honeycombio_slo.md_test", "target_percentage", "99.95"),
+					resource.TestCheckResourceAttr("honeycombio_slo.md_test", "time_period", "30"),
+				),
+			},
+		},
+	})
+
+}
+
 func testAccConfigSLO_basic(dataset, sliAlias string) string {
 	return fmt.Sprintf(`
 	resource "honeycombio_slo" "test" {
@@ -80,6 +150,32 @@ func testAccConfigSLO_basic(dataset, sliAlias string) string {
 	`, dataset, sliAlias)
 }
 
+func testAccConfigSLO_dataset_deprecation(dataset, sliAlias string) string {
+	return fmt.Sprintf(`
+	resource "honeycombio_slo" "test" {
+		name              = "TestAcc SLO"
+		description       = "integration test SLO"
+		datasets          = ["%s"]
+		sli               = "%s"
+		target_percentage = 99.95
+		time_period       = 30
+	}
+	`, dataset, sliAlias)
+}
+
+func testAccConfigSLO_md(dataset1Slug, dataset2Slug, sliAlias string) string {
+	return fmt.Sprintf(`
+	resource "honeycombio_slo" "md_test" {
+		name              = "TestAcc MD SLO"
+		description       = "integration test MD SLO"
+		sli               = "%s"
+		target_percentage = 99.95
+		time_period       = 30
+		datasets     	  = ["%s", "%s"]
+	}
+	`, sliAlias, dataset1Slug, dataset2Slug)
+}
+
 func testAccCheckSLOExists(t *testing.T, name string, slo *honeycombio.SLO) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		resourceState, ok := s.RootModule().Resources[name]
@@ -88,7 +184,7 @@ func testAccCheckSLOExists(t *testing.T, name string, slo *honeycombio.SLO) reso
 		}
 
 		client := testAccClient(t)
-		rslo, err := client.SLOs.Get(context.Background(), resourceState.Primary.Attributes["dataset"], resourceState.Primary.ID)
+		rslo, err := client.SLOs.Get(context.Background(), honeycombio.EnvironmentWideSlug, resourceState.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("failed to fetch created SLO: %w", err)
 		}
@@ -118,4 +214,56 @@ func sloAccTestSetup(t *testing.T) (string, string) {
 	})
 
 	return dataset, sli.Alias
+}
+
+func mdSLOAccTestSetup(t *testing.T) (honeycombio.Dataset, honeycombio.Dataset, honeycombio.DerivedColumn) {
+	t.Helper()
+
+	ctx := context.Background()
+	c := testAccClient(t)
+
+	dataset1, err := c.Datasets.Create(ctx, &honeycombio.Dataset{
+		Name:        "test." + acctest.RandString(8),
+		Description: "test dataset 1",
+	})
+	require.NoError(t, err)
+
+	dataset2, err := c.Datasets.Create(ctx, &honeycombio.Dataset{
+		Name:        "test." + acctest.RandString(8),
+		Description: "test dataset 2",
+	})
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		c.Datasets.Update(ctx, &honeycombio.Dataset{
+			Slug: dataset1.Slug,
+			Settings: honeycombio.DatasetSettings{
+				DeleteProtected: helper.ToPtr(false),
+			},
+		})
+		err = c.Datasets.Delete(ctx, dataset1.Slug)
+		require.NoError(t, err)
+
+		c.Datasets.Update(ctx, &honeycombio.Dataset{
+			Slug: dataset2.Slug,
+			Settings: honeycombio.DatasetSettings{
+				DeleteProtected: helper.ToPtr(false),
+			},
+		})
+		err = c.Datasets.Delete(ctx, dataset2.Slug)
+		require.NoError(t, err)
+	})
+
+	sli, err := c.DerivedColumns.Create(ctx, honeycombio.EnvironmentWideSlug, &honeycombio.DerivedColumn{
+		Alias:       test.RandomStringWithPrefix("test.", 10),
+		Description: "test SLI",
+		Expression:  "BOOL(1)",
+	})
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		c.DerivedColumns.Delete(ctx, honeycombio.EnvironmentWideSlug, sli.ID)
+	})
+
+	return *dataset1, *dataset2, *sli
 }

--- a/honeycombio/resource_slo_test.go
+++ b/honeycombio/resource_slo_test.go
@@ -142,7 +142,7 @@ func TestHoneycombSLO_MD(t *testing.T) {
 					if !ok {
 						return "", fmt.Errorf("resource not found in state")
 					}
-					return fmt.Sprintf("%s", rs.Primary.ID), nil
+					return rs.Primary.ID, nil
 				},
 			},
 		},

--- a/internal/helper/dataset.go
+++ b/internal/helper/dataset.go
@@ -1,0 +1,13 @@
+package helper
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/honeycombio/terraform-provider-honeycombio/client"
+)
+
+func GetDatasetString(dataset types.String) types.String {
+	if dataset == types.StringNull() {
+		return types.StringValue(client.EnvironmentWideSlug)
+	}
+	return dataset
+}

--- a/internal/helper/dataset.go
+++ b/internal/helper/dataset.go
@@ -2,6 +2,7 @@ package helper
 
 import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
 	"github.com/honeycombio/terraform-provider-honeycombio/client"
 )
 

--- a/internal/helper/dataset.go
+++ b/internal/helper/dataset.go
@@ -7,7 +7,7 @@ import (
 )
 
 func GetDatasetString(dataset types.String) types.String {
-	if dataset == types.StringNull() {
+	if dataset == types.StringNull() || dataset.ValueString() == "" {
 		return types.StringValue(client.EnvironmentWideSlug)
 	}
 	return dataset

--- a/internal/helper/modifiers/dataset_deprecation.go
+++ b/internal/helper/modifiers/dataset_deprecation.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 type datasetDeprecation struct{}
@@ -23,8 +24,9 @@ func (m datasetDeprecation) PlanModifyString(ctx context.Context, req planmodifi
 	if req.Plan.Raw.IsNull() {
 		return
 	}
-	// Do nothing if the plan or state is not yet known.
+	// Assign null value if the plan value is unknown or theres no state value to fall back on
 	if req.PlanValue.IsUnknown() || req.StateValue.IsUnknown() {
+		resp.PlanValue = types.StringNull()
 		return
 	}
 

--- a/internal/helper/modifiers/dataset_deprecation.go
+++ b/internal/helper/modifiers/dataset_deprecation.go
@@ -1,0 +1,46 @@
+package modifiers
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+type datasetDeprecation struct{}
+
+var _ planmodifier.String = &datasetDeprecation{}
+
+func (m datasetDeprecation) Description(_ context.Context) string {
+	return "Avoids unnecessary plans if dataset becomes omitted. Configuration should now behave the same."
+}
+
+func (m datasetDeprecation) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m datasetDeprecation) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	// Do nothing on resource destroy.
+	if req.Plan.Raw.IsNull() {
+		return
+	}
+	// Do nothing if the plan or state is not yet known.
+	if req.PlanValue.IsUnknown() || req.StateValue.IsUnknown() {
+		return
+	}
+
+	// Suppress diff if the old and new values are equal
+	if req.PlanValue.Equal(req.StateValue) {
+		resp.PlanValue = req.StateValue
+		return
+	}
+	// Suppress diff if the new value is empty
+	if req.PlanValue.IsNull() {
+		resp.PlanValue = req.StateValue
+		return
+	}
+}
+
+// DatasetDeprecation avoids unnecessary plans if dataset becomes omitted. Configuration should now behave the same.
+func DatasetDeprecation() planmodifier.String {
+	return datasetDeprecation{}
+}

--- a/internal/helper/modifiers/dataset_deprecation.go
+++ b/internal/helper/modifiers/dataset_deprecation.go
@@ -40,6 +40,12 @@ func (m datasetDeprecation) PlanModifyString(ctx context.Context, req planmodifi
 		resp.PlanValue = req.StateValue
 		return
 	}
+
+	if !req.PlanValue.Equal(req.StateValue) {
+		// Require replacement only if the dataset value is explicitly changing
+		resp.RequiresReplace = true
+		return
+	}
 }
 
 // DatasetDeprecation avoids unnecessary plans if dataset becomes omitted. Configuration should now behave the same.

--- a/internal/provider/burn_alert_resource.go
+++ b/internal/provider/burn_alert_resource.go
@@ -98,9 +98,24 @@ func (*burnAlertResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 			},
 			"dataset": schema.StringAttribute{
 				Optional:    true,
+				Computed:    true,
 				Description: "The dataset this Burn Alert is associated with.",
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
+					stringplanmodifier.UseStateForUnknown(),
+					stringplanmodifier.RequiresReplaceIf(
+						func(ctx context.Context, sr planmodifier.StringRequest, rrifr *stringplanmodifier.RequiresReplaceIfFuncResponse) {
+							// If the dataset is empty, we don't want to require a replace
+							if sr.PlanValue.IsNull() || sr.PlanValue.IsUnknown() || sr.PlanValue.ValueString() == "" {
+								return
+							}
+							// Require replacement only if the dataset value is explicitly changing
+							if sr.PlanValue.ValueString() != sr.StateValue.ValueString() {
+								rrifr.RequiresReplace = true
+							}
+						},
+						"Dataset Change Requires Replacement",
+						"Changing the dataset requires replacing the resource.",
+					),
 				},
 			},
 			"description": schema.StringAttribute{
@@ -217,6 +232,7 @@ func (r *burnAlertResource) ValidateConfig(ctx context.Context, req resource.Val
 
 func (r *burnAlertResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	// import ID is of the format <dataset>/<BurnAlert ID>
+	// To import MD burn alerts, format will be __all__/<BurnAlert ID>
 	dataset, id, found := strings.Cut(req.ID, "/")
 	if !found {
 		resp.Diagnostics.AddError(
@@ -224,6 +240,10 @@ func (r *burnAlertResource) ImportState(ctx context.Context, req resource.Import
 			"The supplied ID must be written as <dataset>/<BurnAlert ID>.",
 		)
 		return
+	}
+
+	if dataset == client.EnvironmentWideSlug {
+		dataset = ""
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &models.BurnAlertResourceModel{

--- a/internal/provider/burn_alert_resource.go
+++ b/internal/provider/burn_alert_resource.go
@@ -232,25 +232,20 @@ func (r *burnAlertResource) ValidateConfig(ctx context.Context, req resource.Val
 }
 
 func (r *burnAlertResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	// import ID is of the format <dataset>/<BurnAlert ID>
-	// To import MD burn alerts, just pass in <BurnAlert ID>
 	dataset, id, found := strings.Cut(req.ID, "/")
 
-	// if separator not found, we will assume its the bare id
+	// if dataset separator not found, we will assume its the bare id
 	// if thats the case, we need to reassign values since strings.Cut would return (id, "", false)
+	dsValue := types.StringNull()
 	if !found {
 		id = dataset
-		resp.Diagnostics.Append(resp.State.Set(ctx, &models.BurnAlertResourceModel{
-			ID:         types.StringValue(id),
-			Dataset:    types.StringNull(),
-			Recipients: types.SetUnknown(types.ObjectType{AttrTypes: models.NotificationRecipientAttrType}),
-		})...)
-		return
+	} else {
+		dsValue = types.StringValue(dataset)
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &models.BurnAlertResourceModel{
 		ID:         types.StringValue(id),
-		Dataset:    types.StringValue(dataset),
+		Dataset:    dsValue,
 		Recipients: types.SetUnknown(types.ObjectType{AttrTypes: models.NotificationRecipientAttrType}),
 	})...)
 }

--- a/internal/provider/burn_alert_resource.go
+++ b/internal/provider/burn_alert_resource.go
@@ -236,7 +236,7 @@ func (r *burnAlertResource) ImportState(ctx context.Context, req resource.Import
 	// To import MD burn alerts, just pass in <BurnAlert ID>
 	dataset, id, found := strings.Cut(req.ID, "/")
 
-	// if seperator not found, we will assume its the bare id
+	// if separator not found, we will assume its the bare id
 	// if thats the case, we need to reassign values since strings.Cut would return (id, "", false)
 	if !found {
 		id = dataset

--- a/internal/provider/burn_alert_resource.go
+++ b/internal/provider/burn_alert_resource.go
@@ -233,22 +233,14 @@ func (r *burnAlertResource) ValidateConfig(ctx context.Context, req resource.Val
 
 func (r *burnAlertResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	// import ID is of the format <dataset>/<BurnAlert ID>
-	// To import MD burn alerts, format will be __all__/<BurnAlert ID>
+	// To import MD burn alerts, just pass in <BurnAlert ID>
 	dataset, id, found := strings.Cut(req.ID, "/")
-	if !found {
-		resp.Diagnostics.AddError(
-			"Invalid Import ID",
-			"The supplied ID must be written as <dataset>/<BurnAlert ID>.",
-		)
-		return
-	}
 
-	if dataset == client.EnvironmentWideSlug {
-		resp.Diagnostics.Append(resp.State.Set(ctx, &models.BurnAlertResourceModel{
-			ID:         types.StringValue(id),
-			Recipients: types.SetUnknown(types.ObjectType{AttrTypes: models.NotificationRecipientAttrType}),
-		})...)
-		return
+	// if seperator not found, we will assume its the bare id
+	// if thats the case, we need to reassign values since strings.Cut would return (id, "", false)
+	if !found {
+		id = dataset
+		dataset = ""
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &models.BurnAlertResourceModel{

--- a/internal/provider/burn_alert_resource.go
+++ b/internal/provider/burn_alert_resource.go
@@ -243,7 +243,11 @@ func (r *burnAlertResource) ImportState(ctx context.Context, req resource.Import
 	}
 
 	if dataset == client.EnvironmentWideSlug {
-		dataset = ""
+		resp.Diagnostics.Append(resp.State.Set(ctx, &models.BurnAlertResourceModel{
+			ID:         types.StringValue(id),
+			Recipients: types.SetUnknown(types.ObjectType{AttrTypes: models.NotificationRecipientAttrType}),
+		})...)
+		return
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &models.BurnAlertResourceModel{

--- a/internal/provider/burn_alert_resource.go
+++ b/internal/provider/burn_alert_resource.go
@@ -103,20 +103,6 @@ func (*burnAlertResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				Description: "The dataset this Burn Alert is associated with.",
 				PlanModifiers: []planmodifier.String{
 					modifiers.DatasetDeprecation(),
-					stringplanmodifier.RequiresReplaceIf(
-						func(ctx context.Context, sr planmodifier.StringRequest, rrifr *stringplanmodifier.RequiresReplaceIfFuncResponse) {
-							// If the dataset is empty, we don't want to require a replace
-							if sr.PlanValue.IsNull() || sr.PlanValue.IsUnknown() || sr.PlanValue.ValueString() == "" {
-								return
-							}
-							// Require replacement only if the dataset value is explicitly changing
-							if sr.PlanValue.ValueString() != sr.StateValue.ValueString() {
-								rrifr.RequiresReplace = true
-							}
-						},
-						"Dataset Change Requires Replacement",
-						"Changing the dataset requires replacing the resource.",
-					),
 				},
 			},
 			"description": schema.StringAttribute{

--- a/internal/provider/burn_alert_resource.go
+++ b/internal/provider/burn_alert_resource.go
@@ -240,7 +240,12 @@ func (r *burnAlertResource) ImportState(ctx context.Context, req resource.Import
 	// if thats the case, we need to reassign values since strings.Cut would return (id, "", false)
 	if !found {
 		id = dataset
-		dataset = ""
+		resp.Diagnostics.Append(resp.State.Set(ctx, &models.BurnAlertResourceModel{
+			ID:         types.StringValue(id),
+			Dataset:    types.StringNull(),
+			Recipients: types.SetUnknown(types.ObjectType{AttrTypes: models.NotificationRecipientAttrType}),
+		})...)
+		return
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &models.BurnAlertResourceModel{

--- a/internal/provider/burn_alert_resource.go
+++ b/internal/provider/burn_alert_resource.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strings"
 
+	"github.com/honeycombio/terraform-provider-honeycombio/internal/helper/modifiers"
 	"github.com/honeycombio/terraform-provider-honeycombio/internal/helper/validation"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/float64validator"
@@ -101,7 +102,7 @@ func (*burnAlertResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				Computed:    true,
 				Description: "The dataset this Burn Alert is associated with.",
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
+					modifiers.DatasetDeprecation(),
 					stringplanmodifier.RequiresReplaceIf(
 						func(ctx context.Context, sr planmodifier.StringRequest, rrifr *stringplanmodifier.RequiresReplaceIfFuncResponse) {
 							// If the dataset is empty, we don't want to require a replace

--- a/internal/provider/burn_alert_resource.go
+++ b/internal/provider/burn_alert_resource.go
@@ -102,7 +102,6 @@ func (*burnAlertResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
-				DeprecationMessage: "No longer required.",
 			},
 			"description": schema.StringAttribute{
 				Description: "A description for this Burn Alert.",
@@ -265,7 +264,7 @@ func (r *burnAlertResource) Create(ctx context.Context, req resource.CreateReque
 	}
 
 	// dataset value to use in the API call
-	dataset := getDatasetString(plan.Dataset)
+	dataset := helper.GetDatasetString(plan.Dataset)
 
 	// Create the new burn alert
 	burnAlert, err := r.client.BurnAlerts.Create(ctx, dataset.ValueString(), createRequest)
@@ -309,7 +308,7 @@ func (r *burnAlertResource) Read(ctx context.Context, req resource.ReadRequest, 
 	}
 
 	// dataset value to use in the API call
-	dataset := getDatasetString(state.Dataset)
+	dataset := helper.GetDatasetString(state.Dataset)
 
 	// Read the burn alert, using the values from state
 	var detailedErr client.DetailedError
@@ -391,7 +390,7 @@ func (r *burnAlertResource) Update(ctx context.Context, req resource.UpdateReque
 	}
 
 	// dataset value to use in the API call
-	dataset := getDatasetString(plan.Dataset)
+	dataset := helper.GetDatasetString(plan.Dataset)
 
 	// Update the burn alert
 	_, err := r.client.BurnAlerts.Update(ctx, dataset.ValueString(), updateRequest)
@@ -441,7 +440,7 @@ func (r *burnAlertResource) Delete(ctx context.Context, req resource.DeleteReque
 	}
 
 	// dataset value to use in the API call
-	dataset := getDatasetString(state.Dataset)
+	dataset := helper.GetDatasetString(state.Dataset)
 
 	// Delete the burn alert, using the values from state
 	var detailedErr client.DetailedError
@@ -462,11 +461,4 @@ func (r *burnAlertResource) Delete(ctx context.Context, req resource.DeleteReque
 			)
 		}
 	}
-}
-
-func getDatasetString(dataset types.String) types.String {
-	if dataset == types.StringNull() {
-		return types.StringValue(client.EnvironmentWideSlug)
-	}
-	return dataset
 }

--- a/internal/provider/burn_alert_resource_test.go
+++ b/internal/provider/burn_alert_resource_test.go
@@ -850,7 +850,7 @@ func testAccEnsureBurnAlertDestroyed(t *testing.T) resource.TestCheckFunc {
 }
 
 func TestAcc_BurnAlertResource_MDBasic(t *testing.T) {
-	dataset, sloID := burnAlertAccTestSetup(t)
+	_, sloID := burnAlertAccTestSetup(t)
 	burnAlert := &client.BurnAlert{}
 
 	// Create
@@ -875,14 +875,6 @@ func TestAcc_BurnAlertResource_MDBasic(t *testing.T) {
 			{
 				Config: testAccConfigBurnAlertDefault_MD(exhaustionMinutes, sloID, "critical"),
 				Check:  testAccEnsureSuccessExhaustionTimeAlert(t, burnAlert, exhaustionMinutes, "critical", sloID),
-			},
-			// Import
-			{
-				ResourceName:            "honeycombio_burn_alert.test",
-				ImportStateIdPrefix:     fmt.Sprintf("%v/", dataset),
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"recipient"},
 			},
 			// Update - exhaustion time to exhaustion time
 			{

--- a/internal/provider/burn_alert_resource_test.go
+++ b/internal/provider/burn_alert_resource_test.go
@@ -851,6 +851,12 @@ func testAccEnsureBurnAlertDestroyed(t *testing.T) resource.TestCheckFunc {
 
 func TestAcc_BurnAlertResource_MDBasic(t *testing.T) {
 	_, sloID := burnAlertAccTestSetup(t)
+	c := testAccClient(t)
+
+	if c.IsClassic(context.Background()) {
+		t.Skip("MD SLOs are not supported in classic")
+	}
+
 	burnAlert := &client.BurnAlert{}
 
 	// Create

--- a/internal/provider/burn_alert_resource_test.go
+++ b/internal/provider/burn_alert_resource_test.go
@@ -1212,7 +1212,7 @@ resource "honeycombio_burn_alert" "test" {
 }`, budgetRateWindowMinutes, helper.FloatToPercentString(budgetRateDecreasePercent), dataset, sloID, pdseverity, testBADescription)
 }
 
-func testAccConfigBurnAlertBudgetRate_basic_dataset_deprecation(budgetRateWindowMinutes int, budgetRateDecreasePercent float64, dataset, sloID, pdseverity string) string {
+func testAccConfigBurnAlertBudgetRate_basic_dataset_deprecation(budgetRateWindowMinutes int, budgetRateDecreasePercent float64, sloID, pdseverity string) string {
 	return fmt.Sprintf(`
 resource "honeycombio_pagerduty_recipient" "test" {
   integration_key  = "08b9d4cacd68933151a1ef1028b67da2"

--- a/internal/provider/burn_alert_resource_test.go
+++ b/internal/provider/burn_alert_resource_test.go
@@ -858,7 +858,6 @@ func TestAcc_BurnAlertResource_MDBasic(t *testing.T) {
 			// Import
 			{
 				ResourceName:            "honeycombio_burn_alert.test",
-				ImportStateIdPrefix:     "",
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"recipient"},

--- a/internal/provider/burn_alert_resource_test.go
+++ b/internal/provider/burn_alert_resource_test.go
@@ -933,6 +933,12 @@ func getNewDatasetAndSLO(t *testing.T) (string, string) {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
+		c.Datasets.Update(ctx, &client.Dataset{
+			Slug: dataset.Slug,
+			Settings: client.DatasetSettings{
+				DeleteProtected: helper.ToPtr(false),
+			},
+		})
 		c.Datasets.Delete(ctx, dataset.Slug)
 	})
 	sli, err := c.DerivedColumns.Create(ctx, dataset.Slug, &client.DerivedColumn{

--- a/internal/provider/burn_alert_resource_test.go
+++ b/internal/provider/burn_alert_resource_test.go
@@ -989,19 +989,19 @@ func testAccConfigBurnAlertDefault_MD(exhaustionMinutes int, sloID, pdseverity s
 		}
 		EOT`
 	return fmt.Sprintf(`
-resource "honeycombio_pagerduty_recipient" "test_md" {
+resource "honeycombio_pagerduty_recipient" "test" {
   integration_key  = "08b9d4cacd68933151a1ef1028b67da2"
-  integration_name = "test.pd-basic-md"
+  integration_name = "test.pd-basic"
 }
 
-resource "honeycombio_burn_alert" "test_md" {
+resource "honeycombio_burn_alert" "test" {
   exhaustion_minutes = %[1]d
 
   slo_id             = "%[2]s"
   description        = "%[4]s"
   
   recipient {
-    id = honeycombio_pagerduty_recipient.test_md.id
+    id = honeycombio_pagerduty_recipient.test.id
 
     notification_details {
       pagerduty_severity = "%[3]s"

--- a/internal/provider/burn_alert_resource_test.go
+++ b/internal/provider/burn_alert_resource_test.go
@@ -876,6 +876,14 @@ func TestAcc_BurnAlertResource_MDBasic(t *testing.T) {
 				Config: testAccConfigBurnAlertDefault_MD(exhaustionMinutes, sloID, "critical"),
 				Check:  testAccEnsureSuccessExhaustionTimeAlert(t, burnAlert, exhaustionMinutes, "critical", sloID),
 			},
+			// Import
+			{
+				ResourceName:            "honeycombio_burn_alert.test",
+				ImportStateIdPrefix:     fmt.Sprintf("%v/", client.EnvironmentWideSlug),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"recipient"},
+			},
 			// Update - exhaustion time to exhaustion time
 			{
 				Config: testAccConfigBurnAlertDefault_MD(updatedExhaustionMinutes, sloID, "info"),

--- a/internal/provider/burn_alert_resource_test.go
+++ b/internal/provider/burn_alert_resource_test.go
@@ -324,33 +324,6 @@ func TestAcc_BurnAlertResourceUpgradeFromVersion015(t *testing.T) {
 	})
 }
 
-func TestAcc_BurnAlertResource_Import_validateImportID(t *testing.T) {
-	dataset, sloID := burnAlertAccTestSetup(t)
-	burnAlert := &client.BurnAlert{}
-
-	exhaustionMinutes := 240
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 testAccPreCheck(t),
-		ProtoV5ProviderFactories: testAccProtoV5MuxServerFactory,
-		CheckDestroy:             testAccEnsureBurnAlertDestroyed(t),
-		Steps: []resource.TestStep{
-			// Create resource for importing
-			{
-				Config: testAccConfigBurnAlertDefault_basic(exhaustionMinutes, dataset, sloID, "info"),
-				Check:  testAccEnsureSuccessExhaustionTimeAlert(t, burnAlert, exhaustionMinutes, "info", sloID),
-			},
-			// Import with invalid import ID
-			{
-				ResourceName:        "honeycombio_burn_alert.test",
-				ImportStateIdPrefix: fmt.Sprintf("%v.", dataset),
-				ImportState:         true,
-				ExpectError:         regexp.MustCompile(`Error: Invalid Import ID`),
-			},
-		},
-	})
-}
-
 func TestAcc_BurnAlertResource_validateDefault(t *testing.T) {
 	dataset, sloID := burnAlertAccTestSetup(t)
 

--- a/internal/provider/burn_alert_resource_test.go
+++ b/internal/provider/burn_alert_resource_test.go
@@ -878,7 +878,7 @@ func TestAcc_BurnAlertResource_MDBasic(t *testing.T) {
 			},
 			// Import
 			{
-				ResourceName:            "honeycombio_burn_alert.test_md",
+				ResourceName:            "honeycombio_burn_alert.test",
 				ImportStateIdPrefix:     fmt.Sprintf("%v/", dataset),
 				ImportState:             true,
 				ImportStateVerify:       true,
@@ -1236,12 +1236,12 @@ resource "honeycombio_burn_alert" "test" {
 
 func testAccConfigBurnAlertBudgetRate_MD(budgetRateWindowMinutes int, budgetRateDecreasePercent float64, sloID, pdseverity string) string {
 	return fmt.Sprintf(`
-resource "honeycombio_pagerduty_recipient" "test_md" {
+resource "honeycombio_pagerduty_recipient" "test" {
   integration_key  = "08b9d4cacd68933151a1ef1028b67da2"
-  integration_name = "test.pd-basic-md"
+  integration_name = "test.pd-basic"
 }
 
-resource "honeycombio_burn_alert" "test_md" {
+resource "honeycombio_burn_alert" "test" {
   alert_type                   = "budget_rate"
   description                  = "%[5]s"
   budget_rate_window_minutes   = %[1]d
@@ -1250,7 +1250,7 @@ resource "honeycombio_burn_alert" "test_md" {
   slo_id  = "%[3]s"
 
   recipient {
-    id = honeycombio_pagerduty_recipient.test_md.id
+    id = honeycombio_pagerduty_recipient.test.id
 
     notification_details {
       pagerduty_severity = "%[4]s"

--- a/internal/provider/burn_alert_resource_test.go
+++ b/internal/provider/burn_alert_resource_test.go
@@ -973,13 +973,6 @@ resource "honeycombio_burn_alert" "test" {
 }
 
 func testAccConfigBurnAlertDefault_MD(exhaustionMinutes int, sloID, pdseverity string) string {
-	tmplBody := `<<EOT
-		{
-			"name": " {{ .Name }}",
-			"id": " {{ .ID }}",
-			"description": " {{ .Description }}",
-		}
-		EOT`
 	return fmt.Sprintf(`
 resource "honeycombio_pagerduty_recipient" "test" {
   integration_key  = "08b9d4cacd68933151a1ef1028b67da2"
@@ -999,7 +992,7 @@ resource "honeycombio_burn_alert" "test" {
       pagerduty_severity = "%[3]s"
     }
   }
-}`, exhaustionMinutes, sloID, pdseverity, testBADescription, tmplBody)
+}`, exhaustionMinutes, sloID, pdseverity, testBADescription)
 }
 
 func testAccConfigBurnAlertExhaustionTime_basicWebhookRecipient(exhaustionMinutes int, dataset, sloID, variableValue string) string {

--- a/internal/provider/burn_alert_resource_test.go
+++ b/internal/provider/burn_alert_resource_test.go
@@ -885,7 +885,7 @@ func TestAcc_BurnAlertResource_MDBasic(t *testing.T) {
 			// Import
 			{
 				ResourceName:            "honeycombio_burn_alert.test",
-				ImportStateIdPrefix:     fmt.Sprintf("%v/", client.EnvironmentWideSlug),
+				ImportStateIdPrefix:     fmt.Sprintf(""),
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"recipient"},
@@ -908,7 +908,7 @@ func burnAlertAccTestSetup(t *testing.T) (string, string) {
 	t.Helper()
 
 	ctx := context.Background()
-	dataset := testAccDataset()
+	dataset := testAccDataset() // Ensure this returns a valid, known dataset value
 	c := testAccClient(t)
 
 	sli, err := c.DerivedColumns.Create(ctx, dataset, &client.DerivedColumn{

--- a/internal/provider/burn_alert_resource_test.go
+++ b/internal/provider/burn_alert_resource_test.go
@@ -885,7 +885,7 @@ func TestAcc_BurnAlertResource_MDBasic(t *testing.T) {
 			// Import
 			{
 				ResourceName:            "honeycombio_burn_alert.test",
-				ImportStateIdPrefix:     fmt.Sprintf(""),
+				ImportStateIdPrefix:     "",
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"recipient"},


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Closes https://app.asana.com/0/1205961717360815/1207770326676048/f

## Short description of the changes
- adds multi dataset support for r/burn_alerts by making the `dataset` argument optional.

## How to verify that this has the expected result
- add unit tests
- you can check out the **slo_with_burn_alert** example and omit the `dataset` arg. 

#### Screenshots of terraform plan when omitting `dataset` for burn alert resource:

![Screenshot 2025-03-24 at 2 19 23 PM](https://github.com/user-attachments/assets/e7e504a7-482f-45b0-b3aa-5159ddd516fc)
![Screenshot 2025-03-24 at 2 20 01 PM](https://github.com/user-attachments/assets/23c066ac-4f9b-4387-bd8d-1e28665af32f)
