### PR TITLE
chore(build): upgrade golangci-lint

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
           cache: true
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6.5.2
+        uses: golangci/golangci-lint-action@v8.0.0
         with:
           version: latest
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,50 +1,65 @@
-issues:
-    max-issues-per-linter: 0
-    max-same-issues: 0
-    exclude-rules:
-        - path: '(.+)_test\.go'
-          linters:
-              - errcheck
-              - unparam
-          # disabling these for the SDKv2-based code as it's idomatic and things are being migrated to the Framework
-        - path: honeycombio/*
-          text: "Error return value of `d.Set` is not checked"
-        - path: honeycombio/*
-          text: "type assertion must be checked"
-        - path: honeycombio/*
-          text: "right hand must be only type assertion"
-
-linters-settings:
-    goimports:
-        local-prefixes: github.com/honeycombio/terraform-provider-honeycombio
-    usetesting:
-        context-background: false
-        context-todo: true
-
-linters:
-    disable-all: true
-    enable:
-        - durationcheck
-        - errcheck
-        - copyloopvar
-        - forcetypeassert
-        - goimports
-        - gosimple
-        - ineffassign
-        - makezero
-        - misspell
-        - nilerr
-        - predeclared
-        - staticcheck
-        - testifylint
-        - unconvert
-        - usetesting
-        - unparam
-        - unused
-        - govet
-
+version: "2"
 run:
-    # Prevent false positive timeouts in CI
-    timeout: 5m
-    tests: true
-    allow-parallel-runners: true
+  tests: true
+  allow-parallel-runners: true
+linters:
+  default: none
+  enable:
+    - copyloopvar
+    - durationcheck
+    - errcheck
+    - forcetypeassert
+    - govet
+    - ineffassign
+    - makezero
+    - misspell
+    - nilerr
+    - predeclared
+    - staticcheck
+    - testifylint
+    - unconvert
+    - unparam
+    - unused
+    - usetesting
+  settings:
+    usetesting:
+      context-background: false
+      context-todo: true
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - errcheck
+          - unparam
+        path: (.+)_test\.go
+      - path: honeycombio/*
+        text: Error return value of `d.Set` is not checked
+      - path: honeycombio/*
+        text: type assertion must be checked
+      - path: honeycombio/*
+        text: right hand must be only type assertion
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+formatters:
+  enable:
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/honeycombio/terraform-provider-honeycombio
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/client/board_test.go
+++ b/client/board_test.go
@@ -84,7 +84,7 @@ func TestClassicBoards(t *testing.T) {
 		data.ID = b.ID
 
 		// ensure the board URL got populated
-		assert.NotEqual(t, "", b.Links.BoardURL)
+		assert.NotEmpty(t, b.Links.BoardURL)
 		data.Links.BoardURL = b.Links.BoardURL
 
 		assert.Equal(t, data, b)

--- a/client/burn_alert_test.go
+++ b/client/burn_alert_test.go
@@ -244,7 +244,7 @@ func TestBurnAlerts_BurnAlertAlertTypes(t *testing.T) {
 		actualAlertTypes := client.BurnAlertAlertTypes()
 
 		assert.NotEmpty(t, actualAlertTypes)
-		assert.Equal(t, len(expectedAlertTypes), len(actualAlertTypes))
+		assert.Len(t, actualAlertTypes, len(expectedAlertTypes))
 		assert.ElementsMatch(t, expectedAlertTypes, actualAlertTypes)
 	})
 }

--- a/client/client.go
+++ b/client/client.go
@@ -206,7 +206,7 @@ func (c *Client) Do(ctx context.Context, method, path string, requestBody, respo
 	}
 	defer resp.Body.Close()
 
-	if !(resp.StatusCode >= 200 && resp.StatusCode <= 299) {
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		return ErrorFromResponse(resp)
 	}
 	if responseBody != nil {
@@ -243,5 +243,5 @@ func (c *Client) newRequest(ctx context.Context, method, path string, body any) 
 // urlEncodeDataset sanitizes the dataset name for when it is used as part of
 // the URL.
 func urlEncodeDataset(dataset string) string {
-	return strings.Replace(dataset, "/", "-", -1)
+	return strings.ReplaceAll(dataset, "/", "-")
 }

--- a/client/query_spec.go
+++ b/client/query_spec.go
@@ -128,8 +128,8 @@ func (qs *QuerySpec) EquivalentTo(other QuerySpec) bool {
 	if !reflect.DeepEqual(qs.Breakdowns, other.Breakdowns) &&
 		// an empty Breakdowns is equivalent to a nil Breakdowns, so we need to check that
 		// as DeepEqual will not consider them equal
-		!(qs.Breakdowns == nil && len(other.Breakdowns) == 0 ||
-			len(qs.Breakdowns) == 0 && other.Breakdowns == nil) {
+		((qs.Breakdowns != nil || len(other.Breakdowns) != 0) &&
+			(len(qs.Breakdowns) != 0 || other.Breakdowns != nil)) {
 		return false
 	}
 

--- a/client/v2/client_test.go
+++ b/client/v2/client_test.go
@@ -122,7 +122,7 @@ func TestClient_AuthInfo(t *testing.T) {
 		var de hnyclient.DetailedError
 		require.ErrorAs(t, err, &de)
 		assert.Equal(t, http.StatusUnauthorized, de.Status)
-		assert.Equal(t, "", de.Message)
+		assert.Empty(t, de.Message)
 		assert.Equal(t, "invalid API key", de.Title)
 		assert.Equal(t, "unauthenticated/invalid-key", de.Type)
 		if assert.Len(t, de.Details, 1) {

--- a/honeycombio/provider.go
+++ b/honeycombio/provider.go
@@ -114,6 +114,7 @@ func Provider(version string) *schema.Provider {
 func getConfiguredClient(meta any) (*honeycombio.Client, error) {
 	client, ok := meta.(*honeycombio.Client)
 	if !ok || client == nil {
+		//nolint:staticcheck
 		return nil, errors.New("No v1 API client configured for this provider. " +
 			"Set the `api_key` attribute in the provider's configuration, " +
 			"or set the HONEYCOMB_API_KEY environment variable.")

--- a/internal/provider/api_key_resource.go
+++ b/internal/provider/api_key_resource.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/honeycombio/terraform-provider-honeycombio/client"
-	hny "github.com/honeycombio/terraform-provider-honeycombio/client"
 	v2client "github.com/honeycombio/terraform-provider-honeycombio/client/v2"
 	"github.com/honeycombio/terraform-provider-honeycombio/internal/helper"
 	"github.com/honeycombio/terraform-provider-honeycombio/internal/models"
@@ -200,7 +199,7 @@ func (r *apiKeyResource) Read(ctx context.Context, req resource.ReadRequest, res
 		return
 	}
 
-	var detailedErr hny.DetailedError
+	var detailedErr client.DetailedError
 	key, err := r.client.APIKeys.Get(ctx, state.ID.ValueString())
 	if errors.As(err, &detailedErr) {
 		if detailedErr.IsNotFound() {

--- a/internal/provider/burn_alert_resource.go
+++ b/internal/provider/burn_alert_resource.go
@@ -148,7 +148,7 @@ func validateAttributesWhenAlertTypeIsExhaustionTime(data models.BurnAlertResour
 		}
 
 		// When the alert_type is exhaustion_time, budget_rate_decrease_percent must not be configured
-		if !(data.BudgetRateDecreasePercent.IsNull() || data.BudgetRateDecreasePercent.IsUnknown()) {
+		if !data.BudgetRateDecreasePercent.IsNull() && !data.BudgetRateDecreasePercent.IsUnknown() {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("budget_rate_decrease_percent"),
 				"Conflicting configuration arguments",
@@ -157,7 +157,7 @@ func validateAttributesWhenAlertTypeIsExhaustionTime(data models.BurnAlertResour
 		}
 
 		// When the alert_type is exhaustion_time, budget_rate_window_minutes must not be configured
-		if !(data.BudgetRateWindowMinutes.IsNull() || data.BudgetRateWindowMinutes.IsUnknown()) {
+		if !data.BudgetRateWindowMinutes.IsNull() && !data.BudgetRateWindowMinutes.IsUnknown() {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("budget_rate_window_minutes"),
 				"Conflicting configuration arguments",
@@ -189,7 +189,7 @@ func validateAttributesWhenAlertTypeIsBudgetRate(data models.BurnAlertResourceMo
 		}
 
 		// When the alert_type is budget_rate, exhaustion_minutes must not be configured
-		if !(data.ExhaustionMinutes.IsNull() || data.ExhaustionMinutes.IsUnknown()) {
+		if !data.ExhaustionMinutes.IsNull() && !data.ExhaustionMinutes.IsUnknown() {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("exhaustion_minutes"),
 				"Conflicting configuration arguments",

--- a/internal/provider/flexible_board_resource.go
+++ b/internal/provider/flexible_board_resource.go
@@ -541,7 +541,7 @@ func (*flexibleBoardResource) UpgradeState(ctx context.Context) map[int64]resour
 						SLOPanel:   panel.SLOPanel,
 					}
 
-					if !(panel.Position.IsNull() || panel.Position.IsUnknown()) {
+					if !panel.Position.IsNull() && !panel.Position.IsUnknown() {
 						var oldStylePositions []models.BoardPanelPositionModel
 						resp.Diagnostics.Append(panel.Position.ElementsAs(ctx, &oldStylePositions, false)...)
 						if resp.Diagnostics.HasError() {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -257,6 +257,7 @@ type ConfiguredClient struct {
 
 func (c *ConfiguredClient) V1Client() (*client.Client, error) {
 	if c.v1client == nil {
+		//nolint:staticcheck
 		return nil, errors.New("No v1 API client configured for this provider. " +
 			"Set the `api_key` attribute in the provider's configuration, " +
 			"or set the HONEYCOMB_API_KEY environment variable.",
@@ -267,6 +268,7 @@ func (c *ConfiguredClient) V1Client() (*client.Client, error) {
 
 func (c *ConfiguredClient) V2Client() (*v2client.Client, error) {
 	if c.v2client == nil {
+		//nolint:staticcheck
 		return nil, errors.New("No v2 API client configured for this provider. " +
 			"Set the Key ID and Secret pair in the provider's configuration, " +
 			"or via the HONEYCOMB_KEY_ID and HONEYCOMB_KEY_SECRET environment variables.",
@@ -277,6 +279,7 @@ func (c *ConfiguredClient) V2Client() (*v2client.Client, error) {
 
 func (c *ConfiguredClient) Features() (*features.Features, error) {
 	if c.features == nil {
+		//nolint:staticcheck
 		return nil, errors.New("Unable to initialize provider features. " +
 			"This is a bug in the provider, which should be reported in the provider's own issue tracker.",
 		)


### PR DESCRIPTION
Upgrades golangci-lint (and related GitHub Action) from v1 to v2: had been putting off this upgrade but thankfully turned out to be about 20min of total work.

Configuration for the linter was migrated using the provided `migrate` subcommand and seemed to do a decent job ✨

The update did find a few new things to gripe about: so I either accepted the suggestion or put in the appropriate `nolint` comment.