### PR TITLE
fix(client): use proper format for Retry-After fallback

### DIFF
--- a/client/internal/limits/limits.go
+++ b/client/internal/limits/limits.go
@@ -71,7 +71,7 @@ func rateLimitBackoff(mini, maxi time.Duration, r *http.Response) time.Duration 
 	// try the retry-after header
 	if reset == 0 {
 		if v := r.Header.Get(HeaderRetryAfter); v != "" {
-			retryTime, err := time.Parse(time.RFC3339, v)
+			retryTime, err := time.Parse(http.TimeFormat, v)
 			if err == nil {
 				reset = time.Until(retryTime)
 			}

--- a/client/internal/limits/limits_test.go
+++ b/client/internal/limits/limits_test.go
@@ -48,7 +48,7 @@ func TestClient_rateLimitBackoff(t *testing.T) {
 		{
 			name:          "valid retry-after header",
 			headerName:    HeaderRetryAfter,
-			headerValue:   now.Add(2 * time.Minute).UTC().Format(time.RFC3339),
+			headerValue:   now.Add(2 * time.Minute).UTC().Format(http.TimeFormat),
 			expectedValue: 2 * time.Minute,
 		},
 		{
@@ -82,7 +82,7 @@ func TestClient_rateLimitBackoff(t *testing.T) {
 	t.Run("ratelimit header takes precedence", func(t *testing.T) {
 		w := httptest.NewRecorder()
 		w.Header().Add(HeaderRateLimit, "limit=100, remaining=50, reset=60")
-		w.Header().Add(HeaderRetryAfter, now.Add(2*time.Minute).UTC().Format(time.RFC3339))
+		w.Header().Add(HeaderRetryAfter, now.Add(2*time.Minute).UTC().Format(http.TimeFormat))
 		w.WriteHeader(http.StatusTooManyRequests)
 
 		r := rateLimitBackoff(mini, maxi, w.Result())


### PR DESCRIPTION
Matching the soon to be released upstream change, this updates `Retry-After` to be parsed properly if we happen to fallback on using it (which, is unlikely to be honest).