### PR TITLE
fix(client): add missing Dataset field to QueryPanel

### DIFF
--- a/client/board.go
+++ b/client/board.go
@@ -103,6 +103,7 @@ type BoardPanelPosition struct {
 }
 
 type BoardQueryPanel struct {
+	Dataset               string                           `json:"dataset,omitempty"`
 	QueryID               string                           `json:"query_id,omitempty"`
 	QueryAnnotationID     string                           `json:"query_annotation_id,omitempty"`
 	VisualizationSettings *BoardQueryVisualizationSettings `json:"visualization_settings,omitempty"`

--- a/client/board_test.go
+++ b/client/board_test.go
@@ -245,6 +245,14 @@ func TestFlexibleBoards(t *testing.T) {
 		assert.NotEmpty(t, flexibleBoard.Links.BoardURL)
 		data.Links.BoardURL = flexibleBoard.Links.BoardURL
 
+		// copy dataset name into query panel for comparison
+		for i, panel := range flexibleBoard.Panels {
+			if panel.PanelType == client.BoardPanelTypeQuery {
+				assert.Equal(t, dataset, panel.QueryPanel.Dataset)
+				data.Panels[i].QueryPanel.Dataset = dataset
+			}
+		}
+
 		assert.Equal(t, data, flexibleBoard)
 	})
 
@@ -281,6 +289,14 @@ func TestFlexibleBoards(t *testing.T) {
 		// ensure the board URL got populated
 		assert.NotEmpty(t, flexibleBoard.Links.BoardURL)
 		data.Links.BoardURL = flexibleBoard.Links.BoardURL
+
+		// copy dataset name into query panel for comparison
+		for i, panel := range flexibleBoard.Panels {
+			if panel.PanelType == client.BoardPanelTypeQuery {
+				assert.Equal(t, dataset, panel.QueryPanel.Dataset)
+				data.Panels[i].QueryPanel.Dataset = dataset
+			}
+		}
 
 		for i, panel := range flexibleBoard.Panels {
 			assert.Equal(t, data.Panels[i].PanelType, panel.PanelType)
@@ -344,6 +360,14 @@ func TestFlexibleBoards(t *testing.T) {
 		// ensure the board URL got populated
 		assert.NotEmpty(t, flexibleBoard.Links.BoardURL)
 		data.Links.BoardURL = flexibleBoard.Links.BoardURL
+
+		// copy dataset name into query panel for comparison
+		for i, panel := range flexibleBoard.Panels {
+			if panel.PanelType == client.BoardPanelTypeQuery {
+				assert.Equal(t, dataset, panel.QueryPanel.Dataset)
+				data.Panels[i].QueryPanel.Dataset = dataset
+			}
+		}
 
 		// ensure the tags were added
 		assert.NotEmpty(t, flexibleBoard.Tags)


### PR DESCRIPTION
Adds the missing `dataset` field to the flexible board `QueryPanel` struct.

Originally noted by @seh (with thanks!) the tests in that PR didn't pass, so to avoid the back -- and asking more time of a community member -- I fixed it here.

In the process noticed that some boards weren't getting cleaned up in tests, so added a 'Sweeper' to keep that tidy.

- Replaces #723 
