### PR TITLE
chore(docs): clarify that dataset and datasets field of slos expect slugs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -93,7 +93,8 @@ At least one of `api_key`, or the `api_key_id` and `api_key_secret` pair must be
 
 ## A note on "Datasets"
 
-Several resources in this provider accept a `dataset` or `datasets` argument to specify which Honeycomb Dataset the resource belongs to. These resources include but aren't limited to
+Several resources in this provider accept a `dataset` or `datasets` argument to specify which Honeycomb Dataset the resource belongs to.
+These resources include but aren't limited to:
 * queries
 * triggers
 * slos

--- a/docs/index.md
+++ b/docs/index.md
@@ -90,3 +90,15 @@ Arguments accepted by this provider include:
 * `debug` - (Optional) Enable to log additional debug information. To view the logs, set `TF_LOG` to at least debug.
 
 At least one of `api_key`, or the `api_key_id` and `api_key_secret` pair must be configured.
+
+## A note on "Datasets"
+
+Several resources in this provider accept a `dataset` or `datasets` argument to specify which Honeycomb Dataset the resource belongs to. These resources include but aren't limited to
+* queries
+* triggers
+* slos
+* markers
+* columns
+* boards
+
+Whenever a resource accepts a `dataset` or `datasets` argument, the argument is expected to be a Dataset **slug**, not a Dataset name or ID. Dataset slugs can be found in the URL of the dataset in the Honeycomb UI, or in the `slug` field of the [Dataset API](https://api-docs.honeycomb.io/api/datasets/createdataset#datasets/createdataset/t=response&c=200&path=slug).

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,6 +39,20 @@ resource "honeycombio_marker" "hello" {
 
 More advanced examples can be found in the [example directory](https://github.com/honeycombio/terraform-provider-honeycombio/tree/main/example).
 
+## A note on "Datasets"
+
+Several resources in this provider accept a `dataset` or `datasets` argument to specify which Honeycomb Dataset the resource belongs to.
+These resources include but aren't limited to:
+* queries
+* triggers
+* slos
+* markers
+* columns
+* boards
+
+Whenever a resource accepts a `dataset` or `datasets` argument, the argument is expected to be a Dataset **slug**, not a Dataset name or ID.
+Dataset slugs can be found in the URL of the dataset in the Honeycomb UI, or in the `slug` field of the [Dataset API](https://api-docs.honeycomb.io/api/datasets/createdataset#datasets/createdataset/t=response&c=200&path=slug).
+
 ### Configuring the provider for Honeycomb EU
 
 If you are a Honeycomb EU customer, to use the provider you must override the default API host.
@@ -90,16 +104,3 @@ Arguments accepted by this provider include:
 * `debug` - (Optional) Enable to log additional debug information. To view the logs, set `TF_LOG` to at least debug.
 
 At least one of `api_key`, or the `api_key_id` and `api_key_secret` pair must be configured.
-
-## A note on "Datasets"
-
-Several resources in this provider accept a `dataset` or `datasets` argument to specify which Honeycomb Dataset the resource belongs to.
-These resources include but aren't limited to:
-* queries
-* triggers
-* slos
-* markers
-* columns
-* boards
-
-Whenever a resource accepts a `dataset` or `datasets` argument, the argument is expected to be a Dataset **slug**, not a Dataset name or ID. Dataset slugs can be found in the URL of the dataset in the Honeycomb UI, or in the `slug` field of the [Dataset API](https://api-docs.honeycomb.io/api/datasets/createdataset#datasets/createdataset/t=response&c=200&path=slug).

--- a/docs/resources/slo.md
+++ b/docs/resources/slo.md
@@ -74,8 +74,8 @@ The following arguments are supported:
 
 -   `name` - (Required) The name of the SLO.
 -   `description` - (Optional) A description of the SLO's intent and context.
--   `dataset` - (Optional) The slug of the dataset this SLO is created in. Must be the same dataset as the SLI unless the SLI is an Environment-wide Derived Column. Conflicts with `datasets`. Will be deprecated in a future release of the provider.
--   `datasets` - (Optional) Array of slugs for the datasets the SLO is evaluated on. Conflicts with `dataset`. Must have a length between 1 and 10.
+-   `dataset` - (Optional) The dataset this SLO is created in. Must be the same dataset as the SLI unless the SLI is an Environment-wide Derived Column. Conflicts with `datasets`. Will be deprecated in a future release of the provider.
+-   `datasets` - (Optional) Array of datasets the SLO is evaluated on. Conflicts with `dataset`. Must have a length between 1 and 10.
 -   `sli` - (Required) The alias of the Derived Column that will be used as the SLI to indicate event success.
     The derived column used as the SLI must be in the same dataset as the SLO. Additionally,
     the column evaluation should consistently return nil, true, or false, as these are the only valid values for an SLI.

--- a/docs/resources/slo.md
+++ b/docs/resources/slo.md
@@ -74,8 +74,8 @@ The following arguments are supported:
 
 -   `name` - (Required) The name of the SLO.
 -   `description` - (Optional) A description of the SLO's intent and context.
--   `dataset` - (Optional) The dataset this SLO is created in. Must be the same dataset as the SLI unless the SLI is an Environment-wide Derived Column. Conflicts with `datasets`. Will be deprecated in a future release of the provider.
--   `datasets` - (Optional) Array of datasets the SLO is evaluated on. Conflicts with `dataset`. Must have a length between 1 and 10.
+-   `dataset` - (Optional) The slug of the dataset this SLO is created in. Must be the same dataset as the SLI unless the SLI is an Environment-wide Derived Column. Conflicts with `datasets`. Will be deprecated in a future release of the provider.
+-   `datasets` - (Optional) Array of slugs for the datasets the SLO is evaluated on. Conflicts with `dataset`. Must have a length between 1 and 10.
 -   `sli` - (Required) The alias of the Derived Column that will be used as the SLI to indicate event success.
     The derived column used as the SLI must be in the same dataset as the SLO. Additionally,
     the column evaluation should consistently return nil, true, or false, as these are the only valid values for an SLI.


### PR DESCRIPTION
## Which problem is this PR solving?

The SLO resource has two fields for specifying what dataset the SLO is in: `dataset` and `datasets`.

Our [public API](https://api-docs.honeycomb.io/api/slos/createslo) for SLOs (which the Terraform client uses) expects dataset slugs.

This PR clarifies in our documentation that `dataset` and `datasets` must be dataset slugs, not dataset names.
