### PR TITLE
fix(r/flexible_board): avoid panic on read with index check

### DIFF
--- a/internal/provider/flexible_board_resource.go
+++ b/internal/provider/flexible_board_resource.go
@@ -411,7 +411,7 @@ func (r *flexibleBoardResource) Read(ctx context.Context, req resource.ReadReque
 		panelsObj := make([]attr.Value, 0, len(board.Panels))
 		for i, panel := range board.Panels {
 			var prevPosition client.BoardPanel
-			if len(panelConfig) != 0 {
+			if len(panelConfig) != 0 && i < len(panelConfig) {
 				prevPosition = panelConfig[i]
 			}
 			panelValue := flattenBoardPanel(ctx, panel, &resp.Diagnostics, prevPosition)


### PR DESCRIPTION
Received a crash report via an internal channel:

```
│ Error: Plugin did not respond
│
│ The plugin encountered an error, and failed to respond to the plugin.(*GRPCProvider).ReadResource call. The plugin logs may contain more details.
╵

Stack trace from the terraform-provider-honeycombio_v0.36.0 plugin:

panic: runtime error: index out of range [8] with length 8

goroutine 151 [running]:
github.com/honeycombio/terraform-provider-honeycombio/internal/provider.(*flexibleBoardResource).Read(0xc0001c6038, {0x5ef6938, 0xc000881290}, {{{{0x5efd058, 0xc0007133e0}, {0x5d88f00, 0
xc000193c20}}, {0x5eff9f8, 0xc00047d2c0}}, 0x0, ...}, ...)
        github.com/honeycombio/terraform-provider-honeycombio/internal/provider/flexible_board_resource.go:415 +0xd85
github.com/hashicorp/terraform-plugin-framework/internal/fwserver.(*Server).ReadResource(0xc00015b908, {0x5ef6938, 0xc000881290}, 0xc000a2d3b0, 0xc0008b1530)
        github.com/hashicorp/terraform-plugin-framework@v1.15.0/internal/fwserver/server_readresource.go:156 +0xbae
github.com/hashicorp/terraform-plugin-framework/internal/proto5server.(*Server).ReadResource(0xc00015b908, {0x5ef6938?, 0xc000881170?}, 0xc000a2d310)
        github.com/hashicorp/terraform-plugin-framework@v1.15.0/internal/proto5server/server_readresource.go:72 +0x592
github.com/hashicorp/terraform-plugin-mux/tf5muxserver.(*muxServer).ReadResource(0xc000225e80, {0x5ef6938?, 0xc000880e10?}, 0xc000a2d310)
        github.com/hashicorp/terraform-plugin-mux@v0.20.0/tf5muxserver/mux_server_ReadResource.go:35 +0x196
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).ReadResource(0xc000416000, {0x5ef6938?, 0xc000880420?}, 0xc0001639d0)
        github.com/hashicorp/terraform-plugin-go@v0.28.0/tfprotov5/tf5server/server.go:859 +0x2f6
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ReadResource_Handler({0x5ec2f80, 0xc000416000}, {0x5ef6938, 0xc000880420}, 0xc0002aa680, 0x0)
        github.com/hashicorp/terraform-plugin-go@v0.28.0/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:651 +0x1a9
google.golang.org/grpc.(*Server).processUnaryRPC(0xc000306200, {0x5ef6938, 0xc000880390}, 0xc000851980, 0xc00040e900, 0x662b958, 0x0)
        google.golang.org/grpc@v1.72.1/server.go:1405 +0x103b
google.golang.org/grpc.(*Server).handleStream(0xc000306200, {0x5ef7310, 0xc0000ea000}, 0xc000851980)
        google.golang.org/grpc@v1.72.1/server.go:1815 +0xbaa
google.golang.org/grpc.(*Server).serveStreams.func2.1()
        google.golang.org/grpc@v1.72.1/server.go:1035 +0x7f
created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 8
        google.golang.org/grpc@v1.72.1/server.go:1046 +0x125

Error: The terraform-provider-honeycombio_v0.36.0 plugin crashed!

This is always indicative of a bug within the plugin. It would be immensely
helpful if you could report the crash with the plugin's maintainers so that it
can be fixed. The output above should help diagnose the issue.
```

Issue appears to be an unchecked indexing of a slice when reading board panels.