### PR TITLE
chore(flexible-board): Fix typo in resource description

### DIFF
--- a/docs/resources/flexible_board.md
+++ b/docs/resources/flexible_board.md
@@ -80,7 +80,7 @@ resource "honeycombio_slo" "slo" {
 
 resource "honeycombio_flexible_board" "overview" {
   name        = "Service Overview"
-  description = "My flexible baord description"
+  description = "My flexible board description"
 
   tags = {
     team    = "web"

--- a/example/flexible_board/main.tf
+++ b/example/flexible_board/main.tf
@@ -78,7 +78,7 @@ resource "honeycombio_slo" "slo" {
 
 resource "honeycombio_flexible_board" "overview" {
   name        = "Service Overview"
-  description = "My flexible baord description"
+  description = "My flexible board description"
 
   panel {
     type = "query"


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
A typo i discovered while going through the Honeycomb Terraform provider web pages.

## Short description of the changes
Fixing typo for `board`

## How to verify that this has the expected result
N/A
