### PR TITLE
feat(features): add features support with column import override

### DIFF
--- a/client/errors.go
+++ b/client/errors.go
@@ -61,6 +61,14 @@ func (e *DetailedError) IsNotFound() bool {
 	return e.Status == http.StatusNotFound
 }
 
+// IsConflict returns true if the error is an HTTP 409
+func (e *DetailedError) IsConflict() bool {
+	if e == nil {
+		return false
+	}
+	return e.Status == http.StatusConflict
+}
+
 // Error returns a pretty-printed representation of the error
 func (e DetailedError) Error() string {
 	if len(e.Details) > 0 {

--- a/docs/index.md
+++ b/docs/index.md
@@ -139,4 +139,5 @@ The `features` block supports the following:
 * `column` - (Optional) A `column` block as defined below.
 ---
 The `column` block supports the following:
-* `import_on_conflict` - (Optional) This changes the creation behavior of the column resource to import an existing column if it already exists, rather than erroring out. Defaults to `false`.
+* `import_on_conflict` - (Optional) This changes the creation behavior of the column resource to import and update an existing column if it already exists, rather than erroring out. Defaults to `false`.
+    This is potentially dangerous if the type changes on the update -- switching from `string` to `boolean` and causing dataloss, for example -- and should be used with caution.

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,10 @@ terraform {
 provider "honeycombio" {
   # You can set the API key with the environment variable HONEYCOMB_API_KEY,
   # or the HONEYCOMB_KEY_ID+HONEYCOMB_KEY_SECRET environment variable pair
+
+  # The features block allows customization of the behavior of the Honeycomb Provider.
+  # More information can be found below.
+  features {}
 }
 
 variable "dataset" {
@@ -102,5 +106,37 @@ Arguments accepted by this provider include:
 * `api_key_secret` - (Optional) The secret portion of the Honeycomb Management API key to use. It can also be set via the `HONEYCOMB_KEY_SECRET` environment variable.
 * `api_url` - (Optional) Override the URL of the Honeycomb.io API. It can also be set using `HONEYCOMB_API_ENDPOINT`. Defaults to `https://api.honeycomb.io`.
 * `debug` - (Optional) Enable to log additional debug information. To view the logs, set `TF_LOG` to at least debug.
+* `features` - (Optional) The features block allows customization of the behavior of the Honeycomb Provider. Full details documented below.
 
 At least one of `api_key`, or the `api_key_id` and `api_key_secret` pair must be configured.
+
+## Features Block
+
+The Honeycomb Provider allows the behavior of certain resources to be modified using the features block.
+
+This allows different users to select the behavior they require for their use case while preserving default, "Terraform-y" behavior.
+
+### Example Usage
+
+If you wish to use the default behaviors of the Honeycomb provider, then nothing needs to be done to your configuration at all.
+
+Each of the blocks defined below can be optionally specified to configure the behaviour as needed - this example shows all the possible behaviors which can be configured:
+
+```hcl
+provider "honeycombio" {
+  features {
+    column {
+      import_on_conflict = true
+    }
+  }
+}
+```
+
+### Arguments Reference
+
+The `features` block supports the following:
+
+* `column` - (Optional) A `column` block as defined below.
+---
+The `column` block supports the following:
+* `import_on_conflict` - (Optional) This changes the creation behavior of the column resource to import an existing column if it already exists, rather than erroring out. Defaults to `false`.

--- a/docs/resources/column.md
+++ b/docs/resources/column.md
@@ -5,7 +5,8 @@ This can be used to create, update, and delete columns in a dataset.
 
 ~> **Warning** Deleting a column is a destructive and irreversible operation which also removes the data in the column.
 
--> Version 0.38 and later of the Honeycomb Provider include a Feature Toggle which allows the column to be imported automatically if there is a conflict during create instead of throwing an error.
+-> Version 0.38 and later of the Honeycomb Provider include a Feature Toggle which allows the column to be imported and updated automatically if there is a conflict during create instead of throwing an error.
+  This is potentially dangerous if the type changes on the update -- switching from `string` to `boolean` and causing dataloss, for example -- and should be used with caution.
 
 ## Example Usage
 

--- a/docs/resources/column.md
+++ b/docs/resources/column.md
@@ -5,6 +5,8 @@ This can be used to create, update, and delete columns in a dataset.
 
 ~> **Warning** Deleting a column is a destructive and irreversible operation which also removes the data in the column.
 
+-> Version 0.38 and later of the Honeycomb Provider include a Feature Toggle which allows the column to be imported automatically on create instead of throwing an error.
+
 ## Example Usage
 
 ```hcl

--- a/docs/resources/column.md
+++ b/docs/resources/column.md
@@ -5,7 +5,7 @@ This can be used to create, update, and delete columns in a dataset.
 
 ~> **Warning** Deleting a column is a destructive and irreversible operation which also removes the data in the column.
 
--> Version 0.38 and later of the Honeycomb Provider include a Feature Toggle which allows the column to be imported automatically on create instead of throwing an error.
+-> Version 0.38 and later of the Honeycomb Provider include a Feature Toggle which allows the column to be imported automatically if there is a conflict during create instead of throwing an error.
 
 ## Example Usage
 

--- a/honeycombio/provider.go
+++ b/honeycombio/provider.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	honeycombio "github.com/honeycombio/terraform-provider-honeycombio/client"
+	"github.com/honeycombio/terraform-provider-honeycombio/internal/features"
 	"github.com/honeycombio/terraform-provider-honeycombio/internal/helper/log"
 )
 
@@ -49,6 +50,7 @@ func Provider(version string) *schema.Provider {
 				Optional:    true,
 				Description: "Enable the API client's debug logs. By default, a `TF_LOG` setting of debug or higher will enable this.",
 			},
+			"features": features.GetPluginSDKFeaturesSchema(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"honeycombio_column":            dataSourceHoneycombioColumn(),

--- a/internal/features/README.md
+++ b/internal/features/README.md
@@ -1,0 +1,140 @@
+# Features Package
+
+The features package is a simple way of providing resource-level "feature toggles" so users of the Honeycomb Provider can modify behavior.
+
+The package only supports Framework-based resources: if the resource you are looking to add a feature toggle for is still based on the PluginSDK please migrate the resource to the Framework as a first step.
+
+## Adding a new Feature
+
+To add new features, follow these steps:
+
+### 1. Define Features Types
+
+In `features.go`, add your new features types:
+
+```go
+// Add to Features struct
+type Features struct {
+    Column  FeaturesColumn
+    Dataset FeaturesDataset  // New feature category
+}
+
+// Add new features struct
+type FeaturesDataset struct {
+    AutoRetention bool
+    EnableCaching bool
+}
+
+// Add Framework model struct
+type FeaturesDatasetModel struct {
+    AutoRetention types.Bool `tfsdk:"auto_retention"`
+    EnableCaching types.Bool `tfsdk:"enable_caching"`
+}
+
+// Add to Model struct
+type Model struct {
+    Column  []FeaturesColumnModel
+    Dataset []FeaturesDatasetModel  // New field
+}
+```
+
+### 2. Update Parsing Functions
+
+Extend parsing functions in `features.go`:
+
+```go
+// Update Parse function for Framework provider
+func Parse(m Model) *Features {
+    features := DefaultFeatures()
+
+    // ... existing column parsing ...
+
+    // Parse dataset features
+    if len(m.Dataset) > 0 {
+        datasetFeatures := m.Dataset[0]
+        if !datasetFeatures.AutoRetention.IsNull() && !datasetFeatures.AutoRetention.IsUnknown() {
+            features.Dataset.AutoRetention = datasetFeatures.AutoRetention.ValueBool()
+        }
+        // ... similar for other dataset features
+    }
+
+    return &features
+}
+```
+
+### 3. Update Schema Functions
+
+As we are bridging (via a MuxServer) a PluginSDK-based and a Framework-based provider, the two of them need to start up with _identical_ configurations or they will panic (we have tests to catch this -- don't worry!).
+So, even though the SDKv2-based provider doesn't make use of features, it needs to have the same provider schema.
+
+In `schema.go`, add schema definitions for applicable provider type:
+
+```go
+// Update Framework schema
+func GetFeaturesBlock() schema.Block {
+    return schema.ListNestedBlock{
+        // ... existing config ...
+        NestedObject: schema.NestedBlockObject{
+            Blocks: map[string]schema.Block{
+                "column":  /* existing column schema */,
+                "dataset": schema.ListNestedBlock{...}
+            },
+        },
+    }
+}
+
+// Update PluginSDK schema
+func GetPluginSDKFeaturesSchema() *pluginsdk.Schema {
+    return &pluginsdk.Schema{
+        // ... existing config ...
+        Elem: &pluginsdk.Resource{
+            Schema: map[string]*pluginsdk.Schema{
+                "column":  /* existing column schema */,
+                "dataset": { ... }
+            },
+        },
+    }
+}
+```
+
+### 4. Update Defaults
+
+In `defaults.go`, add default values:
+
+```go
+func DefaultFeatures() Features {
+    return Features{
+        Column:  defaultColumnFeatures(),
+        Dataset: defaultDatasetFeatures(),  // New defaults
+    }
+}
+
+func defaultDatasetFeatures() FeaturesDataset {
+    return FeaturesDataset{
+        AutoRetention: false,
+        EnableCaching: true,
+    }
+}
+```
+
+### 5. Add Tests
+
+Create comprehensive tests in `features_test.go`:
+
+```go
+func TestDatasetFeatureParsing(t *testing.T) {
+    // Test Framework parsing
+    model := Model{
+        Dataset: []FeaturesDatasetModel{
+            {
+                AutoRetention: types.BoolValue(true),
+                EnableCaching: types.BoolValue(false),
+            },
+        },
+    }
+
+    features := Parse(model)
+    assert.True(t, features.Dataset.AutoRetention)
+    assert.False(t, features.Dataset.EnableCaching)
+}
+```

--- a/internal/features/defaults.go
+++ b/internal/features/defaults.go
@@ -1,0 +1,14 @@
+package features
+
+// DefaultFeatures returns the default features for the provider.
+func DefaultFeatures() *Features {
+	return &Features{
+		Column: defaultColumnFeatures(),
+	}
+}
+
+func defaultColumnFeatures() FeaturesColumn {
+	return FeaturesColumn{
+		ImportOnConflict: false,
+	}
+}

--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -1,0 +1,43 @@
+package features
+
+import "github.com/hashicorp/terraform-plugin-framework/types"
+
+// Features represents provider-level features.
+type Features struct {
+	Column FeaturesColumn
+}
+
+// FeaturesColumn represents column-specific features.
+type FeaturesColumn struct {
+	// ImportOnConflict controls whether to import an existing column if a create
+	// operation fails due to a conflict (HTTP 409).
+	ImportOnConflict bool
+}
+
+// FeaturesColumnModel represents column-specific features for Terraform schema.
+type FeaturesColumnModel struct {
+	ImportOnConflict types.Bool `tfsdk:"import_on_conflict"`
+}
+
+type Model struct {
+	Column []FeaturesColumnModel `tfsdk:"column"`
+}
+
+// Parse converts a Terraform model to internal Features representation for
+// plugin-based providers while handling default values.
+func Parse(m []Model) *Features {
+	result := DefaultFeatures()
+	if len(m) == 0 {
+		return result
+	}
+	features := m[0]
+
+	if len(features.Column) > 0 {
+		columnFeatures := features.Column[0]
+		if !columnFeatures.ImportOnConflict.IsNull() && !columnFeatures.ImportOnConflict.IsUnknown() {
+			result.Column.ImportOnConflict = columnFeatures.ImportOnConflict.ValueBool()
+		}
+	}
+
+	return result
+}

--- a/internal/features/features_test.go
+++ b/internal/features/features_test.go
@@ -1,0 +1,82 @@
+package features
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestModelParse(t *testing.T) {
+	t.Parallel()
+
+	t.Run("handles empty model with defaults", func(t *testing.T) {
+		model := []Model{}
+		features := Parse(model)
+
+		assert.False(t, features.Column.ImportOnConflict)
+	})
+
+	t.Run("parses column features", func(t *testing.T) {
+		testCases := map[string]struct {
+			model  []Model
+			expect bool
+		}{
+			"parses ImportOnConflict as false": {
+				model: []Model{
+					{
+						Column: []FeaturesColumnModel{
+							{
+								ImportOnConflict: types.BoolValue(false),
+							},
+						},
+					},
+				},
+				expect: false,
+			},
+			"parses ImportOnConflict as true": {
+				model: []Model{
+					{
+						Column: []FeaturesColumnModel{
+							{
+								ImportOnConflict: types.BoolValue(true),
+							},
+						},
+					},
+				},
+				expect: true,
+			},
+			"handles Null": {
+				model: []Model{
+					{
+						Column: []FeaturesColumnModel{
+							{
+								ImportOnConflict: types.BoolNull(),
+							},
+						},
+					},
+				},
+				expect: false,
+			},
+			"handles Unknown": {
+				model: []Model{
+					{
+						Column: []FeaturesColumnModel{
+							{
+								ImportOnConflict: types.BoolUnknown(),
+							},
+						},
+					},
+				},
+				expect: false,
+			},
+		}
+
+		for name, tc := range testCases {
+			t.Run(name, func(t *testing.T) {
+				features := Parse(tc.model)
+				assert.Equal(t, tc.expect, features.Column.ImportOnConflict)
+			})
+		}
+	})
+}

--- a/internal/features/schema.go
+++ b/internal/features/schema.go
@@ -1,0 +1,62 @@
+package features
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	pluginsdk "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// GetFeaturesBlock returns the schema for the features block for the Framework-based provider.
+func GetFeaturesBlock() schema.Block {
+	return schema.ListNestedBlock{
+		MarkdownDescription: "The features block allows customization of the behavior of the Honeycomb Provider.",
+		Validators: []validator.List{
+			listvalidator.SizeBetween(1, 1),
+		},
+		NestedObject: schema.NestedBlockObject{
+			Blocks: map[string]schema.Block{
+				"column": schema.ListNestedBlock{
+					MarkdownDescription: "Column resource features.",
+					NestedObject: schema.NestedBlockObject{
+						Attributes: map[string]schema.Attribute{
+							"import_on_conflict": schema.BoolAttribute{
+								MarkdownDescription: "This changes the creation behavior of the column resource to import an existing column if it already exists, rather than erroring out.",
+								Optional:            true,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// GetPluginSDKFeaturesSchema returns the schema for the features block for the PluginSDK-based provider.
+func GetPluginSDKFeaturesSchema() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:        pluginsdk.TypeList,
+		Optional:    true,
+		MaxItems:    1,
+		Description: "The features block allows customization of the behavior of the Honeycomb Provider.",
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"column": {
+					Type:        pluginsdk.TypeList,
+					Optional:    true,
+					MaxItems:    1,
+					Description: "Column resource features.",
+					Elem: &pluginsdk.Resource{
+						Schema: map[string]*pluginsdk.Schema{
+							"import_on_conflict": {
+								Type:        pluginsdk.TypeBool,
+								Optional:    true,
+								Description: "This changes the creation behavior of the column resource to import an existing column if it already exists, rather than erroring out.",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/provider/column_resource_test.go
+++ b/internal/provider/column_resource_test.go
@@ -88,6 +88,8 @@ resource "honeycombio_column" "test" {
 	})
 
 	t.Run("feature: import_on_conflict", func(t *testing.T) {
+		t.Parallel() // we don't want this test to block others as it sleeps for a while
+
 		c := testAccClient(t)
 		dataset := testAccDataset()
 
@@ -99,6 +101,9 @@ resource "honeycombio_column" "test" {
 		t.Cleanup(func() {
 			c.Columns.Delete(ctx, dataset, column.KeyName)
 		})
+
+		// give the backend a chance to catch up
+		time.Sleep(31 * time.Second)
 
 		// column creation can be a bit racey, so we'll wait for it to be available
 		assert.Eventually(t, func() bool {

--- a/internal/provider/column_resource_test.go
+++ b/internal/provider/column_resource_test.go
@@ -142,6 +142,15 @@ resource "honeycombio_column" "test" {
 }`, column.KeyName, dataset),
 					Check: resource.ComposeTestCheckFunc(
 						testAccEnsureColumnExists(t, "honeycombio_column.test", column.KeyName),
+						resource.TestCheckResourceAttrSet("honeycombio_column.test", "id"),
+						resource.TestCheckResourceAttr("honeycombio_column.test", "name", column.KeyName),
+						resource.TestCheckResourceAttr("honeycombio_column.test", "dataset", dataset),
+						resource.TestCheckResourceAttr("honeycombio_column.test", "type", "string"), // default type is string
+						resource.TestCheckResourceAttr("honeycombio_column.test", "hidden", "false"),
+						resource.TestCheckResourceAttr("honeycombio_column.test", "description", ""),
+						resource.TestCheckResourceAttrSet("honeycombio_column.test", "created_at"),
+						resource.TestCheckResourceAttrSet("honeycombio_column.test", "updated_at"),
+						resource.TestCheckResourceAttrSet("honeycombio_column.test", "last_written_at"),
 					),
 				},
 			},


### PR DESCRIPTION
This introduces a `features` block to the provider configuration allowing 'feature toggles' to be provided to resources as we see fit. This design is heavily influenced by the Azure Provider.

The first feature toggle is included, enabling the ability for the columns resource to automatically import a column during creation on conflict (which, was the behaviour prior to v0.12.0 of this provider).

The features block is part of the provider configuration and is designed to be extended per resource as we see fit in the future.

To enable the "import on conflict" behavior for the columns resource you would initialize your provider like this:

```hcl
provider "honeycombio" {
  features {
    column {
      import_on_conflict = true
    }
  }
}
```

This partially resolves #552, and I intend to follow on with an `r/dataset` feature toggle for the same.

Kudos to @elimt for spiking out much of this -- I've listed him as a co-author.