### PR TITLE
fix(docs): fix 'features block' formatting

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -140,11 +140,13 @@ provider "honeycombio" {
 The `features` block supports the following:
 
 * `column` - (Optional) A `column` block as defined below.
-* `dataset` - (Optional) A `dataset` block as defined blow.
+* `dataset` - (Optional) A `dataset` block as defined below.
+
 ---
 The `column` block supports the following:
 * `import_on_conflict` - (Optional) This changes the creation behavior of the column resource to import and update an existing column if it already exists, rather than erroring out. Defaults to `false`.
     This is potentially dangerous if the type changes on the update -- switching from `string` to `boolean` and causing dataloss, for example -- and should be used with caution.
+
 ---
 The `dataset` block supports the following:
 * `import_on_conflict` - (Optional) This changes the creation behavior of the dataset resource to import and update an existing dataset if it already exists, rather than erroring out. Defaults to `false`.


### PR DESCRIPTION
The Features Block section of the main documentation index was improperly formatted resulting in a ToC rendered like this on the public registry:

<img width="576" height="585" alt="image" src="https://github.com/user-attachments/assets/c63625aa-965a-4a2d-8bf5-7989f9bf6390" />

This adjusts the formatting (verified using the [Doc Preview Tool](https://registry.terraform.io/tools/doc-preview)) to render properly:

<img width="576" height="585" alt="image" src="https://github.com/user-attachments/assets/3b8b8921-bdff-4604-acb9-8fcad821e650" />
