### PR TITLE
fix(r/slo): SLO update causing resource replacement

### DIFF
--- a/internal/helper/modifiers/datasets_require_replace.go
+++ b/internal/helper/modifiers/datasets_require_replace.go
@@ -1,0 +1,68 @@
+package modifiers
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// RequiresReplaceIfDatasetChanges returns a plan modifier that forces resource replacement
+// when the datasets field changes.
+func RequiresReplaceIfDatasetChanges() planmodifier.Set {
+	return requiresReplaceIfDatasetChangesSetModifier{}
+}
+
+var _ planmodifier.Set = &requiresReplaceIfDatasetChangesSetModifier{}
+
+type requiresReplaceIfDatasetChangesSetModifier struct{}
+
+func (r requiresReplaceIfDatasetChangesSetModifier) Description(ctx context.Context) string {
+	return "If the datasets value changes, Terraform will destroy and recreate the resource."
+}
+
+func (r requiresReplaceIfDatasetChangesSetModifier) MarkdownDescription(ctx context.Context) string {
+	return r.Description(ctx)
+}
+
+func (r requiresReplaceIfDatasetChangesSetModifier) PlanModifySet(ctx context.Context, req planmodifier.SetRequest, resp *planmodifier.SetResponse) {
+	// Don't require replacement during create
+	if req.State.Raw.IsNull() {
+		return
+	}
+
+	// Don't require replacement during destroy
+	if req.Plan.Raw.IsNull() {
+		return
+	}
+
+	var stateValue, planValue types.Set
+
+	resp.Diagnostics.Append(req.State.GetAttribute(ctx, req.Path, &stateValue)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, req.Path, &planValue)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// If both are null, no change
+	if stateValue.IsNull() && planValue.IsNull() {
+		return
+	}
+
+	// If both are unknown, can't determine change
+	if stateValue.IsUnknown() || planValue.IsUnknown() {
+		return
+	}
+
+	// If values are equal, no change
+	if stateValue.Equal(planValue) {
+		return
+	}
+
+	// If we get here, the datasets value has changed - require replacement
+	resp.RequiresReplace = true
+}

