### PR TITLE
feat(r/trigger): add baseline_details support

### DIFF
--- a/client/trigger.go
+++ b/client/trigger.go
@@ -74,7 +74,13 @@ type Trigger struct {
 	// divisible by 60 and between 60 and 86400 (between 1 minute and 1 day).
 	Frequency int `json:"frequency,omitempty"`
 	// Recipients are notified when the trigger fires.
-	Recipients []NotificationRecipient `json:"recipients,omitempty"`
+	Recipients      []NotificationRecipient `json:"recipients,omitempty"`
+	BaselineDetails *TriggerBaselineDetails `json:"baseline_details,omitempty"`
+}
+
+type TriggerBaselineDetails struct {
+	Type          string `json:"type"`
+	OffsetMinutes int    `json:"offset_minutes"`
 }
 
 // TriggerThreshold represents the threshold of a trigger.

--- a/client/trigger_test.go
+++ b/client/trigger_test.go
@@ -206,3 +206,97 @@ func TestMatchesTriggerSubset(t *testing.T) {
 		assert.Equal(t, c.expectedErr, err, "Test case %d, QuerySpec: %v", i, c.in)
 	}
 }
+
+func TestTriggersWithBaselineDetails(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	var trigger *client.Trigger
+	var err error
+
+	c := newTestClient(t)
+	dataset := testDataset(t)
+	floatCol, _, _ := createRandomTestColumns(t, c, dataset)
+
+	t.Run("Create - with baseline_details", func(t *testing.T) {
+		data := &client.Trigger{
+			Name:        test.RandomStringWithPrefix("test.", 8),
+			Description: "Some description",
+			Disabled:    true,
+			Query: &client.QuerySpec{
+				Breakdowns: nil,
+				Calculations: []client.CalculationSpec{
+					{
+						Op:     client.CalculationOpRateAvg,
+						Column: &floatCol.KeyName,
+					},
+				},
+				TimeRange: client.ToPtr(900),
+			},
+			Frequency: 900,
+			Threshold: &client.TriggerThreshold{
+				Op:    client.TriggerThresholdOpGreaterThanOrEqual,
+				Value: 10000,
+			},
+			Recipients: []client.NotificationRecipient{
+				{
+					Type:   client.RecipientTypeMarker,
+					Target: "This marker is created by a trigger",
+				},
+			},
+			BaselineDetails: &client.TriggerBaselineDetails{
+				Type:          "percentage",
+				OffsetMinutes: 1440,
+			},
+		}
+		trigger, err = c.Triggers.Create(ctx, dataset, data)
+		require.NoError(t, err)
+		assert.NotNil(t, trigger.ID)
+
+		// copy IDs before asserting equality
+		data.ID = trigger.ID
+		data.QueryID = trigger.QueryID
+		data.AlertType = trigger.AlertType
+		data.Recipients[0].ID = trigger.Recipients[0].ID
+		// set default time range
+		data.Query.TimeRange = client.ToPtr(900)
+
+		// set the default alert type
+		data.AlertType = client.TriggerAlertTypeOnChange
+		// set the default evaluation window type
+		data.EvaluationScheduleType = client.TriggerEvaluationScheduleFrequency
+		// set the default threshold exceeded limit
+		data.Threshold.ExceededLimit = 1
+		data.BaselineDetails = &client.TriggerBaselineDetails{
+			Type:          "percentage",
+			OffsetMinutes: 1440,
+		}
+		assert.Equal(t, data, trigger)
+	})
+
+	t.Run("Get - with baseline details", func(t *testing.T) {
+		trigger.BaselineDetails = &client.TriggerBaselineDetails{
+			Type:          "percentage",
+			OffsetMinutes: 1440,
+		}
+		getTrigger, err := c.Triggers.Get(ctx, dataset, trigger.ID)
+
+		require.NoError(t, err)
+		assert.Equal(t, trigger.BaselineDetails.Type, getTrigger.BaselineDetails.Type)
+		assert.Equal(t, trigger.BaselineDetails.OffsetMinutes, getTrigger.BaselineDetails.OffsetMinutes)
+	})
+
+	t.Run("Update - with baseline_details", func(t *testing.T) {
+		trigger.BaselineDetails = &client.TriggerBaselineDetails{
+			Type:          "percentage",
+			OffsetMinutes: 1440,
+		}
+		result, err := c.Triggers.Update(ctx, dataset, trigger)
+
+		require.NoError(t, err)
+		assert.Equal(t, trigger.BaselineDetails.Type, result.BaselineDetails.Type)
+		assert.Equal(t, trigger.BaselineDetails.OffsetMinutes, result.BaselineDetails.OffsetMinutes)
+	})
+
+}

