### PR TITLE
Accommodate the "dataset" field in board panels

### DIFF
--- a/client/board.go
+++ b/client/board.go
@@ -103,6 +103,7 @@ type BoardPanelPosition struct {
 }
 
 type BoardQueryPanel struct {
+	Dataset               string                           `json:"dataset,omitempty"`
 	QueryID               string                           `json:"query_id,omitempty"`
 	QueryAnnotationID     string                           `json:"query_annotation_id,omitempty"`
 	VisualizationSettings *BoardQueryVisualizationSettings `json:"visualization_settings,omitempty"`

--- a/client/board_test.go
+++ b/client/board_test.go
@@ -215,6 +215,7 @@ func TestFlexibleBoards(t *testing.T) {
 						Width:  4,
 					},
 					QueryPanel: &client.BoardQueryPanel{
+						Dataset:           dataset,
 						QueryID:           *query.ID,
 						QueryAnnotationID: queryAnnotation.ID,
 						Style:             client.BoardQueryStyleGraph,
@@ -258,6 +259,7 @@ func TestFlexibleBoards(t *testing.T) {
 				{
 					PanelType: client.BoardPanelTypeQuery,
 					QueryPanel: &client.BoardQueryPanel{
+						Dataset:           dataset,
 						QueryID:           *query.ID,
 						QueryAnnotationID: queryAnnotation.ID,
 						Style:             client.BoardQueryStyleGraph,
@@ -312,6 +314,7 @@ func TestFlexibleBoards(t *testing.T) {
 						Width:  4,
 					},
 					QueryPanel: &client.BoardQueryPanel{
+						Dataset:           dataset,
 						QueryID:           *query.ID,
 						QueryAnnotationID: queryAnnotation.ID,
 						Style:             client.BoardQueryStyleGraph,


### PR DESCRIPTION
Augment the Honeycomb API client in the `client` package to allow clients to discern within a board with which dataset a given query panel's query is associated.

For boards of the newer "flexible" type, their panels that present queries have [a "dataset" field](https://api-docs.honeycomb.io/api/boards/getboard#boards/getboard/t=response&c=200&path=&d=1/panels&oneof=0/query_panel/dataset) that conveys the _name_—crucially, not the slug—of the dataset on which the query operates, if any. This field is empty—not the sentinel `__all__` value—for queries that operate at the environment level and are not tied to any particular dataset.

Note that this change does not yet cover [the Terraform provider](https://registry.terraform.io/providers/honeycombio/honeycombio/latest)'s publishing of data to the Honeycomb API as exposed through [its `honeycombio_flexible_board` Terraform resource](https://registry.terraform.io/providers/honeycombio/honeycombio/latest/docs/resources/flexible_board).