### PR TITLE
feat(r/triggers): add support for tags on triggers

### DIFF
--- a/client/trigger.go
+++ b/client/trigger.go
@@ -76,6 +76,9 @@ type Trigger struct {
 	// Recipients are notified when the trigger fires.
 	Recipients      []NotificationRecipient `json:"recipients,omitempty"`
 	BaselineDetails *TriggerBaselineDetails `json:"baseline_details,omitempty"`
+	// Tags are used to categorize triggers. They can be used to filtering triggers
+	// and are useful for grouping triggers together.
+	Tags []Tag `json:"tags"`
 }
 
 type TriggerBaselineDetails struct {

--- a/docs/resources/trigger.md
+++ b/docs/resources/trigger.md
@@ -114,6 +114,11 @@ resource "honeycombio_trigger" "example" {
       "friday"
     ]
   }
+
+  tags = {
+    team = "backend"
+    env  = "production"
+  }
 }
 ```
 ### Example - Example with Webhook Recipient and Notification Variable
@@ -179,6 +184,11 @@ resource "honeycombio_trigger" "example" {
             "friday"
         ]
     }
+
+  tags = {
+      team = "backend"
+      env  = "production"
+  }
 }
 ```
 
@@ -212,6 +222,11 @@ resource "honeycombio_trigger" "example" {
     baseline_details {
         type            = "percentage"
         offset_minutes  = 1440
+    }
+
+    tags = {
+        team = "backend"
+        env  = "production"
     }
 }
 ```

--- a/example/trigger_with_baseline_details/main.tf
+++ b/example/trigger_with_baseline_details/main.tf
@@ -50,6 +50,11 @@ resource "honeycombio_trigger" "trigger" {
     type = "percentage"
     offset_minutes = 1440
   }
+
+  tags = {
+    team = "backend"
+    env  = "production"
+  }
 }
 
 

--- a/example/trigger_with_slack_recipient/main.tf
+++ b/example/trigger_with_slack_recipient/main.tf
@@ -50,4 +50,9 @@ resource "honeycombio_trigger" "trigger" {
   }
 
   frequency = 1800
+
+  tags = {
+    team = "backend"
+    env  = "production"
+  }
 }

--- a/internal/helper/tags.go
+++ b/internal/helper/tags.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
 	"github.com/honeycombio/terraform-provider-honeycombio/client"
 )
 

--- a/internal/helper/tags.go
+++ b/internal/helper/tags.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-
 	"github.com/honeycombio/terraform-provider-honeycombio/client"
 )
 
@@ -20,4 +19,28 @@ func TagsToMap(ctx context.Context, tags []client.Tag) (types.Map, diag.Diagnost
 		return types.MapValueFrom(ctx, types.StringType, tagMap)
 	}
 	return types.MapNull(types.StringType), nil
+}
+
+// MapToTags converts a map attribute of tags to a slice of client.Tag objects.
+// If the map is null, it returns an empty slice to clear any existing tags.
+func MapToTags(ctx context.Context, tagsMap types.Map) ([]client.Tag, diag.Diagnostics) {
+	var tags []client.Tag
+
+	if !tagsMap.IsNull() {
+		var tagMap map[string]string
+		diags := tagsMap.ElementsAs(ctx, &tagMap, false)
+		if diags.HasError() {
+			return nil, diags
+		}
+
+		for k, v := range tagMap {
+			tags = append(tags, client.Tag{Key: k, Value: v})
+		}
+	} else {
+		// if 'tags' is not present in the config, set to empty slice
+		// to clear the tags
+		tags = make([]client.Tag, 0)
+	}
+
+	return tags, nil
 }

--- a/internal/models/triggers.go
+++ b/internal/models/triggers.go
@@ -19,6 +19,7 @@ type TriggerResourceModel struct {
 	Recipients         types.Set    `tfsdk:"recipient"`           // NotificationRecipientModel
 	EvaluationSchedule types.List   `tfsdk:"evaluation_schedule"` // TriggerEvaluationScheduleModel
 	BaselineDetails    types.List   `tfsdk:"baseline_details"`
+	Tags               types.Map    `tfsdk:"tags"`
 }
 
 type TriggerBaselineDetailsModel struct {

--- a/internal/provider/slo_resource.go
+++ b/internal/provider/slo_resource.go
@@ -382,20 +382,9 @@ func expandSLO(ctx context.Context, plan models.SLOResourceModel) (*client.SLO, 
 		}
 	}
 
-	var tags []client.Tag
-	if !plan.Tags.IsNull() {
-		var tagMap map[string]string
-		diags := plan.Tags.ElementsAs(ctx, &tagMap, false)
-		if diags.HasError() {
-			return nil, fmt.Errorf("error extracting tags: %v", diags)
-		}
-		for k, v := range tagMap {
-			tags = append(tags, client.Tag{Key: k, Value: v})
-		}
-	} else {
-		// if 'tags' is not present in the config, set to empty slice
-		// to clear the tags
-		tags = make([]client.Tag, 0)
+	tags, diags := helper.MapToTags(ctx, plan.Tags)
+	if diags.HasError() {
+		return nil, fmt.Errorf("error extracting tags: %v", diags)
 	}
 
 	slo := &client.SLO{


### PR DESCRIPTION
## Which problem is this PR solving?

add support for tagging triggers

## Short description of the changes
- update create, read and update methods to support tags on triggers.
- move shared code for MapToTags to tags helper

## How to verify that this has the expected result

1. Create a trigger with tags. For example,

```
resource "honeycombio_trigger" "trigger" {
  name = "Requests are slower than usual"

  query_json = data.honeycombio_query_specification.query.json
  dataset    = var.dataset

  threshold {
    op    = ">"
    value = 1000
  }

  // Add a recipient by ID, this will not create a new recipient.
  recipient {
    id = data.honeycombio_recipient.slack.id
  }
  recipient {
    type   = "email"
    target = "hello@example.com"
  }

  frequency = 1800

  tags = {
    team = "backend"
    env  = "production"
  }
}
``` 

2. Update the tags and the state should show the latest updated values