### PR TITLE
feat: remove need for magic environment-wide string

### DIFF
--- a/docs/data-sources/derived_column.md
+++ b/docs/data-sources/derived_column.md
@@ -23,8 +23,8 @@ data "honeycombio_derived_column" "mydc" {
 
 The following arguments are supported:
 
-* `dataset` - (Required) The dataset this derived column is associated with. Use `__all__` for Environment-wide derived columns.
 * `alias` - (Required) The alias of the column
+* `dataset` - (Optional) The dataset this derived column is associated with. If not set, an Environment-wide lookup will be performed.
 
 ## Attribute Reference
 

--- a/docs/data-sources/derived_columns.md
+++ b/docs/data-sources/derived_columns.md
@@ -25,7 +25,7 @@ data "honeycombio_derived_columns" "foo" {
 
 The following arguments are supported:
 
-* `dataset` - (Required) The dataset to retrieve the columns list from. Use `__all__` for Environment-wide derived columns.
+* `dataset` - (Optional) The dataset to retrieve the columns list from. If not set, an Environment-wide lookup will be performed.
 * `starts_with` - (Optional) Only return derived columns starting with the given value.
 
 ## Attribute Reference

--- a/docs/data-sources/query_result.md
+++ b/docs/data-sources/query_result.md
@@ -36,7 +36,7 @@ output "event_count" {
 
 The following arguments are supported:
 
-* `dataset` - (Required) The dataset this query is associated with. Use `__all__` for Environment-wide queries.
+* `dataset` - (Optional) The dataset to query. If not set, an Environment-wide query will be performed.
 * `query_json` - (Required) A JSON object describing the query according to the Query Specification. While the JSON can be constructed manually, it is easiest to use the honeycombio_query_specification data source.
 
 ## Attribute Reference

--- a/docs/resources/derived_column.md
+++ b/docs/resources/derived_column.md
@@ -24,7 +24,7 @@ The following arguments are supported:
 
 * `dataset` - (Required) The dataset this derived column is added to. If not set, an Environment-wide derived column will be created.
 * `alias` - (Required) The name of the derived column. Must be unique per dataset.
-* `expression` - (Required) The formula of the derived column. See [Derived Column Syntax](https://docs.honeycomb.io/working-with-your-data/customizing-your-query/derived-columns/#derived-column-syntax).
+* `expression` - (Required) The formula of the derived column. See [Derived Column Syntax](https://docs.honeycomb.io/reference/derived-column-formula/syntax/).
 * `description` - (Optional) A description that is shown in the UI.
 
 ## Attribute Reference

--- a/docs/resources/derived_column.md
+++ b/docs/resources/derived_column.md
@@ -22,9 +22,9 @@ resource "honeycombio_derived_column" "duration_ms_log" {
 
 The following arguments are supported:
 
-* `dataset` - (Required) The dataset this derived column is added to. Use `__all__` for Environment-wide derived columns.
+* `dataset` - (Required) The dataset this derived column is added to. If not set, an Environment-wide derived column will be created.
 * `alias` - (Required) The name of the derived column. Must be unique per dataset.
-* `expression` - (Required) The function of the derived column. See [Derived Column Syntax](https://docs.honeycomb.io/working-with-your-data/customizing-your-query/derived-columns/#derived-column-syntax).
+* `expression` - (Required) The formula of the derived column. See [Derived Column Syntax](https://docs.honeycomb.io/working-with-your-data/customizing-your-query/derived-columns/#derived-column-syntax).
 * `description` - (Optional) A description that is shown in the UI.
 
 ## Attribute Reference

--- a/docs/resources/marker.md
+++ b/docs/resources/marker.md
@@ -16,7 +16,7 @@ variable "app_version" {
   type = string
 }
 
-resource "honeycombio_marker" "marker" {
+resource "honeycombio_marker" "app_deploy" {
   message = "deploy ${var.app_version}"
   type    = "deploy"
   url     = "http://www.example.com/"
@@ -29,10 +29,10 @@ resource "honeycombio_marker" "marker" {
 
 The following arguments are supported:
 
-* `dataset` - (Required) The dataset this marker is placed on. Use `__all__` for Environment-wide markers.
-* `message` - (Optional) The message on the marker.
-* `type` - (Optional) The type of the marker, Honeycomb.io can display markers in different colors depending on their type.
-* `url` - (Optional) A target for the Marker. If you click on the Marker text, it will take you to this URL.
+* `dataset` - (Optional) The dataset where this marker is placed. If not set, an Environment-wide Marker will be created.
+* `message` - (Optional) A message that appears above the marker and can be used to describe the marker.
+* `type` - (Optional) The type of the marker (e.g. "deploy", "job-run")
+* `url` - (Optional) A target URL for the Marker. Rendered as a link in the UI..
 
 ## Attribute Reference
 

--- a/docs/resources/marker_setting.md
+++ b/docs/resources/marker_setting.md
@@ -9,14 +9,9 @@ For more information on marker settings, check out the [Marker Settings API](htt
 variable "dataset" {
   type = string
 }
-
-variable "type" {
-  type = string
-}
-
-resource "honeycombio_marker_setting" "markerSetting" {
-  type =  var.type
-  color = "#DF4661"
+resource "honeycombio_marker_setting" "deploy_marker" {
+  type    =  "deploy"
+  color   = "#DF4661"
   dataset = var.dataset
 }
 ```
@@ -25,9 +20,9 @@ resource "honeycombio_marker_setting" "markerSetting" {
 
 The following arguments are supported:
 
-* `dataset` - (Required) The dataset this marker setting is placed on. Use `__all__` for Environment-wide marker settings.
-* `type` - (Required) The type of the marker setting, Honeycomb.io can display markers in different colors depending on their type.
-* `color` - (Required) The color set for the marker as a hex color code (e.g. `#DF4661`)
+* `dataset` - (Optional) The dataset this marker setting belongs to. If not set, the marker setting will be Environment-wide.
+* `type` - (Required) The type of the marker setting. (e.g. "deploy", "job-run")
+* `color` - (Required) The color set for the marker as a hex color code.(e.g. `#DF4661`)
 
 ## Attribute Reference
 

--- a/docs/resources/query.md
+++ b/docs/resources/query.md
@@ -62,8 +62,7 @@ resource "honeycombio_query" "example" {
 
 The following arguments are supported:
 
-* `dataset` - (Required) The dataset this query is scoped to.
-  Use `__all__` for Environment-wide queries.
+* `dataset` - (Optional) The dataset this query is scoped to.  If not set, an Environment-wide query will be created.
 * `query_json` - (Required) A JSON object describing the query according to the [Query Specification](https://docs.honeycomb.io/api/query-specification/#fields-on-a-query-specification).
   While the JSON can be constructed manually, using the [`honeycombio_query_specification`](../data-sources/query_specification.md) data source provides deeper validation.
 

--- a/docs/resources/query_annotation.md
+++ b/docs/resources/query_annotation.md
@@ -43,10 +43,10 @@ resource "honeycombio_query_annotation" "test_annotation" {
 
 The following arguments are supported:
 
-* `dataset` - (Required) The dataset this query annotation is added to. Use `__all__` for Environment-wide query annotations.
+* `dataset` - (Optional) The dataset this query annotation is added to. If not set, an Environment-wide query annotation will be created.
 * `query_id` - (Required) The ID of the query that the annotation will be created on. Note that a query can have more than one annotation.
-* `name` - (Required) The name of the query annotation that will display in the Honeycomb UI.
-* `description` - (Optional) The description for the query annotation.
+* `name` - (Required) The name to display as the query annotation.
+* `description` - (Optional) The description to display as the query annotation.
 
 ## Attribute Reference
 

--- a/docs/resources/slo.md
+++ b/docs/resources/slo.md
@@ -36,7 +36,6 @@ resource "honeycombio_slo" "slo" {
 resource "honeycombio_derived_column" "request_latency_sli" {
   alias       = "sli.request_latency"
   description = "SLI: request latency less than 300ms"
-  dataset     = "__all__"
 
   # heredoc also works
   expression = file("../sli/sli.request_latency.honeycomb")
@@ -65,7 +64,7 @@ The following arguments are supported:
 
 -   `name` - (Required) The name of the SLO.
 -   `description` - (Optional) A description of the SLO's intent and context.
--   `dataset` - (Optional) The dataset this SLO is created in. Must be the same dataset as the SLI unless the SLI's dataset is `"__all__"`. Conflicts with `datasets`. Will be deprecated in a future release of the provider.
+-   `dataset` - (Optional) The dataset this SLO is created in. Must be the same dataset as the SLI unless the SLI is an Environment-wide Derived Column. Conflicts with `datasets`. Will be deprecated in a future release of the provider.
 -   `datasets` - (Optional) Array of datasets the SLO is evaluated on. Conflicts with `dataset`. Must have a length between 1 and 10.
 -   `sli` - (Required) The alias of the Derived Column that will be used as the SLI to indicate event success.
     The derived column used as the SLI must be in the same dataset as the SLO. Additionally,
@@ -73,7 +72,7 @@ The following arguments are supported:
 -   `target_percentage` - (Required) The percentage of qualified events that you expect to succeed during the `time_period`.
 -   `time_period` - (Required) The time period, in days, over which your SLO will be evaluated.
 
-~> **Note** `dataset` will be deprecated in a future release. In the meantime, you can swap `dataset` with a single value array for `datasets` to effectively evaluate to the same configuration.
+~> **Note** `dataset` will be deprecated in a future release. One of `dataset` or `datasets` is required. In the meantime, you can swap `dataset` with a single value array for `datasets` to effectively evaluate to the same configuration.
 
 ## Attribute Reference
 

--- a/honeycombio/data_source_query_result.go
+++ b/honeycombio/data_source_query_result.go
@@ -18,8 +18,9 @@ func dataSourceHoneycombioQueryResult() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"dataset": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The dataset to query. If not specified, an Environment-wide query will be run.",
 			},
 			"query_json": {
 				Type:             schema.TypeString,
@@ -57,7 +58,7 @@ func dataSourceHoneycombioQueryResultRead(ctx context.Context, d *schema.Resourc
 	if err != nil {
 		return diagFromErr(err)
 	}
-	dataset := d.Get("dataset").(string)
+	dataset := getDatasetOrAll(d)
 
 	err = json.Unmarshal([]byte(d.Get("query_json").(string)), &querySpec)
 	if err != nil {

--- a/honeycombio/data_source_query_result_test.go
+++ b/honeycombio/data_source_query_result_test.go
@@ -15,17 +15,7 @@ func TestAccDataSourceHoneycombioQueryResult_basic(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactory,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceQueryResultConfig(dataset),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckOutput("results", "COUNT"),
-				),
-			},
-		},
-	})
-}
-
-func testAccDataSourceQueryResultConfig(dataset string) string {
-	return fmt.Sprintf(`
+				Config: fmt.Sprintf(`
 data "honeycombio_query_specification" "test" {
   time_range = 86400
 
@@ -54,5 +44,11 @@ output "results" {
       ]
     )
   )
-}`, dataset, dataset)
+}`, dataset, dataset),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckOutput("results", "COUNT"),
+				),
+			},
+		},
+	})
 }

--- a/honeycombio/internal/verify/dataset.go
+++ b/honeycombio/internal/verify/dataset.go
@@ -1,0 +1,19 @@
+package verify
+
+import "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+// SuppressEquivEnvWideDataset suppresses the dataset field if the old value is
+// equivalent to the new value, or if the new value is empty.
+//
+// This is used to allow migrations from the magic '__all__' to the empty string
+// to be handled gracefully, and not force re-creation of the resource.
+func SuppressEquivEnvWideDataset(_, oldValue, newValue string, _ *schema.ResourceData) bool {
+	if oldValue == newValue {
+		return true
+	}
+	// if the config moves away from deprecated dataset, nothing should change
+	if newValue == "" && oldValue == "__all__" {
+		return true
+	}
+	return false
+}

--- a/honeycombio/resource_derived_column.go
+++ b/honeycombio/resource_derived_column.go
@@ -37,7 +37,7 @@ func newDerivedColumn() *schema.Resource {
 			"expression": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "The formula of the derived column. See [Derived Column Syntax](https://docs.honeycomb.io/working-with-your-data/customizing-your-query/derived-columns/#derived-column-syntax).",
+				Description: "The formula of the derived column. See [Derived Column Syntax](https://docs.honeycomb.io/reference/derived-column-formula/syntax/).",
 				ValidateFunc: validation.All(
 					validation.StringLenBetween(1, 4095),
 					func(i interface{}, k string) ([]string, []error) {

--- a/honeycombio/resource_derived_column.go
+++ b/honeycombio/resource_derived_column.go
@@ -13,6 +13,7 @@ import (
 	dcparser "github.com/honeycombio/honeycomb-derived-column-validator/pkg/parser"
 
 	honeycombio "github.com/honeycombio/terraform-provider-honeycombio/client"
+	"github.com/honeycombio/terraform-provider-honeycombio/honeycombio/internal/verify"
 )
 
 func newDerivedColumn() *schema.Resource {
@@ -30,11 +31,13 @@ func newDerivedColumn() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
+				Description:  "The alias of the derived column. Must be unique within the dataset or environment.",
 				ValidateFunc: validation.StringLenBetween(1, 255),
 			},
 			"expression": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The formula of the derived column. See [Derived Column Syntax](https://docs.honeycomb.io/working-with-your-data/customizing-your-query/derived-columns/#derived-column-syntax).",
 				ValidateFunc: validation.All(
 					validation.StringLenBetween(1, 4095),
 					func(i interface{}, k string) ([]string, []error) {
@@ -54,26 +57,33 @@ func newDerivedColumn() *schema.Resource {
 			"description": {
 				Type:         schema.TypeString,
 				Optional:     true,
+				Description:  "A description of the derived column.",
 				ValidateFunc: validation.StringLenBetween(1, 255),
 			},
 			"dataset": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:             schema.TypeString,
+				Optional:         true,
+				ForceNew:         true,
+				Description:      "The dataset this derived column belongs to. If not set, it will be Environment-wide.",
+				DiffSuppressFunc: verify.SuppressEquivEnvWideDataset,
 			},
 		},
 	}
 }
 
 func resourceDerivedColumnImport(ctx context.Context, d *schema.ResourceData, i interface{}) ([]*schema.ResourceData, error) {
-	// import ID is of the format <dataset>/<derived column alias>
 	dataset, alias, found := strings.Cut(d.Id(), "/")
+
+	// if dataset separator not found, we will assume its the bare alias
+	// if thats the case, we need to reassign values since strings.Cut would return (alias "", false)
 	if !found {
-		return nil, errors.New("invalid import ID, supplied ID must be written as <dataset>/<derived column alias>")
+		alias = dataset
+	} else {
+		d.Set("dataset", dataset)
 	}
 
 	d.Set("alias", alias)
-	d.Set("dataset", dataset)
+
 	return []*schema.ResourceData{d}, nil
 }
 
@@ -83,7 +93,7 @@ func resourceDerivedColumnCreate(ctx context.Context, d *schema.ResourceData, me
 		return diagFromErr(err)
 	}
 
-	dataset := d.Get("dataset").(string)
+	dataset := getDatasetOrAll(d)
 	derivedColumn := readDerivedColumn(d)
 
 	derivedColumn, err = client.DerivedColumns.Create(ctx, dataset, derivedColumn)
@@ -101,7 +111,7 @@ func resourceDerivedColumnRead(ctx context.Context, d *schema.ResourceData, meta
 		return diagFromErr(err)
 	}
 
-	dataset := d.Get("dataset").(string)
+	dataset := getDatasetOrAll(d)
 
 	var detailedErr honeycombio.DetailedError
 	derivedColumn, err := client.DerivedColumns.GetByAlias(ctx, dataset, d.Get("alias").(string))
@@ -129,7 +139,7 @@ func resourceDerivedColumnUpdate(ctx context.Context, d *schema.ResourceData, me
 		return diagFromErr(err)
 	}
 
-	dataset := d.Get("dataset").(string)
+	dataset := getDatasetOrAll(d)
 	derivedColumn := readDerivedColumn(d)
 
 	derivedColumn, err = client.DerivedColumns.Update(ctx, dataset, derivedColumn)
@@ -147,7 +157,7 @@ func resourceDerivedColumnDelete(ctx context.Context, d *schema.ResourceData, me
 		return diagFromErr(err)
 	}
 
-	dataset := d.Get("dataset").(string)
+	dataset := getDatasetOrAll(d)
 
 	err = client.DerivedColumns.Delete(ctx, dataset, d.Id())
 	if err != nil {

--- a/honeycombio/resource_derived_column_test.go
+++ b/honeycombio/resource_derived_column_test.go
@@ -1,6 +1,7 @@
 package honeycombio
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"testing"
@@ -110,6 +111,41 @@ EOF
 }`,
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccHoneycombioDerivedColumn_AllToUnset(t *testing.T) {
+	ctx := context.Background()
+	c := testAccClient(t)
+
+	if c.IsClassic(ctx) {
+		t.Skip("env-wide Derived Columns are not supported in classic")
+	}
+
+	alias := test.RandomStringWithPrefix("test.", 10)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 testAccPreCheck(t),
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "honeycombio_derived_column" "test" {
+  alias       = "%s"
+  expression  = "BOOL(1)"
+  dataset     = "__all__"
+}`, alias),
+			},
+			{
+				Config: fmt.Sprintf(`
+resource "honeycombio_derived_column" "test" {
+  alias       = "%s"
+  expression  = "BOOL(1)"
+}`, alias),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
 			},
 		},
 	})

--- a/honeycombio/resource_marker_test.go
+++ b/honeycombio/resource_marker_test.go
@@ -7,7 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/stretchr/testify/assert"
+
+	honeycombio "github.com/honeycombio/terraform-provider-honeycombio/client"
 )
 
 func TestAccHoneycombioMarker_basic(t *testing.T) {
@@ -18,11 +19,17 @@ func TestAccHoneycombioMarker_basic(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactory,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMarkerConfig(dataset),
+				Config: fmt.Sprintf(`
+resource "honeycombio_marker" "test" {
+  message = "Hello world!"
+  type    = "deploy"
+  url     = "https://www.honeycomb.io/"
+  dataset = "%s"
+}`, dataset),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMarkerExists(t, "honeycombio_marker.test"),
+					testAccCheckMarkerExists(t, "honeycombio_marker.test", dataset),
 					resource.TestCheckResourceAttr("honeycombio_marker.test", "message", "Hello world!"),
-					resource.TestCheckResourceAttr("honeycombio_marker.test", "type", "deploys"),
+					resource.TestCheckResourceAttr("honeycombio_marker.test", "type", "deploy"),
 					resource.TestCheckResourceAttr("honeycombio_marker.test", "url", "https://www.honeycomb.io/"),
 					resource.TestCheckResourceAttr("honeycombio_marker.test", "dataset", dataset),
 				),
@@ -31,19 +38,42 @@ func TestAccHoneycombioMarker_basic(t *testing.T) {
 	})
 }
 
-func testAccMarkerConfig(dataset string) string {
-	return fmt.Sprintf(`
-resource "honeycombio_marker" "test" {
-  message = "Hello world!"
-  type    = "deploys"
-  url     = "https://www.honeycomb.io/"
-  dataset = "%s"
-}`, dataset)
+func TestAccHoneycombioMarker_AllToUnset(t *testing.T) {
+	ctx := context.Background()
+	c := testAccClient(t)
+
+	if c.IsClassic(ctx) {
+		t.Skip("env-wide markers are not supported in classic")
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 testAccPreCheck(t),
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+resource "honeycombio_marker" "test" {		
+  message = "hey"
+	type    = "test"
+  dataset = "__all__"
+}`,
+				Check: testAccCheckMarkerExists(t, "honeycombio_marker.test", honeycombio.EnvironmentWideSlug),
+			},
+			{
+				Config: `
+resource "honeycombio_marker" "test" {		
+  message = "hey"
+	type    = "test"
+}`,
+				Check:              testAccCheckMarkerExists(t, "honeycombio_marker.test", honeycombio.EnvironmentWideSlug),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
 }
 
-// testAccCheckMarkerExists queries the API to verify the Marker exists and
-// matches with the Terraform state.
-func testAccCheckMarkerExists(t *testing.T, name string) resource.TestCheckFunc {
+func testAccCheckMarkerExists(t *testing.T, name, dataset string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		resourceState, ok := s.RootModule().Resources[name]
 		if !ok {
@@ -51,14 +81,10 @@ func testAccCheckMarkerExists(t *testing.T, name string) resource.TestCheckFunc 
 		}
 
 		c := testAccClient(t)
-		m, err := c.Markers.Get(context.Background(), resourceState.Primary.Attributes["dataset"], resourceState.Primary.ID)
+		_, err := c.Markers.Get(context.Background(), dataset, resourceState.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("could not retrieve marker: %w", err)
 		}
-
-		assert.Equal(t, "Hello world!", m.Message)
-		assert.Equal(t, "deploys", m.Type)
-		assert.Equal(t, "https://www.honeycomb.io/", m.URL)
 
 		return nil
 	}

--- a/honeycombio/resource_slo.go
+++ b/honeycombio/resource_slo.go
@@ -41,7 +41,7 @@ func newSLO() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				ForceNew:    true,
-				Description: "The dataset this SLO is created in. Must be the same dataset as the SLI unless the SLI Derived Column is Environment-wide.",
+				Description: "The dataset this SLO is created in. Will be deprecated in a future release. Must be the same dataset as the SLI unless the SLI Derived Column is Environment-wide.",
 				DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
 					// not using the shared 'SuppressEquivEnvWideDataset' as SLOs aren't using
 					// `__all__` directly and need an explicit list of datasets (below)

--- a/honeycombio/resource_slo.go
+++ b/honeycombio/resource_slo.go
@@ -41,18 +41,20 @@ func newSLO() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				ForceNew:    true,
-				Description: "The dataset this SLO is created in. Must be the same dataset as the SLI unless the SLI's dataset is `\"__all__\"`.",
+				Description: "The dataset this SLO is created in. Must be the same dataset as the SLI unless the SLI Derived Column is Environment-wide.",
 				DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
+					// not using the shared 'SuppressEquivEnvWideDataset' as SLOs aren't using
+					// `__all__` directly and need an explicit list of datasets (below)
 					if oldValue == newValue {
 						return true
 					}
-					// if the config moves away from deprecated dataset, nothing should change
+					// if the config moves away from to-be-deprecated dataset, nothing should change
 					if newValue == "" {
 						return true
 					}
 					return false
 				},
-				ExactlyOneOf: []string{"dataset", "datasets"},
+				ConflictsWith: []string{"datasets"},
 			},
 			"datasets": {
 				Type:         schema.TypeSet,
@@ -110,7 +112,7 @@ func resourceSLOCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 		return diagFromErr(err)
 	}
 
-	dataset := getDataset(d)
+	dataset := getDatasetOrAll(d)
 
 	s, err := client.SLOs.Create(ctx, dataset, expandSLO(d))
 	if err != nil {
@@ -127,7 +129,7 @@ func resourceSLORead(ctx context.Context, d *schema.ResourceData, meta interface
 		return diagFromErr(err)
 	}
 
-	dataset := getDataset(d)
+	dataset := getDatasetOrAll(d)
 
 	var detailedErr honeycombio.DetailedError
 	s, err := client.SLOs.Get(ctx, dataset, d.Id())
@@ -159,7 +161,7 @@ func resourceSLOUpdate(ctx context.Context, d *schema.ResourceData, meta interfa
 		return diagFromErr(err)
 	}
 
-	dataset := getDataset(d)
+	dataset := getDatasetOrAll(d)
 
 	s, err := client.SLOs.Update(ctx, dataset, expandSLO(d))
 	if err != nil {
@@ -176,7 +178,7 @@ func resourceSLODelete(ctx context.Context, d *schema.ResourceData, meta interfa
 		return diagFromErr(err)
 	}
 
-	dataset := getDataset(d)
+	dataset := getDatasetOrAll(d)
 
 	err = client.SLOs.Delete(ctx, dataset, d.Id())
 	if err != nil {
@@ -202,12 +204,4 @@ func expandSLO(d *schema.ResourceData) *honeycombio.SLO {
 		SLI:              honeycombio.SLIRef{Alias: d.Get("sli").(string)},
 		DatasetSlugs:     datasets,
 	}
-}
-
-func getDataset(d *schema.ResourceData) string {
-	dataset := d.Get("dataset").(string)
-	if dataset == "" {
-		dataset = "__all__"
-	}
-	return dataset
 }

--- a/honeycombio/type_helpers.go
+++ b/honeycombio/type_helpers.go
@@ -29,6 +29,16 @@ func coerceValueToType(i string) interface{} {
 	return i
 }
 
+// getDatasetOrAll returns the dataset from the resource data.
+// If the dataset is empty, it returns the 'magic' EnvironmentWideSlug `__all__`.
+func getDatasetOrAll(d *schema.ResourceData) string {
+	dataset := d.Get("dataset").(string)
+	if dataset == "" {
+		dataset = honeycombio.EnvironmentWideSlug
+	}
+	return dataset
+}
+
 func expandRecipient(t honeycombio.RecipientType, d *schema.ResourceData) (*honeycombio.Recipient, error) {
 	r := &honeycombio.Recipient{
 		ID:   d.Id(),

--- a/internal/helper/dataset.go
+++ b/internal/helper/dataset.go
@@ -6,7 +6,9 @@ import (
 	"github.com/honeycombio/terraform-provider-honeycombio/client"
 )
 
-func GetDatasetString(dataset types.String) types.String {
+// GetDatasetOrAll returns the dataset.
+// If the dataset is empty, it returns the 'magic' EnvironmentWideSlug `__all__`.
+func GetDatasetOrAll(dataset types.String) types.String {
 	if dataset == types.StringNull() || dataset.ValueString() == "" {
 		return types.StringValue(client.EnvironmentWideSlug)
 	}

--- a/internal/helper/modifiers/dataset_deprecation.go
+++ b/internal/helper/modifiers/dataset_deprecation.go
@@ -5,14 +5,21 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/honeycombio/terraform-provider-honeycombio/client"
 )
 
-type datasetDeprecation struct{}
+type datasetDeprecation struct {
+	// if true, will allow the previous value of dataset to not strictly be `__all__`
+	allowAnyDataset bool
+}
 
 var _ planmodifier.String = &datasetDeprecation{}
 
 func (m datasetDeprecation) Description(_ context.Context) string {
-	return "Avoids unnecessary plans if dataset becomes omitted. Configuration should now behave the same."
+	return "Avoids unnecessary replacement if dataset is unset. " +
+		"Intended to allow removal of `__all__` from the dataset field, " +
+		"but if `allowAnyDataset` is true, will allow any previous value."
 }
 
 func (m datasetDeprecation) MarkdownDescription(ctx context.Context) string {
@@ -24,31 +31,34 @@ func (m datasetDeprecation) PlanModifyString(ctx context.Context, req planmodifi
 	if req.Plan.Raw.IsNull() {
 		return
 	}
-	// Assign null value if the plan value is unknown or theres no state value to fall back on
-	if req.PlanValue.IsUnknown() || req.StateValue.IsUnknown() {
+
+	if req.ConfigValue.IsNull() {
+		// default value is null
 		resp.PlanValue = types.StringNull()
-		return
 	}
 
-	// Suppress diff if the old and new values are equal
-	if req.PlanValue.Equal(req.StateValue) {
-		resp.PlanValue = req.StateValue
-		return
-	}
-	// Suppress diff if the new value is empty
-	if req.PlanValue.IsNull() {
-		resp.PlanValue = req.StateValue
-		return
+	// null now, but what was it previously?
+	if req.ConfigValue.IsNull() {
+		if m.allowAnyDataset || req.StateValue.ValueString() == client.EnvironmentWideSlug {
+			// if the previous value was `__all__`, or we're allowing any previous value, suppress the diff
+			resp.PlanValue = req.StateValue
+			return
+		}
 	}
 
 	if !req.PlanValue.Equal(req.StateValue) {
-		// Require replacement only if the dataset value is explicitly changing
+		// require replacement only if the dataset value is otherwise changing
 		resp.RequiresReplace = true
 		return
 	}
+
 }
 
-// DatasetDeprecation avoids unnecessary plans if dataset becomes omitted. Configuration should now behave the same.
-func DatasetDeprecation() planmodifier.String {
-	return datasetDeprecation{}
+// DatasetDeprecation avoids unnecessary diffs if dataset becomes omitted.
+// Intended to allow removal of `__all__` from the dataset field,
+// but if `allowAnyDataset` is true, will allow any previous value of dataset.
+func DatasetDeprecation(allowAnyDataset bool) planmodifier.String {
+	return datasetDeprecation{
+		allowAnyDataset: allowAnyDataset,
+	}
 }

--- a/internal/helper/modifiers/dataset_deprecation.go
+++ b/internal/helper/modifiers/dataset_deprecation.go
@@ -33,16 +33,13 @@ func (m datasetDeprecation) PlanModifyString(ctx context.Context, req planmodifi
 	}
 
 	if req.ConfigValue.IsNull() {
-		// default value is null
-		resp.PlanValue = types.StringNull()
-	}
-
-	// null now, but what was it previously?
-	if req.ConfigValue.IsNull() {
-		if m.allowAnyDataset || req.StateValue.ValueString() == client.EnvironmentWideSlug {
+		if req.StateValue.ValueString() == client.EnvironmentWideSlug || (m.allowAnyDataset && !req.StateValue.IsNull()) {
 			// if the previous value was `__all__`, or we're allowing any previous value, suppress the diff
 			resp.PlanValue = req.StateValue
 			return
+		} else {
+			// otherwise, the value is null
+			resp.PlanValue = types.StringNull()
 		}
 	}
 
@@ -51,7 +48,6 @@ func (m datasetDeprecation) PlanModifyString(ctx context.Context, req planmodifi
 		resp.RequiresReplace = true
 		return
 	}
-
 }
 
 // DatasetDeprecation avoids unnecessary diffs if dataset becomes omitted.

--- a/internal/provider/burn_alert_resource.go
+++ b/internal/provider/burn_alert_resource.go
@@ -102,7 +102,7 @@ func (*burnAlertResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				Computed:    true,
 				Description: "The dataset this Burn Alert is associated with.",
 				PlanModifiers: []planmodifier.String{
-					modifiers.DatasetDeprecation(),
+					modifiers.DatasetDeprecation(true),
 				},
 			},
 			"description": schema.StringAttribute{
@@ -266,8 +266,7 @@ func (r *burnAlertResource) Create(ctx context.Context, req resource.CreateReque
 		createRequest.BudgetRateWindowMinutes = &budgetRateWindowMinutes
 	}
 
-	// dataset value to use in the API call
-	dataset := helper.GetDatasetString(plan.Dataset)
+	dataset := helper.GetDatasetOrAll(plan.Dataset)
 
 	// Create the new burn alert
 	burnAlert, err := r.client.BurnAlerts.Create(ctx, dataset.ValueString(), createRequest)
@@ -310,8 +309,7 @@ func (r *burnAlertResource) Read(ctx context.Context, req resource.ReadRequest, 
 		return
 	}
 
-	// dataset value to use in the API call
-	dataset := helper.GetDatasetString(state.Dataset)
+	dataset := helper.GetDatasetOrAll(state.Dataset)
 
 	// Read the burn alert, using the values from state
 	var detailedErr client.DetailedError
@@ -392,8 +390,7 @@ func (r *burnAlertResource) Update(ctx context.Context, req resource.UpdateReque
 		updateRequest.BudgetRateWindowMinutes = &budgetRateWindowMinutes
 	}
 
-	// dataset value to use in the API call
-	dataset := helper.GetDatasetString(plan.Dataset)
+	dataset := helper.GetDatasetOrAll(plan.Dataset)
 
 	// Update the burn alert
 	_, err := r.client.BurnAlerts.Update(ctx, dataset.ValueString(), updateRequest)
@@ -443,7 +440,7 @@ func (r *burnAlertResource) Delete(ctx context.Context, req resource.DeleteReque
 	}
 
 	// dataset value to use in the API call
-	dataset := helper.GetDatasetString(state.Dataset)
+	dataset := helper.GetDatasetOrAll(state.Dataset)
 
 	// Delete the burn alert, using the values from state
 	var detailedErr client.DetailedError

--- a/internal/provider/burn_alert_resource.go
+++ b/internal/provider/burn_alert_resource.go
@@ -100,9 +100,9 @@ func (*burnAlertResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 			"dataset": schema.StringAttribute{
 				Optional:    true,
 				Computed:    true,
-				Description: "The dataset this Burn Alert is associated with.",
+				Description: "The dataset this Burn Alert is associated with. Will be deprecated in a future release.",
 				PlanModifiers: []planmodifier.String{
-					modifiers.DatasetDeprecation(true),
+					modifiers.DatasetDeprecation(true), // Burn Alerts switching to env-wide from any dataset is desirable
 				},
 			},
 			"description": schema.StringAttribute{

--- a/internal/provider/burn_alert_resource_test.go
+++ b/internal/provider/burn_alert_resource_test.go
@@ -67,7 +67,6 @@ func TestAcc_BurnAlertResource_defaultBasic(t *testing.T) {
 				Config: testAccConfigBurnAlertBudgetRate_basic(budgetRateWindowMinutes, budgetRateDecreasePercent, dataset, sloID, "info"),
 				Check:  testAccEnsureSuccessBudgetRateAlert(t, burnAlert, budgetRateWindowMinutes, budgetRateDecreasePercent, "info", sloID),
 			},
-
 			// update the config to remove dataset and ensure nothing changes
 			{
 				Config:   testAccConfigBurnAlertBudgetRate_basic_dataset_deprecation(budgetRateWindowMinutes, budgetRateDecreasePercent, sloID, "info"),

--- a/internal/provider/derived_column_data_source.go
+++ b/internal/provider/derived_column_data_source.go
@@ -47,8 +47,8 @@ func (d *derivedColumnDataSource) Schema(_ context.Context, _ datasource.SchemaR
 				Computed: true,
 			},
 			"dataset": schema.StringAttribute{
-				Description: "The dataset to fetch the derived column from. Use '__all__' to fetch an Environment-wide derived column.",
-				Required:    true,
+				Description: "The dataset to fetch the derived column from. If not set, an Environment-wide lookup will be performed.",
+				Optional:    true,
 			},
 			"alias": schema.StringAttribute{
 				Description: "The alias of the Derived Column.",
@@ -92,7 +92,9 @@ func (d *derivedColumnDataSource) Read(ctx context.Context, req datasource.ReadR
 		return
 	}
 
-	dc, err := d.client.DerivedColumns.GetByAlias(ctx, data.Dataset.ValueString(), data.Alias.ValueString())
+	dataset := helper.GetDatasetOrAll(data.Dataset)
+
+	dc, err := d.client.DerivedColumns.GetByAlias(ctx, dataset.ValueString(), data.Alias.ValueString())
 	if helper.AddDiagnosticOnError(&resp.Diagnostics,
 		fmt.Sprintf("Looking up Derived Column %q", data.ID.ValueString()),
 		err) {

--- a/internal/provider/derived_column_data_source_test.go
+++ b/internal/provider/derived_column_data_source_test.go
@@ -5,53 +5,89 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/stretchr/testify/require"
 
 	"github.com/honeycombio/terraform-provider-honeycombio/client"
+	"github.com/honeycombio/terraform-provider-honeycombio/internal/helper/test"
 )
 
 func TestAcc_DerivedColumnDataSource(t *testing.T) {
 	ctx := context.Background()
 	c := testAccClient(t)
-	dataset := testAccDataset()
 
-	testColumn := client.DerivedColumn{
-		Alias:       acctest.RandString(4) + "_column1",
-		Description: "test column1",
-		Expression:  "BOOL(1)",
-	}
+	t.Run("dataset-specific lookup", func(t *testing.T) {
+		dataset := testAccDataset()
 
-	col, err := c.DerivedColumns.Create(ctx, dataset, &testColumn)
-	if err != nil {
-		t.Error(err)
-	}
-	// update ID for removal later
-	testColumn.ID = col.ID
-	t.Cleanup(func() {
-		c.DerivedColumns.Delete(ctx, dataset, testColumn.ID)
-	})
+		testColumn := client.DerivedColumn{
+			Alias:       test.RandomStringWithPrefix("test.", 10),
+			Description: test.RandomString(20),
+			Expression:  "BOOL(1)",
+		}
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 testAccPreCheck(t),
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactory,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDerivedColumnDataSourceConfig(dataset, testColumn.Alias),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.honeycombio_derived_column.test", "description", testColumn.Description),
-					resource.TestCheckResourceAttr("data.honeycombio_derived_column.test", "expression", testColumn.Expression),
-				),
-			},
-		},
-	})
-}
+		col, err := c.DerivedColumns.Create(ctx, dataset, &testColumn)
+		require.NoError(t, err)
 
-func testAccDerivedColumnDataSourceConfig(dataset, alias string) string {
-	return fmt.Sprintf(`
+		// update ID for removal later
+		testColumn.ID = col.ID
+		t.Cleanup(func() {
+			c.DerivedColumns.Delete(ctx, dataset, testColumn.ID)
+		})
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:                 testAccPreCheck(t),
+			ProtoV5ProviderFactories: testAccProtoV5ProviderFactory,
+			Steps: []resource.TestStep{
+				{
+					Config: fmt.Sprintf(`
 data "honeycombio_derived_column" "test" {
   dataset     = "%s"
   alias       = "%s"
-}
-`, dataset, alias)
+}`, dataset, testColumn.Alias),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr("data.honeycombio_derived_column.test", "description", testColumn.Description),
+						resource.TestCheckResourceAttr("data.honeycombio_derived_column.test", "expression", testColumn.Expression),
+					),
+				},
+			},
+		})
+	})
+
+	t.Run("environment-wide lookup", func(t *testing.T) {
+		if c.IsClassic(ctx) {
+			t.Skip("classic does not support environment-wide derived columns")
+		}
+
+		testColumn := client.DerivedColumn{
+			Alias:       test.RandomStringWithPrefix("test.", 10),
+			Description: test.RandomString(20),
+			Expression:  "BOOL(1)",
+		}
+
+		col, err := c.DerivedColumns.Create(ctx, client.EnvironmentWideSlug, &testColumn)
+		require.NoError(t, err)
+
+		// update ID for removal later
+		testColumn.ID = col.ID
+		t.Cleanup(func() {
+			c.DerivedColumns.Delete(ctx, client.EnvironmentWideSlug, testColumn.ID)
+		})
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:                 testAccPreCheck(t),
+			ProtoV5ProviderFactories: testAccProtoV5ProviderFactory,
+			Steps: []resource.TestStep{
+				{
+					Config: fmt.Sprintf(`
+data "honeycombio_derived_column" "test" {
+  alias       = "%s"
+}`, testColumn.Alias),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr("data.honeycombio_derived_column.test", "description", testColumn.Description),
+						resource.TestCheckResourceAttr("data.honeycombio_derived_column.test", "expression", testColumn.Expression),
+					),
+				},
+			},
+		})
+	})
 }

--- a/internal/provider/derived_columns_data_source.go
+++ b/internal/provider/derived_columns_data_source.go
@@ -47,8 +47,8 @@ func (d *derivedColumnsDataSource) Schema(_ context.Context, _ datasource.Schema
 				Computed: true,
 			},
 			"dataset": schema.StringAttribute{
-				Description: "The dataset to fetch the derived columns from. Use '__all__' to fetch Environment-wide derived columns.",
-				Required:    true,
+				Description: "The dataset to fetch the derived columns from. If not set, an Environment-wide lookup will be performed.",
+				Optional:    true,
 			},
 			"starts_with": schema.StringAttribute{
 				Description: "Only return columns starting with the given value.",
@@ -87,7 +87,9 @@ func (d *derivedColumnsDataSource) Read(ctx context.Context, req datasource.Read
 		return
 	}
 
-	columns, err := d.client.DerivedColumns.List(ctx, data.Dataset.ValueString())
+	dataset := helper.GetDatasetOrAll(data.Dataset)
+
+	columns, err := d.client.DerivedColumns.List(ctx, dataset.ValueString())
 	if helper.AddDiagnosticOnError(&resp.Diagnostics, "Listing Derived Columns", err) {
 		return
 	}

--- a/internal/provider/derived_columns_data_source_test.go
+++ b/internal/provider/derived_columns_data_source_test.go
@@ -5,65 +5,113 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/stretchr/testify/require"
 
 	"github.com/honeycombio/terraform-provider-honeycombio/client"
+	"github.com/honeycombio/terraform-provider-honeycombio/internal/helper/test"
 )
 
 func TestAcc_DerivedColumnsDataSource(t *testing.T) {
 	ctx := context.Background()
 	c := testAccClient(t)
-	dataset := testAccDataset()
-	dcPrefix := acctest.RandString(4)
 
-	testColumns := []client.DerivedColumn{
-		{
-			Alias:       dcPrefix + "_column1",
-			Description: "test column1",
-			Expression:  "BOOL(1)",
-		},
-		{
-			Alias:       dcPrefix + "_column2",
-			Description: "test column2",
-			Expression:  "BOOL(1)",
-		},
-	}
+	t.Run("dataset-specific lookup", func(t *testing.T) {
+		dataset := testAccDataset()
+		dcPrefix := fmt.Sprintf("test.%s-", test.RandomString(8))
 
-	for i, column := range testColumns {
-		col, err := c.DerivedColumns.Create(ctx, dataset, &column)
-		if err != nil {
-			t.Error(err)
-		}
-		// update ID for removal later
-		testColumns[i].ID = col.ID
-	}
-	t.Cleanup(func() {
-		// remove DCs at the of the test run
-		for _, col := range testColumns {
-			c.DerivedColumns.Delete(ctx, dataset, col.ID)
-		}
-	})
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 testAccPreCheck(t),
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactory,
-		Steps: []resource.TestStep{
+		testColumns := []client.DerivedColumn{
 			{
-				Config: testAccDerivedColumnsDataSourceConfig(dataset, dcPrefix),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.honeycombio_derived_columns.test", "names.#", fmt.Sprintf("%d", len(testColumns))),
-				),
+				Alias:       dcPrefix + "column1",
+				Description: "test column1",
+				Expression:  "BOOL(1)",
 			},
-		},
-	})
-}
+			{
+				Alias:       dcPrefix + "column2",
+				Description: "test column2",
+				Expression:  "BOOL(1)",
+			},
+		}
 
-func testAccDerivedColumnsDataSourceConfig(dataset, prefix string) string {
-	return fmt.Sprintf(`
+		for i, column := range testColumns {
+			col, err := c.DerivedColumns.Create(ctx, dataset, &column)
+			require.NoError(t, err)
+
+			// update ID for removal later
+			testColumns[i].ID = col.ID
+		}
+		t.Cleanup(func() {
+			// remove DCs at the of the test run
+			for _, col := range testColumns {
+				c.DerivedColumns.Delete(ctx, dataset, col.ID)
+			}
+		})
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:                 testAccPreCheck(t),
+			ProtoV5ProviderFactories: testAccProtoV5ProviderFactory,
+			Steps: []resource.TestStep{
+				{
+					Config: fmt.Sprintf(`
 data "honeycombio_derived_columns" "test" {
   dataset     = "%s"
   starts_with = "%s"
-}
-`, dataset, prefix)
+}`, dataset, dcPrefix),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr("data.honeycombio_derived_columns.test", "names.#", fmt.Sprintf("%d", len(testColumns))),
+					),
+				},
+			},
+		})
+	})
+
+	t.Run("environment-wide lookup", func(t *testing.T) {
+		if c.IsClassic(ctx) {
+			t.Skip("classic does not support environment-wide derived columns")
+		}
+
+		dcPrefix := fmt.Sprintf("test.%s-", test.RandomString(8))
+		testColumns := []client.DerivedColumn{
+			{
+				Alias:       dcPrefix + "column1",
+				Description: "test column1",
+				Expression:  "BOOL(1)",
+			},
+			{
+				Alias:       dcPrefix + "column2",
+				Description: "test column2",
+				Expression:  "BOOL(1)",
+			},
+		}
+
+		for i, column := range testColumns {
+			col, err := c.DerivedColumns.Create(ctx, client.EnvironmentWideSlug, &column)
+			require.NoError(t, err)
+
+			// update ID for removal later
+			testColumns[i].ID = col.ID
+		}
+		t.Cleanup(func() {
+			// remove DCs at the of the test run
+			for _, col := range testColumns {
+				c.DerivedColumns.Delete(ctx, client.EnvironmentWideSlug, col.ID)
+			}
+		})
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:                 testAccPreCheck(t),
+			ProtoV5ProviderFactories: testAccProtoV5ProviderFactory,
+			Steps: []resource.TestStep{
+				{
+					Config: fmt.Sprintf(`
+data "honeycombio_derived_columns" "test" {
+  starts_with = "%s"
+}`, dcPrefix),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr("data.honeycombio_derived_columns.test", "names.#", fmt.Sprintf("%d", len(testColumns))),
+					),
+				},
+			},
+		})
+	})
 }

