### PR TITLE
Accommodate the "dataset_slug" field in triggers

### DIFF
--- a/client/trigger.go
+++ b/client/trigger.go
@@ -45,6 +45,9 @@ var _ Triggers = (*triggers)(nil)
 type Trigger struct {
 	ID string `json:"id,omitempty"`
 
+	// DatasetSlug is the slug of the dataset this trigger belongs to. For environment-wide
+	// triggers, this will be [EnvironmentWideSlug].
+	DatasetSlug string `json:"dataset_slug,omitempty"`
 	// Name of the trigger. This field is required.
 	Name string `json:"name"`
 	// Description is displayed on the triggers page.

--- a/client/trigger_test.go
+++ b/client/trigger_test.go
@@ -69,6 +69,7 @@ func TestTriggers(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotNil(t, trigger.ID)
 
+		data.DatasetSlug = trigger.DatasetSlug
 		// copy IDs before asserting equality
 		data.ID = trigger.ID
 		data.QueryID = trigger.QueryID
@@ -270,6 +271,7 @@ func TestTriggersWithBaselineDetails(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotNil(t, trigger.ID)
 
+		data.DatasetSlug = trigger.DatasetSlug
 		// copy IDs before asserting equality
 		data.ID = trigger.ID
 		data.QueryID = trigger.QueryID
@@ -314,7 +316,6 @@ func TestTriggersWithBaselineDetails(t *testing.T) {
 		assert.Equal(t, trigger.BaselineDetails.Type, result.BaselineDetails.Type)
 		assert.Equal(t, trigger.BaselineDetails.OffsetMinutes, result.BaselineDetails.OffsetMinutes)
 	})
-
 }
 
 func TestTriggersEnvironmentWide(t *testing.T) {
@@ -365,6 +366,7 @@ func TestTriggersEnvironmentWide(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotNil(t, trigger.ID)
 
+		data.DatasetSlug = trigger.DatasetSlug
 		// copy IDs before asserting equality
 		data.ID = trigger.ID
 		data.QueryID = trigger.QueryID


### PR DESCRIPTION
Augment the Honeycomb API client in the `client` package to convey the "dataset_slug" field for triggers. When querying for triggers at the environment level, the API returns all triggers within the environment—including those tied to a particular dataset. Clients can read the populated "dataset_slug" field to distinguish which triggers are tied to which dataset and those that sit at the environment level, above and separate from any particular dataset.

Note that this change does not yet cover [the Terraform provider](https://registry.terraform.io/providers/honeycombio/honeycombio/latest)'s publishing to or querying of data from the Honeycomb API as exposed through its Terraform resources and [data sources](https://registry.terraform.io/providers/honeycombio/honeycombio/latest/docs/resources/trigger).
