### PR TITLE
fix(r/trigger,r/burn_alert): gracefully handle recipients with notification details on import

### DIFF
--- a/internal/provider/burn_alert_resource.go
+++ b/internal/provider/burn_alert_resource.go
@@ -229,11 +229,10 @@ func (r *burnAlertResource) ImportState(ctx context.Context, req resource.Import
 		dsValue = types.StringValue(dataset)
 	}
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, &models.BurnAlertResourceModel{
-		ID:         types.StringValue(id),
-		Dataset:    dsValue,
-		Recipients: types.SetUnknown(types.ObjectType{AttrTypes: models.NotificationRecipientAttrType}),
-	})...)
+	req.ID = id
+	resp.State.SetAttribute(ctx, path.Root("dataset"), dsValue)
+
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
 func (r *burnAlertResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {

--- a/internal/provider/notification_recipients.go
+++ b/internal/provider/notification_recipients.go
@@ -220,24 +220,6 @@ func expandNotificationRecipients(ctx context.Context, set types.Set, diags *dia
 
 	return clientRecips
 }
-
-func notificationRecipientToObjectValue(ctx context.Context, r client.NotificationRecipient, diags *diag.Diagnostics) basetypes.ObjectValue {
-	recipObj := map[string]attr.Value{
-		"id":                   types.StringValue(r.ID),
-		"type":                 types.StringValue(string(r.Type)),
-		"target":               types.StringValue(r.Target),
-		"notification_details": types.ListNull(types.ObjectType{AttrTypes: models.NotificationRecipientDetailsAttrType}),
-	}
-
-	if r.Type == client.RecipientTypeWebhook || r.Type == client.RecipientTypePagerDuty {
-		recipObj["notification_details"] = notificationRecipientDetailsToList(ctx, r.Details, diags)
-	}
-	recipObjVal, d := types.ObjectValue(models.NotificationRecipientAttrType, recipObj)
-	diags.Append(d...)
-
-	return recipObjVal
-}
-
 func notificationRecipientModelToObjectValue(ctx context.Context, r models.NotificationRecipientModel, diags *diag.Diagnostics) basetypes.ObjectValue {
 	recipObj := map[string]attr.Value{
 		"id":     r.ID,

--- a/internal/provider/notification_recipients.go
+++ b/internal/provider/notification_recipients.go
@@ -147,9 +147,29 @@ func mapNotificationRecipientToState(ctx context.Context, remote []client.Notifi
 }
 
 func reconcileReadNotificationRecipientState(ctx context.Context, remote []client.NotificationRecipient, state types.Set, diags *diag.Diagnostics) types.Set {
-	if state.IsNull() || state.IsUnknown() {
-		// if we don't have any state, we can't reconcile anything so just return the remote recipients
-		return flattenNotificationRecipients(ctx, remote, diags)
+	if len(remote) == 0 || state.IsUnknown() {
+		return types.SetNull(types.ObjectType{AttrTypes: models.NotificationRecipientAttrType})
+	}
+
+	if state.IsNull() {
+		// if we don't have any state, we can't reconcile anything so
+		// just return the remote recipients biased toward id over type+target
+		var values []attr.Value
+		for _, r := range remote {
+			recipObj, d := types.ObjectValue(models.NotificationRecipientAttrType, map[string]attr.Value{
+				"id":                   types.StringValue(r.ID),
+				"type":                 types.StringNull(),
+				"target":               types.StringNull(),
+				"notification_details": types.ListNull(types.ObjectType{AttrTypes: models.NotificationRecipientDetailsAttrType}),
+			})
+			diags.Append(d...)
+
+			values = append(values, recipObj)
+		}
+		result, d := types.SetValueFrom(ctx, types.ObjectType{AttrTypes: models.NotificationRecipientAttrType}, values)
+		diags.Append(d...)
+
+		return result
 	}
 
 	var recipients []models.NotificationRecipientModel
@@ -201,27 +221,16 @@ func expandNotificationRecipients(ctx context.Context, set types.Set, diags *dia
 	return clientRecips
 }
 
-func flattenNotificationRecipients(ctx context.Context, n []client.NotificationRecipient, diags *diag.Diagnostics) types.Set {
-	if len(n) == 0 {
-		return types.SetNull(types.ObjectType{AttrTypes: models.NotificationRecipientAttrType})
-	}
-
-	var values []attr.Value
-	for _, r := range n {
-		values = append(values, notificationRecipientToObjectValue(ctx, r, diags))
-	}
-	result, d := types.SetValueFrom(ctx, types.ObjectType{AttrTypes: models.NotificationRecipientAttrType}, values)
-	diags.Append(d...)
-
-	return result
-}
-
 func notificationRecipientToObjectValue(ctx context.Context, r client.NotificationRecipient, diags *diag.Diagnostics) basetypes.ObjectValue {
 	recipObj := map[string]attr.Value{
 		"id":                   types.StringValue(r.ID),
 		"type":                 types.StringValue(string(r.Type)),
 		"target":               types.StringValue(r.Target),
-		"notification_details": notificationRecipientDetailsToList(ctx, r.Details, diags),
+		"notification_details": types.ListNull(types.ObjectType{AttrTypes: models.NotificationRecipientDetailsAttrType}),
+	}
+
+	if r.Type == client.RecipientTypeWebhook || r.Type == client.RecipientTypePagerDuty {
+		recipObj["notification_details"] = notificationRecipientDetailsToList(ctx, r.Details, diags)
 	}
 	recipObjVal, d := types.ObjectValue(models.NotificationRecipientAttrType, recipObj)
 	diags.Append(d...)

--- a/internal/provider/notification_recipients_test.go
+++ b/internal/provider/notification_recipients_test.go
@@ -38,7 +38,7 @@ func Test_reconcileReadNotificationRecipientState(t *testing.T) {
 				state: types.SetNull(elemType),
 			},
 			want: notificationRecipientModelsToSet([]models.NotificationRecipientModel{
-				{ID: types.StringValue("abcd12345"), Type: types.StringValue("email"), Target: types.StringValue("test@example.com")},
+				{ID: types.StringValue("abcd12345")}, // we use ID over type+target when there is no state
 			}),
 		},
 		{

--- a/internal/provider/trigger_resource.go
+++ b/internal/provider/trigger_resource.go
@@ -517,17 +517,11 @@ func (r *triggerResource) ImportState(ctx context.Context, req resource.ImportSt
 		)
 		return
 	}
+	req.ID = id
+	resp.State.SetAttribute(ctx, path.Root("dataset"), dataset)
+	resp.State.SetAttribute(ctx, path.Root("query_id"), types.StringNull()) // favor query_json on import
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, &models.TriggerResourceModel{
-		ID:                 types.StringValue(id),
-		Dataset:            types.StringValue(dataset),
-		QueryID:            types.StringNull(),
-		QueryJson:          types.StringUnknown(), // favor QueryJSON on import
-		Recipients:         types.SetUnknown(types.ObjectType{AttrTypes: models.NotificationRecipientAttrType}),
-		Threshold:          types.ListUnknown(types.ObjectType{AttrTypes: models.TriggerThresholdAttrType}),
-		EvaluationSchedule: types.ListUnknown(types.ObjectType{AttrTypes: models.TriggerEvaluationScheduleAttrType}),
-		BaselineDetails:    types.ListUnknown(types.ObjectType{AttrTypes: models.TriggerBaselineDetailsAttrType}),
-	})...)
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
 func (r *triggerResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {


### PR DESCRIPTION
We've had multiple reports (and finally a repro. case!) where importing a trigger (or presumably a burn alert) which has one or more recipients with `notification_details` causes an error on `apply` looking something like this:

```
honeycombio_trigger.test: Modifying... [id=2TQRBJ7xp3s]
╷
│ Error: Provider produced inconsistent result after apply
│
│ When applying changes to honeycombio_trigger.test, provider "provider[\"registry.terraform.io/honeycombio/honeycombio\"]" produced an unexpected new value: .recipient: planned set element
│ cty.ObjectVal(map[string]cty.Value{"id":cty.StringVal("tqGosJVZzkN"), "notification_details":cty.ListValEmpty(cty.Object(map[string]cty.Type{"pagerduty_severity":cty.String,
│ "variable":cty.Set(cty.Object(map[string]cty.Type{"name":cty.String, "value":cty.String}))})), "target":cty.StringVal("#test.93259235823"), "type":cty.StringVal("slack")}) does not correlate
│ with any element in actual.
│
│ This is a bug in the provider, which should be reported in the provider's own issue tracker.
```

The general description of the fix is that on import we will now populate the recipients as sparsely as possible (just `id`), and allow later mapping between the remote side (API) and the configuration to resolve state.

### Testing

Annoyingly, a _cannot_ get the test suite to put state in the correct, uh, state to trigger this bug but it can be done manually by:

1. writing a configuration for a trigger with a "pagerduty" or "webhook" recipient and applying it
1. removing that trigger from state (`terraform state rm honeycombio_trigger.mytrigger`)
1. importing that trigger (`terraform import honeycombio_trigger.mytrigger dataset/3hjsdf38`)
1. running `terraform apply`

Following the steps above prior to this change produces the "inconsistent result after apply" error above.


- Closes #640 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210057444771670