--- a/internal/provider/slo_resource.go
+++ b/internal/provider/slo_resource.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
@@ -64,6 +64,9 @@ func (*sloResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *re
 			"id": schema.StringAttribute{
 				Description: "The ID of the SLO.",
 				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"name": schema.StringAttribute{
 				Description: "The name of the SLO.",
@@ -96,7 +99,7 @@ func (*sloResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *re
 				Computed:    true,
 				ElementType: types.StringType,
 				PlanModifiers: []planmodifier.Set{
-					setplanmodifier.RequiresReplace(),
+					modifiers.RequiresReplaceIfDatasetChanges(),
 				},
 				Validators: []validator.Set{
 					setvalidator.SizeAtLeast(1),

--- a/internal/provider/slo_resource_test.go
+++ b/internal/provider/slo_resource_test.go
@@ -318,6 +318,11 @@ func TestAccHoneycombioSLO_DatasetConstraint(t *testing.T) {
 }
 
 func TestAccHoneycombioSLO_Update(t *testing.T) {
+	c := testAccClient(t)
+	if c.IsClassic(context.Background()) {
+		t.Skip("Multi-dataset SLOs are not supported in classic")
+	}
+
 	dataset1, dataset2, sliAlias := mdSLOAccTestSetup(t)
 
 	slo := &honeycombio.SLO{}

--- a/internal/provider/slo_resource_test.go
+++ b/internal/provider/slo_resource_test.go
@@ -317,6 +317,112 @@ func TestAccHoneycombioSLO_DatasetConstraint(t *testing.T) {
 	})
 }
 
+func TestAccHoneycombioSLO_Update(t *testing.T) {
+	dataset1, dataset2, sliAlias := mdSLOAccTestSetup(t)
+
+	slo := &honeycombio.SLO{}
+	var originalID string
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 testAccPreCheck(t),
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "honeycombio_slo" "test" {
+  name              = "TestAcc SLO"
+  description       = "test SLO"
+  datasets           = ["%s"]
+  sli               = "%s"
+  target_percentage = 99.95
+  time_period       = 30
+
+  tags = {
+    env  = "test"
+    team = "blue"
+  }
+}`, dataset1.Slug, sliAlias.Alias),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSLOExists(t, "honeycombio_slo.test", slo),
+					func(s *terraform.State) error {
+						rs := s.RootModule().Resources["honeycombio_slo.test"]
+						originalID = rs.Primary.ID
+						return nil
+					},
+					resource.TestCheckResourceAttr("honeycombio_slo.test", "name", "TestAcc SLO"),
+					resource.TestCheckResourceAttr("honeycombio_slo.test", "description", "test SLO"),
+					resource.TestCheckResourceAttr("honeycombio_slo.test", "target_percentage", "99.95"),
+					resource.TestCheckResourceAttr("honeycombio_slo.test", "time_period", "30"),
+					resource.TestCheckResourceAttr("honeycombio_slo.test", "datasets.#", "1"),
+					resource.TestCheckTypeSetElemAttr("honeycombio_slo.test", "datasets.*", dataset1.Slug),
+				),
+			},
+			{ // Update description - should not change ID
+				Config: fmt.Sprintf(`
+resource "honeycombio_slo" "test" {
+  name              = "TestAcc SLO"
+  description       = "UPDATED integration test SLO"
+  datasets           = ["%s"]
+  sli               = "%s"
+  target_percentage = 99.95
+  time_period       = 30
+
+  tags = {
+    env  = "test"
+    team = "blue"
+  }
+}`, dataset1.Slug, sliAlias.Alias),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSLOExists(t, "honeycombio_slo.test", slo),
+					func(s *terraform.State) error {
+						rs := s.RootModule().Resources["honeycombio_slo.test"]
+						if rs.Primary.ID != originalID {
+							return fmt.Errorf("expected ID to remain %s after description update, but got %s", originalID, rs.Primary.ID)
+						}
+						return nil
+					},
+					resource.TestCheckResourceAttr("honeycombio_slo.test", "description", "UPDATED integration test SLO"),
+					resource.TestCheckResourceAttr("honeycombio_slo.test", "name", "TestAcc SLO"),
+					resource.TestCheckResourceAttr("honeycombio_slo.test", "target_percentage", "99.95"),
+					resource.TestCheckResourceAttr("honeycombio_slo.test", "time_period", "30"),
+					resource.TestCheckResourceAttr("honeycombio_slo.test", "datasets.#", "1"),
+					resource.TestCheckTypeSetElemAttr("honeycombio_slo.test", "datasets.*", dataset1.Slug),
+				),
+			},
+			{ // Update datasets - should CHANGE ID (force replacement)
+				Config: fmt.Sprintf(`
+resource "honeycombio_slo" "test" {
+  name              = "TestAcc SLO Update"
+  description       = "UPDATED test SLO for updates"
+  datasets          = ["%s"]
+  sli               = "%s"
+  target_percentage = 99.99
+  time_period       = 30
+
+  tags = {
+    env  = "production"
+    team = "red"
+    owner = "devops"
+  }
+}`, dataset2.Slug, sliAlias.Alias),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSLOExists(t, "honeycombio_slo.test", slo),
+					func(s *terraform.State) error {
+						rs := s.RootModule().Resources["honeycombio_slo.test"]
+						if rs.Primary.ID == originalID {
+							return fmt.Errorf("expected ID to change after datasets update, but it remained %s", originalID)
+						}
+						originalID = rs.Primary.ID
+						return nil
+					},
+					resource.TestCheckResourceAttr("honeycombio_slo.test", "datasets.#", "1"),
+					resource.TestCheckTypeSetElemAttr("honeycombio_slo.test", "datasets.*", dataset2.Slug),
+				),
+			},
+		},
+	})
+}
+
 func testAccConfigSLO_basic(dataset, sliAlias string) string {
 	return fmt.Sprintf(`
 resource "honeycombio_slo" "test" {

--- a/internal/provider/slo_resource_test.go
+++ b/internal/provider/slo_resource_test.go
@@ -325,7 +325,7 @@ func TestAccHoneycombioSLO_Update(t *testing.T) {
 
 	dataset1, dataset2, sliAlias := mdSLOAccTestSetup(t)
 
-	slo := &honeycombio.SLO{}
+	slo := &client.SLO{}
 	var originalID string
 
 	resource.Test(t, resource.TestCase{


### PR DESCRIPTION
Updating SLO resource after recreation cause the resource to be completely replaced. This was due to `RequiresReplace` forcing a new update everytime.

- add a new plan modifier that only requires the SLO resource to be replaced when `datasets` is changed
- add `UseStateForUnknown` which copies the prior state value, if not null. This will address the bug where the SLO cannot be found during updates

<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- https://github.com/honeycombio/terraform-provider-honeycombio/issues/701

## Short description of the changes

Updating SLO resource after recreation cause the resource to be completely replaced. This was due to `RequiresReplace` forcing a new update everytime.

- add a new plan modifier that only requires the SLO resource to be replaced when `datasets` is changed
- add `UseStateForUnknown` which copies the prior state value, if not null. This will address the bug where the SLO cannot be found during updates

## How to verify that this has the expected result
1. Create a SLO resource and note the ID
2. Change any field in the SLO and note the ID
3. The ID should now be different