### PR TITLE
fix(r/trigger): adjust frequency<>duration validation error message for clarity

### DIFF
--- a/internal/provider/trigger_resource.go
+++ b/internal/provider/trigger_resource.go
@@ -588,7 +588,7 @@ func (r *triggerResource) ValidateConfig(ctx context.Context, req resource.Valid
 			resp.Diagnostics.AddAttributeError(
 				path.Root("frequency"),
 				"Trigger validation error",
-				"The Trigger's frequency cannot be more than four times the query duration.",
+				"The Trigger's duration cannot be more than four times the frequency.",
 			)
 		}
 	}

--- a/internal/provider/trigger_resource_test.go
+++ b/internal/provider/trigger_resource_test.go
@@ -853,7 +853,7 @@ resource "honeycombio_trigger" "test" {
 
   query_json = data.honeycombio_query_specification.test.json
 }`,
-				ExpectError: regexp.MustCompile(`frequency cannot be more than four times the query duration`),
+				ExpectError: regexp.MustCompile(`duration cannot be more than four times the frequency`),
 			},
 		},
 	})


### PR DESCRIPTION
Adjust's the validation error message when a Trigger's duration exceeds `4*frequency` to match the UI.

- Closes #653 

