### PR TITLE
chore(client): add limit and disable series to query result request

### DIFF
--- a/client/query_result.go
+++ b/client/query_result.go
@@ -28,7 +28,7 @@ var _ QueryResults = (*queryResults)(nil)
 
 // QueryResult represents a Honeycomb query result.
 //
-// API docs: https://docs.honeycomb.io/api/query-results/#get-example-response
+// API docs: https://api-docs.honeycomb.io/api/query-data/getqueryresult
 type QueryResult struct {
 	// ID of a query result is only set when the query is returned from the
 	// Query Result API. This value should not be set when creating queries results.
@@ -46,6 +46,10 @@ type QueryResult struct {
 
 type QueryResultRequest struct {
 	ID string `json:"query_id"`
+	// If DisableSeries is true, Limit allows the default query limit of 1000 results to be overridden up to 10,000 results.
+	Limit int `json:"limit,omitempty"`
+	// DisableSeries controls whether timeseries data will be returned in the series response field. Defaults to false.
+	DisableSeries bool `json:"disable_series,omitempty"`
 }
 
 type QueryResultData struct {


### PR DESCRIPTION
## Which problem is this PR solving?

[Create Query Result](https://api-docs.honeycomb.io/api/query-data/createqueryresult) operations have several newer fields that this client doesn't know about, such as `limit` or `disable_series`. Used in combination, `limit` allows more than 1000 query results (up to 10k) to be returned in a single query.

## Short description of the changes

This PR updates the Client's `QueryResultRequest` to accept the `limit` and `disable_series` fields.

Follow up improvements will add these fields to the query resource. For now, this is just the client.

