### PR TITLE
fix(r/query_annotation): handle empty description

### DIFF
--- a/docs/resources/query_annotation.md
+++ b/docs/resources/query_annotation.md
@@ -46,7 +46,7 @@ The following arguments are supported:
 * `dataset` - (Optional) The dataset this query annotation is added to. If not set, an Environment-wide query annotation will be created.
 * `query_id` - (Required) The ID of the query that the annotation will be created on. Note that a query can have more than one annotation.
 * `name` - (Required) The name to display as the query annotation.
-* `description` - (Optional) The description to display as the query annotation.
+* `description` - (Optional) The description to display as the query annotation. Defaults to an empty string.
 
 ## Attribute Reference
 

--- a/internal/provider/query_annotation_resource.go
+++ b/internal/provider/query_annotation_resource.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -89,8 +90,10 @@ func (*queryAnnotationResource) Schema(_ context.Context, _ resource.SchemaReque
 			"description": schema.StringAttribute{
 				Description: "The description to display as the query annotation.",
 				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString(""),
 				Validators: []validator.String{
-					stringvalidator.LengthBetween(1, 1023),
+					stringvalidator.LengthBetween(0, 1023),
 				},
 			},
 		},

--- a/internal/provider/query_annotation_resource.go
+++ b/internal/provider/query_annotation_resource.go
@@ -93,7 +93,7 @@ func (*queryAnnotationResource) Schema(_ context.Context, _ resource.SchemaReque
 				Computed:    true,
 				Default:     stringdefault.StaticString(""),
 				Validators: []validator.String{
-					stringvalidator.LengthBetween(0, 1023),
+					stringvalidator.LengthAtMost(1023),
 				},
 			},
 		},


### PR DESCRIPTION
Fixes the follow error if `description` was empty:

> Error: Provider produced inconsistent result after apply
When applying changes to honeycombio_query_annotation.nice, provider "provider[\"[registry.terraform.io/honeycombio/honeycombio](http://registry.terraform.io/honeycombio/honeycombio)\"]" produced an unexpected new value: .description: was null, but now cty.StringVal("").
This is a bug in the provider, which should be reported in the provider's own issue tracker.

- Introduced by #744 