--- a/internal/provider/query_resource_test.go
+++ b/internal/provider/query_resource_test.go
@@ -184,6 +184,38 @@ EOT
 	})
 }
 
+func TestAcc_QueryAllToUnset(t *testing.T) {
+	ctx := context.Background()
+	c := testAccClient(t)
+
+	if c.IsClassic(ctx) {
+		t.Skip("env-wide queries are not supported in classic")
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 testAccPreCheck(t),
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+resource "honeycombio_query" "test" {
+  dataset    = "__all__"
+  query_json = "{}"
+}`,
+				Check: testAccEnsureQueryExists(t, "honeycombio_query.test"),
+			},
+			{
+				Config: `
+resource "honeycombio_query" "test" {
+  query_json = "{}"
+}`,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
 func testAccConfigBasicQueryTest(dataset, column string, value float64) string {
 	return fmt.Sprintf(`
 data "honeycombio_query_specification" "test" {

--- a/internal/provider/slo_data_source.go
+++ b/internal/provider/slo_data_source.go
@@ -109,13 +109,9 @@ func (d *sloDataSource) Read(ctx context.Context, req datasource.ReadRequest, re
 		return
 	}
 
-	dataset := data.Dataset.ValueString()
+	dataset := helper.GetDatasetOrAll(data.Dataset)
 
-	if data.Dataset.IsNull() {
-		dataset = "__all__"
-	}
-
-	slo, err := d.client.SLOs.Get(ctx, dataset, data.ID.ValueString())
+	slo, err := d.client.SLOs.Get(ctx, dataset.ValueString(), data.ID.ValueString())
 	if helper.AddDiagnosticOnError(&resp.Diagnostics,
 		fmt.Sprintf("Looking up SLO %q", data.ID.ValueString()),
 		err) {


### PR DESCRIPTION
Previously, creating "environment wide" resources required the use of the ✨ magic ✨  `dataset = "__all__"`.

With this change, resources that have Environment-wide support will move to the "dataset" argument becoming optional with the assumption that if it isn't set the intention is to operate at the Environment level.