--- a/client/trigger_test.go
+++ b/client/trigger_test.go
@@ -219,6 +219,11 @@ func TestTriggersWithBaselineDetails(t *testing.T) {
 	dataset := testDataset(t)
 	floatCol, _, _ := createRandomTestColumns(t, c, dataset)
 
+	// delete the trigger after the tests run
+	t.Cleanup(func() {
+		c.Triggers.Delete(ctx, dataset, trigger.ID)
+	})
+
 	t.Run("Create - with baseline_details", func(t *testing.T) {
 		data := &client.Trigger{
 			Name:        test.RandomStringWithPrefix("test.", 8),

--- a/docs/resources/trigger.md
+++ b/docs/resources/trigger.md
@@ -182,6 +182,40 @@ resource "honeycombio_trigger" "example" {
 }
 ```
 
+### Example - Example with Baseline Details
+```hcl
+variable "dataset" {
+    type = string
+}
+
+data "honeycombio_query_specification" "example" {
+    calculation {
+        op     = "AVG"
+        column = "duration_ms"
+    }
+}
+
+resource "honeycombio_trigger" "example" {
+    name        = "Requests are slower than usual"
+    description = "Average duration of all requests for the last 10 minutes."
+
+    query_json = data.honeycombio_query_specification.example.json
+    dataset    = var.dataset
+
+    frequency = 600 // in seconds, 10 minutes
+
+    threshold {
+        op             = ">="
+        value          = 1000
+    }
+    
+    baseline_details {
+        type            = "percentage"
+        offset_minutes  = 1440
+    }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:

--- a/docs/resources/trigger.md
+++ b/docs/resources/trigger.md
@@ -203,6 +203,7 @@ Defaults to 900 (15 minutes).
 When the time is within the scheduled window the trigger will be run at the specified frequency.
 Outside of the window, the trigger will not be run.
 If no schedule is specified, the trigger will be run at the specified frequency at all times.
+* `baseline_details` - (Optional) A configuration block (described below) allows you to receive notifications when the delta between values in your data, compared to a previous time period, cross thresholds you configure.
 * `recipient` - (Optional) Zero or more configuration blocks (described below) with the recipients to notify when the trigger fires.
 
 One of `query_id` or `query_json` are required.
@@ -223,6 +224,11 @@ Each trigger configuration may provide an `evaluation_schedule` block, which acc
 * `start_time` - (Required) UTC time to start evaluating the trigger in HH:mm format (e.g. `13:00`)
 * `end_time` - (Required) UTC time to stop evaluating the trigger in HH:mm format (e.g. `13:00`)
 * `days_of_week` - (Required) A list of days of the week (in lowercase) to evaluate the trigger on
+
+Each trigger configuration may provide an `baseline_details` block, which accepts the following arguments:
+
+* `type` - (Required) Either `value` or `percentage` to indicate either an absolute value or percentage delta.
+* `offset_minutes` - (Required) Either `60` (1 hour), `1440` (24 hours), `10080` (7 days), or `40320` (28 days) to indicate the length of the previous time period.
 
 Each trigger configuration may have zero or more `recipient` blocks, which each accept the following arguments. A trigger recipient block can either refer to an existing recipient (a recipient that is already present in another trigger) or a new recipient. When specifying an existing recipient, only `id` may be set. If you pass in a recipient without its ID and only include the type and target, Honeycomb will make a best effort to match to an existing recipient. To retrieve the ID of an existing recipient, refer to the [`honeycombio_recipient`](../data-sources/recipient.md) data source.
 

--- a/example/trigger_with_baseline_details/main.tf
+++ b/example/trigger_with_baseline_details/main.tf
@@ -1,0 +1,54 @@
+terraform {
+  required_providers {
+    honeycombio = {
+      source = "honeycombio/honeycombio"
+    }
+  }
+}
+
+data "honeycombio_query_specification" "query" {
+  calculation {
+    op     = "AVG"
+    column = "db_dur_ms"
+  }
+
+  time_range = 900 // in seconds, 15 minutes
+  
+}
+
+resource "honeycombio_trigger" "trigger" {
+  name        = "Requests are slower than usual"
+  description = "Average duration of all requests for ThatSpecialTenant for the last 15 minutes."
+
+  disabled = false
+
+  query_json = data.honeycombio_query_specification.query.json
+  dataset    = var.dataset
+
+  frequency = 900 // in seconds, 15 minutes
+
+  threshold {
+    op    = ">="
+    value = 1000
+  }
+
+  # zero or more recipients
+  recipient {
+    type   = "email"
+    target = "hello@example.com"
+  }
+  recipient {
+    type   = "marker"
+    target = "Trigger - slow requests" # name of the marker
+  }
+
+  baseline_details {
+    type = "percentage"
+    offset_minutes = 1440
+  }
+}
+
+
+output "result" {
+  value = resource.honeycombio_trigger.trigger
+}

--- a/example/trigger_with_baseline_details/main.tf
+++ b/example/trigger_with_baseline_details/main.tf
@@ -16,6 +16,10 @@ data "honeycombio_query_specification" "query" {
   
 }
 
+variable "dataset" {
+  type = string
+}
+
 resource "honeycombio_trigger" "trigger" {
   name        = "Requests are slower than usual"
   description = "Average duration of all requests for ThatSpecialTenant for the last 15 minutes."

--- a/internal/models/triggers.go
+++ b/internal/models/triggers.go
@@ -18,6 +18,17 @@ type TriggerResourceModel struct {
 	Threshold          types.List   `tfsdk:"threshold"`           // TriggerThresholdModel
 	Recipients         types.Set    `tfsdk:"recipient"`           // NotificationRecipientModel
 	EvaluationSchedule types.List   `tfsdk:"evaluation_schedule"` // TriggerEvaluationScheduleModel
+	BaselineDetails    types.List   `tfsdk:"baseline_details"`
+}
+
+type TriggerBaselineDetailsModel struct {
+	Type          types.String `tfsdk:"type"`
+	OffsetMinutes types.Int64  `tfsdk:"offset_minutes"`
+}
+
+var TriggerBaselineDetailsAttrType = map[string]attr.Type{
+	"type":           types.StringType,
+	"offset_minutes": types.Int64Type,
 }
 
 type TriggerThresholdModel struct {

--- a/internal/provider/trigger_resource.go
+++ b/internal/provider/trigger_resource.go
@@ -213,23 +213,22 @@ func (r *triggerResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 			},
 			"recipient": notificationRecipientSchema(client.TriggerRecipientTypes()),
 			"baseline_details": schema.ListNestedBlock{
-				Description: "The schedule that determines when the trigger is run. When the time is within the scheduled window, " +
-					" the trigger will be run at the specified frequency. Outside of the window, the trigger will not be run." +
-					"If no schedule is specified, the trigger will be run at the specified frequency at all times.",
+				Description: "A configuration block that allows you to receive notifications when the delta between values in your data, " +
+					"compared to a previous time period, cross thresholds you configure.",
 				Validators: []validator.List{
 					listvalidator.SizeAtMost(1),
 				},
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
 						"type": schema.StringAttribute{
-							Description: "UTC time to start evaluating the trigger in HH:mm format",
+							Description: "Whether to use an absolute value or percentage delta.",
 							Required:    true,
 							Validators: []validator.String{
 								stringvalidator.OneOf("value", "percentage"),
 							},
 						},
 						"offset_minutes": schema.Int64Attribute{
-							Description: "UTC time to stop evaluating the trigger in HH:mm format",
+							Description: "What previous time period to evaluate against: 1 hour, 1 day, 1 week, or 4 weeks.",
 							Required:    true,
 							Validators: []validator.Int64{
 								int64validator.OneOf(60, 1440, 10080, 40320),
@@ -713,10 +712,6 @@ func expandBaselineDetails(
 	if diags.HasError() || len(s) == 0 {
 		return nil
 	}
-
-	// if s[0].Type.IsNull() || s[0].OffsetMinutes.IsNull() {
-	// 	return nil
-	// }
 
 	return &client.TriggerBaselineDetails{
 		Type:          s[0].Type.ValueString(),

--- a/internal/provider/trigger_resource.go
+++ b/internal/provider/trigger_resource.go
@@ -222,14 +222,14 @@ func (r *triggerResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 					Attributes: map[string]schema.Attribute{
 						"type": schema.StringAttribute{
 							Description: "Whether to use an absolute value or percentage delta.",
-							Optional:    true,
+							Required:    true,
 							Validators: []validator.String{
 								stringvalidator.OneOf("value", "percentage"),
 							},
 						},
 						"offset_minutes": schema.Int64Attribute{
 							Description: "What previous time period to evaluate against: 1 hour, 1 day, 1 week, or 4 weeks.",
-							Optional:    true,
+							Required:    true,
 							Validators: []validator.Int64{
 								int64validator.OneOf(60, 1440, 10080, 40320),
 							},
@@ -703,8 +703,9 @@ func expandBaselineDetails(
 	l types.List,
 	diags *diag.Diagnostics,
 ) *client.TriggerBaselineDetails {
+	// if plan doesn't include baseline_details, send the API an empty object so trigger becomes a static threshold
 	if l.IsNull() || l.IsUnknown() {
-		return nil
+		return &client.TriggerBaselineDetails{}
 	}
 
 	var s []models.TriggerBaselineDetailsModel

--- a/internal/provider/trigger_resource.go
+++ b/internal/provider/trigger_resource.go
@@ -222,14 +222,14 @@ func (r *triggerResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 					Attributes: map[string]schema.Attribute{
 						"type": schema.StringAttribute{
 							Description: "Whether to use an absolute value or percentage delta.",
-							Required:    true,
+							Optional:    true,
 							Validators: []validator.String{
 								stringvalidator.OneOf("value", "percentage"),
 							},
 						},
 						"offset_minutes": schema.Int64Attribute{
 							Description: "What previous time period to evaluate against: 1 hour, 1 day, 1 week, or 4 weeks.",
-							Required:    true,
+							Optional:    true,
 							Validators: []validator.Int64{
 								int64validator.OneOf(60, 1440, 10080, 40320),
 							},

--- a/internal/provider/trigger_resource_test.go
+++ b/internal/provider/trigger_resource_test.go
@@ -152,6 +152,37 @@ func TestAcc_TriggerResource(t *testing.T) {
 			},
 		})
 	})
+
+	t.Run("trigger resource with baselinedetails", func(t *testing.T) {
+		resource.Test(t, resource.TestCase{
+			PreCheck:                 testAccPreCheck(t),
+			ProtoV5ProviderFactories: testAccProtoV5MuxServerFactory,
+			Steps: []resource.TestStep{
+				{
+					Config: testAccConfigBasicTriggerWithBaselineDetailsTest(dataset, name, "info"),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						testAccEnsureTriggerExists(t, "honeycombio_trigger.test"),
+						resource.TestCheckResourceAttr("honeycombio_trigger.test", "name", name),
+						resource.TestCheckResourceAttr("honeycombio_trigger.test", "frequency", "1200"),
+						resource.TestCheckResourceAttr("honeycombio_trigger.test", "recipient.#", "2"),
+						resource.TestCheckResourceAttr("honeycombio_trigger.test", "threshold.0.exceeded_limit", "1"),
+						resource.TestCheckResourceAttrPair("honeycombio_trigger.test", "query_id", "honeycombio_query.test", "id"),
+						resource.TestCheckNoResourceAttr("honeycombio_trigger.test", "query_json"),
+						resource.TestCheckResourceAttr("honeycombio_trigger.test", "baseline_details.0.offset_minutes", "1440"),
+					),
+				},
+				// then update the PD Severity from info -> critical (the default)
+				{
+					Config: testAccConfigBasicTriggerTest(dataset, name, "critical"),
+				},
+				{
+					ResourceName:        "honeycombio_trigger.test",
+					ImportStateIdPrefix: fmt.Sprintf("%v/", dataset),
+					ImportState:         true,
+				},
+			},
+		})
+	})
 }
 
 // TestAcc_TriggerResourceUpgradeFromVersion014 is intended to test the migration
@@ -946,6 +977,65 @@ resource "honeycombio_trigger" "test" {
     notification_details {
       pagerduty_severity = "%[3]s"
     }
+  }
+}`, dataset, name, pdseverity, email, pdKey, pdName)
+}
+
+func testAccConfigBasicTriggerWithBaselineDetailsTest(dataset, name, pdseverity string) string {
+	email := test.RandomEmail()
+	pdKey := test.RandomString(32)
+	pdName := test.RandomStringWithPrefix("test.", 20)
+
+	return fmt.Sprintf(`
+data "honeycombio_query_specification" "test" {
+  calculation {
+    op     = "AVG"
+    column = "db_dur_ms"
+  }
+  time_range = 1200
+}
+
+resource "honeycombio_query" "test" {
+  dataset    = "%[1]s"
+  query_json = data.honeycombio_query_specification.test.json
+}
+
+resource "honeycombio_pagerduty_recipient" "test" {
+  integration_key  = "%[5]s"
+  integration_name = "%[6]s"
+}
+
+resource "honeycombio_trigger" "test" {
+  name    = "%[2]s"
+  dataset = "%[1]s"
+
+  description = "My nice description"
+
+  query_id = honeycombio_query.test.id
+
+  threshold {
+    op    = ">="
+    value = 100
+  }
+
+	frequency = 1200
+
+  recipient {
+    type   = "email"
+    target = "%[4]s"
+  }
+
+  recipient {
+    id = honeycombio_pagerduty_recipient.test.id
+
+    notification_details {
+      pagerduty_severity = "%[3]s"
+    }
+  }
+
+  baseline_details {
+  	type = "value"
+  	offset_minutes = 1440
   }
 }`, dataset, name, pdseverity, email, pdKey, pdName)
 }

--- a/internal/provider/trigger_resource_test.go
+++ b/internal/provider/trigger_resource_test.go
@@ -173,7 +173,7 @@ func TestAcc_TriggerResource(t *testing.T) {
 				},
 				// then update the PD Severity from info -> critical (the default)
 				{
-					Config: testAccConfigBasicTriggerTest(dataset, name, "critical"),
+					Config: testAccConfigBasicTriggerWithBaselineDetailsTest(dataset, name, "critical"),
 				},
 				{
 					ResourceName:        "honeycombio_trigger.test",

--- a/internal/provider/trigger_resource_test.go
+++ b/internal/provider/trigger_resource_test.go
@@ -990,7 +990,7 @@ func testAccConfigBasicTriggerWithBaselineDetailsTest(dataset, name, pdseverity 
 data "honeycombio_query_specification" "test" {
   calculation {
     op     = "AVG"
-    column = "db_dur_ms"
+    column = "duration_ms"
   }
   time_range = 1200
 }

--- a/internal/provider/trigger_resource_test.go
+++ b/internal/provider/trigger_resource_test.go
@@ -1024,7 +1024,7 @@ func testAccConfigBasicTriggerWithBaselineDetailsTest(dataset string, name strin
 data "honeycombio_query_specification" "test" {
   calculation {
     op     = "AVG"
-    column = "db_dur_ms"
+    column = "duration_ms"
   }
   time_range = 1200
 }


### PR DESCRIPTION
## Which problem is this PR solving?

- https://app.asana.com/1/72322038700732/project/1203970798110426/task/1209772672706729

## Short description of the changes

Adds support for a trigger with a dynamic threshold aka baseline_details. 

## How to verify that this has the expected result

pre-reqs:
- run hound in tilt (you need both poodle and public-api)
- in the root, run `make build`

examples:
- in `examples/trigger`, run `terraform init`,`terraform plan` and `terraform apply`
- confirm that the trigger was made in your local poodle ui (with a static threshold)
- in `examples/trigger_with_baseline_details`, run `terraform init`,`terraform plan` and `terraform apply`
- confirm that the trigger was made in your local poodle ui (with a dynamic threshold)

You can adjust the example to test validations: 
- only include one of the `baseline_details` fields, like `type` but no `offset_minutes`
- give it an invalid `type` (not `value` or `percentage`)
- give it an invalid `offset_minutes` (not 60, 1440, 10080, or 40320)
