### PR TITLE
feat(d/environment): add detail_filter to simplify environment lookup

### DIFF
--- a/docs/data-sources/environment.md
+++ b/docs/data-sources/environment.md
@@ -22,8 +22,10 @@ data "honeycombio_environment" "prod" {
 
 ```hcl
 data "honeycombio_environment" "classic" {
-  detail_filter = "name"
-  value         = "Classic"
+  detail_filter {
+    name  = "name"
+    value = "Classic"
+  }
 }
 
 data "honeycombio_environment" "prod" {

--- a/docs/data-sources/environment.md
+++ b/docs/data-sources/environment.md
@@ -1,7 +1,10 @@
 # Data Source: honeycombio_environment
 
 The `honeycombio_environment` data source retrieves the details of a single Environment.
-If you want to retrieve multiple Environments, use the `honeycombio_environments` data source instead.
+
+~> **Warning** Terraform will fail unless exactly one environment is returned by the search.
+  Ensure that your search is specific enough to return a single environment only.
+  If you want to retrieve multiple environments, use the `honeycombio_environments` data source instead.
 
 -> This data source requires the provider be configured with a Management Key with `environments:read` in the configured scopes.
 
@@ -15,11 +18,34 @@ data "honeycombio_environment" "prod" {
 }
 ```
 
+### Filter Example
+
+```hcl
+data "honeycombio_environment" "classic" {
+  detail_filter = "name"
+  value         = "Classic"
+}
+
+data "honeycombio_environment" "prod" {
+  detail_filter {
+    name  = "name"
+    value = "prod"
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
 
-* `id` - (Required) The ID of the Environment
+* `id` - (Optional) The ID of the Environment. Conflicts with `detail_filter`.
+* `detail_filter` - (Optional) a block to further filter results as described below. `name` must be set when providing a filter.
+
+To filter the results, a `detail_filter` block can be provided which accepts the following arguments:
+
+* `name` - (Required) The name of the detail field to filter by. Currently only `name` is supported.
+* `value` - (Optional) The value of the detail field to match on.
+* `value_regex` - (Optional) A regular expression string to apply to the value of the detail field to match on.
 
 ## Attribute Reference
 
@@ -30,4 +56,3 @@ In addition to all arguments above, the following attributes are exported:
 * `description` - the Environment's description.
 * `color` - the Environment's color.
 * `delete_protected` - the current state of the Environment's deletion protection status.
-

--- a/internal/models/environments.go
+++ b/internal/models/environments.go
@@ -5,12 +5,13 @@ import (
 )
 
 type EnvironmentResourceModel struct {
-	ID              types.String `tfsdk:"id"`
-	Name            types.String `tfsdk:"name"`
-	Slug            types.String `tfsdk:"slug"`
-	Description     types.String `tfsdk:"description"`
-	Color           types.String `tfsdk:"color"`
-	DeleteProtected types.Bool   `tfsdk:"delete_protected"`
+	ID              types.String        `tfsdk:"id"`
+	DetailFilter    []DetailFilterModel `tfsdk:"detail_filter"`
+	Name            types.String        `tfsdk:"name"`
+	Slug            types.String        `tfsdk:"slug"`
+	Description     types.String        `tfsdk:"description"`
+	Color           types.String        `tfsdk:"color"`
+	DeleteProtected types.Bool          `tfsdk:"delete_protected"`
 }
 
 type EnvironmentsDataSourceModel struct {

--- a/internal/models/environments.go
+++ b/internal/models/environments.go
@@ -5,6 +5,15 @@ import (
 )
 
 type EnvironmentResourceModel struct {
+	ID              types.String `tfsdk:"id"`
+	Name            types.String `tfsdk:"name"`
+	Slug            types.String `tfsdk:"slug"`
+	Description     types.String `tfsdk:"description"`
+	Color           types.String `tfsdk:"color"`
+	DeleteProtected types.Bool   `tfsdk:"delete_protected"`
+}
+
+type EnvironmentDataSourceModel struct {
 	ID              types.String        `tfsdk:"id"`
 	DetailFilter    []DetailFilterModel `tfsdk:"detail_filter"`
 	Name            types.String        `tfsdk:"name"`

--- a/internal/provider/environment_data_source.go
+++ b/internal/provider/environment_data_source.go
@@ -4,12 +4,16 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	v2client "github.com/honeycombio/terraform-provider-honeycombio/client/v2"
 	"github.com/honeycombio/terraform-provider-honeycombio/internal/helper"
+	"github.com/honeycombio/terraform-provider-honeycombio/internal/helper/filter"
 	"github.com/honeycombio/terraform-provider-honeycombio/internal/models"
 )
 
@@ -33,11 +37,20 @@ func (d *environmentDataSource) Metadata(_ context.Context, req datasource.Metad
 
 func (d *environmentDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description: "Fetches the details of a single Environment.",
+		Description: `Fetches the details of a single Environment.
+
+Note: Terraform will fail unless exactly one environment is returned by the search.
+Ensure that your search is specific enough to return a single environment only.
+If you want to match multiple environments, use the 'honeycombio_environments' data source instead.
+`,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description: "The ID of the Environment to fetch.",
-				Required:    true,
+				Optional:    true,
+				Computed:    true,
+				Validators: []validator.String{
+					stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("detail_filter")),
+				},
 			},
 			"name": schema.StringAttribute{
 				Description: "The name of the Environment.",
@@ -70,6 +83,9 @@ func (d *environmentDataSource) Schema(_ context.Context, _ datasource.SchemaReq
 				Required:    false,
 			},
 		},
+		Blocks: map[string]schema.Block{
+			"detail_filter": detailFilterSchema(),
+		},
 	}
 }
 
@@ -94,10 +110,61 @@ func (d *environmentDataSource) Read(ctx context.Context, req datasource.ReadReq
 		return
 	}
 
-	env, err := d.client.Environments.Get(ctx, data.ID.ValueString())
-	if helper.AddDiagnosticOnError(&resp.Diagnostics,
-		fmt.Sprintf("Looking up Environment %q", data.ID.ValueString()), err) {
-		return
+	var err error
+	var env *v2client.Environment
+	if !data.ID.IsNull() {
+		env, err = d.client.Environments.Get(ctx, data.ID.ValueString())
+		if helper.AddDiagnosticOnError(&resp.Diagnostics,
+			fmt.Sprintf("Looking up Environment %q", data.ID.ValueString()), err) {
+			return
+		}
+	} else {
+		// we're using the detail filter to find the environment
+		var envFilter *filter.DetailFilter
+		if len(data.DetailFilter) > 0 {
+			envFilter, err = data.DetailFilter[0].NewFilter()
+			if err != nil {
+				resp.Diagnostics.AddError("Unable to create Environment filter", err.Error())
+				return
+			}
+		}
+
+		pager, err := d.client.Environments.List(ctx)
+		if helper.AddDiagnosticOnError(&resp.Diagnostics, "Listing Environments", err) {
+			return
+		}
+		envs := []*v2client.Environment{}
+		for pager.HasNext() {
+			items, err := pager.Next(ctx)
+			if helper.AddDiagnosticOnError(&resp.Diagnostics, "Listing Environments", err) {
+				return
+			}
+			envs = append(envs, items...)
+		}
+
+		matched := make([]*v2client.Environment, 0, len(envs))
+		for _, e := range envs {
+			if !envFilter.MatchName(e.Name) {
+				continue
+			}
+			matched = append(matched, e)
+		}
+
+		if len(matched) == 0 {
+			resp.Diagnostics.AddError(
+				"No Environments found",
+				"Your filter returned no matches.",
+			)
+			return
+		}
+		if len(matched) > 1 {
+			resp.Diagnostics.AddError(
+				"Multiple Environments found",
+				"Please filter by ID or use a more specific detail filter.",
+			)
+			return
+		}
+		env = matched[0]
 	}
 
 	data.ID = types.StringValue(env.ID)

--- a/internal/provider/environment_data_source.go
+++ b/internal/provider/environment_data_source.go
@@ -104,7 +104,7 @@ func (d *environmentDataSource) Configure(ctx context.Context, req datasource.Co
 }
 
 func (d *environmentDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
-	var data models.EnvironmentResourceModel
+	var data models.EnvironmentDataSourceModel
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/environment_data_source_test.go
+++ b/internal/provider/environment_data_source_test.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -19,19 +20,62 @@ func TestAcc_EnvironmentDataSource(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`
-data "honeycombio_environment" "test" {
+data "honeycombio_environment" "test_id" {
   id = "%s"
-}`, env.ID),
+}
+
+data "honeycombio_environment" "test_filter" {
+  detail_filter {
+    name = "name"
+    value = "%s"
+  }
+}`, env.ID, env.Name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.honeycombio_environment.test", "id", env.ID),
-					resource.TestCheckResourceAttr("data.honeycombio_environment.test", "name", env.Name),
-					resource.TestCheckResourceAttr("data.honeycombio_environment.test", "slug", env.Slug),
-					resource.TestCheckResourceAttr("data.honeycombio_environment.test", "color", *env.Color),
-					resource.TestCheckResourceAttr("data.honeycombio_environment.test", "description", *env.Description),
-					resource.TestCheckResourceAttr("data.honeycombio_environment.test", "delete_protected", "true"),
+					resource.TestCheckResourceAttr("data.honeycombio_environment.test_id", "id", env.ID),
+					resource.TestCheckResourceAttr("data.honeycombio_environment.test_id", "name", env.Name),
+					resource.TestCheckResourceAttr("data.honeycombio_environment.test_id", "slug", env.Slug),
+					resource.TestCheckResourceAttr("data.honeycombio_environment.test_id", "color", *env.Color),
+					resource.TestCheckResourceAttr("data.honeycombio_environment.test_id", "description", *env.Description),
+					resource.TestCheckResourceAttr("data.honeycombio_environment.test_id", "delete_protected", "true"),
+					resource.TestCheckResourceAttr("data.honeycombio_environment.test_filter", "id", env.ID),
+					resource.TestCheckResourceAttr("data.honeycombio_environment.test_filter", "name", env.Name),
+					resource.TestCheckResourceAttr("data.honeycombio_environment.test_filter", "slug", env.Slug),
+					resource.TestCheckResourceAttr("data.honeycombio_environment.test_filter", "color", *env.Color),
+					resource.TestCheckResourceAttr("data.honeycombio_environment.test_filter", "description", *env.Description),
+					resource.TestCheckResourceAttr("data.honeycombio_environment.test_filter", "delete_protected", "true"),
 				),
 			},
 		},
 	})
 
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 testAccPreCheckV2API(t),
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+data "honeycombio_environment" "test" {
+  id = "boop"
+
+  detail_filter {
+    name  = "name"
+    value = "boop"
+  }
+}`,
+				ExpectError: regexp.MustCompile(`Attribute "detail_filter" cannot be specified when "id" is specified`),
+				PlanOnly:    true,
+			},
+			{
+				Config: `
+data "honeycombio_environment" "test" {
+  detail_filter {
+    name  = "name"
+    value = "boop"
+  }
+}`,
+				ExpectError: regexp.MustCompile(`Your filter returned no matches`),
+				PlanOnly:    true,
+			},
+		},
+	})
 }


### PR DESCRIPTION
Received feedback that looking up environment IDs was a bit awkward.

This allows looking up a single environment via a filter: the "no match" behaviour may feel like a breaking change but when `id` was the only option the data source would fail with 404 anyway, so, the same net-result.