### PR TITLE
Fix incorrect "prefer_overlaid_charts" field name in flexible board docs

### DIFF
--- a/docs/resources/flexible_board.md
+++ b/docs/resources/flexible_board.md
@@ -154,7 +154,7 @@ Each `visualization_settings` configuration accepts the following arguments:
 - `use_utc_xaxis` - (Optional) Display UTC Time X-Axis or Localtime X-Axis.
 - `hide_markers` - (Optional) Hide [markers](https://docs.honeycomb.io/investigate/query/customize-results/#markers) from appearing on graph.
 - `hide_hovers` - (Optional) Disable Graph tooltips in the results display when hovering over a graph.
-- `overlaid_charts` - (Optional) Combine any visualized AVG, MIN, MAX, and PERCENTILE clauses into a single chart.
+- `prefer_overlaid_charts` - (Optional) Combine any visualized AVG, MIN, MAX, and PERCENTILE clauses into a single chart.
 - `chart` - (Optional) a configuration block to manage the query's charts.
 
 Each `chart` configuration accepts the following arguments:


### PR DESCRIPTION
May want to call this out in the migration guide for honeycomb_board -> honeycomb_flexible_board, also.
