### PR TITLE
chore(ci): fix CI status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Honeycomb.io Terraform Provider
 
 [![OSS Lifecycle](https://img.shields.io/osslifecycle/honeycombio/terraform-provider-honeycombio)](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md)
-[![CI](https://github.com/honeycombio/terraform-provider-honeycombio/workflows/CI/badge.svg)](https://github.com/honeycombio/terraform-provider-honeycombio/actions)
+[![CI](https://github.com/honeycombio/terraform-provider-honeycombio/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/honeycombio/terraform-provider-honeycombio/actions/workflows/ci.yaml)
 [![Terraform Registry](https://img.shields.io/github/v/release/honeycombio/terraform-provider-honeycombio?color=5e4fe3&label=Terraform%20Registry&logo=terraform&sort=semver)](https://registry.terraform.io/providers/honeycombio/honeycombio/latest)
 
 A Terraform provider for Honeycomb.io.


### PR DESCRIPTION
Noticed the CI badge was showing red this morning because some PR workflows were failing: this status badge should be reflective of the health of the `main` branch.

New Markdown was generated by following [these instructions](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/monitoring-workflows/adding-a-workflow-status-badge).