### PR TITLE
fix(tags): handle empty tags map

### DIFF
--- a/internal/provider/slo_resource_test.go
+++ b/internal/provider/slo_resource_test.go
@@ -75,6 +75,34 @@ resource "honeycombio_slo" "test" {
 					resource.TestCheckResourceAttr("honeycombio_slo.test", "tags.%", "0"),
 				),
 			},
+			{ // test tags set to empty map
+				Config: fmt.Sprintf(`
+resource "honeycombio_slo" "test" {
+  name              = "TestAcc SLO"
+  description       = "updated integration test SLO"
+  dataset           = "%s"
+  sli               = "%s"
+  target_percentage = 99.99
+  time_period       = 30
+
+  tags = {}
+}`, dataset, sliAlias),
+				Check: resource.TestCheckResourceAttr("honeycombio_slo.test", "tags.%", "0"),
+			},
+			{ // test tags set to null
+				Config: fmt.Sprintf(`
+resource "honeycombio_slo" "test" {
+  name              = "TestAcc SLO"
+  description       = "updated integration test SLO"
+  dataset           = "%s"
+  sli               = "%s"
+  target_percentage = 99.99
+  time_period       = 30
+
+  tags = null
+}`, dataset, sliAlias),
+				Check: resource.TestCheckResourceAttr("honeycombio_slo.test", "tags.%", "0"),
+			},
 			{
 				ResourceName:        "honeycombio_slo.test",
 				ImportStateIdPrefix: fmt.Sprintf("%s/", dataset),

--- a/internal/provider/tags.go
+++ b/internal/provider/tags.go
@@ -3,7 +3,9 @@ package provider
 import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -17,17 +19,30 @@ func tagsSchema() schema.MapAttribute {
 	return schema.MapAttribute{
 		Description: "A map of tags to assign to the resource.",
 		Optional:    true,
+		Computed:    true,
 		ElementType: types.StringType,
+		Default: mapdefault.StaticValue( // Default to an empty map
+			types.MapValueMust(
+				types.StringType,
+				map[string]attr.Value{},
+			),
+		),
 		PlanModifiers: []planmodifier.Map{
 			modifiers.EquivalentTags(),
 		},
 		Validators: []validator.Map{
 			mapvalidator.SizeAtMost(client.MaxTagsPerResource),
 			mapvalidator.KeysAre(
-				stringvalidator.RegexMatches(client.TagKeyValidationRegex, "must only contain lowercase letters, and be 1-32 characters long"),
+				stringvalidator.RegexMatches(
+					client.TagKeyValidationRegex,
+					"must only contain lowercase letters, and be 1-32 characters long",
+				),
 			),
 			mapvalidator.ValueStringsAre(
-				stringvalidator.RegexMatches(client.TagValueValidationRegex, "must begin with a lowercase letter, be between 1-32 characters long, and only contain lowercase alphanumeric characters, -, or /"),
+				stringvalidator.RegexMatches(
+					client.TagValueValidationRegex,
+					"must begin with a lowercase letter, be between 1-32 characters long, and only contain lowercase alphanumeric characters, -, or /",
+				),
 			),
 		},
 	}


### PR DESCRIPTION
Handles setting `tags` to an empty map (e.g. `tags = {}`) without an apply-time error by making the tags default an empty map.

Includes an aliased import cleanup 🧹✨ 

- Closes #699 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210526264774553