### PR TITLE
feat(queries): Add support for compare_time_offset_seconds

### DIFF
--- a/client/query_spec.go
+++ b/client/query_spec.go
@@ -61,6 +61,9 @@ type QuerySpec struct {
 	// The time resolution of the query’s graph, in seconds. Valid values are
 	// the query’s time range /10 at maximum, and /1000 at minimum.
 	Granularity *int `json:"granularity,omitempty"`
+	// The time offset for comparison queries, in seconds. Used to compare current
+	// time range data with data from a previous time period.
+	CompareTimeOffsetSeconds *int `json:"compare_time_offset_seconds,omitempty"`
 }
 
 // Encode returns the JSON string representation of the QuerySpec.
@@ -148,6 +151,9 @@ func (qs *QuerySpec) EquivalentTo(other QuerySpec) bool {
 	}
 	// Granularity may be exported out of the Query Builder as '0' when not provided
 	if PtrValueOrDefault(qs.Granularity, 0) != PtrValueOrDefault(other.Granularity, 0) {
+		return false
+	}
+	if !reflect.DeepEqual(qs.CompareTimeOffsetSeconds, other.CompareTimeOffsetSeconds) {
 		return false
 	}
 

--- a/client/query_spec_test.go
+++ b/client/query_spec_test.go
@@ -79,9 +79,10 @@ func TestQuerySpec(t *testing.T) {
 				Value:       1000.0,
 			},
 		},
-		Limit:       client.ToPtr(100),
-		TimeRange:   client.ToPtr(3600), // 1 hour
-		Granularity: client.ToPtr(60),   // 1 minute
+		Limit:                    client.ToPtr(100),
+		TimeRange:                client.ToPtr(3600),  // 1 hour
+		Granularity:              client.ToPtr(60),    // 1 minute
+		CompareTimeOffsetSeconds: client.ToPtr(86400), // 1 day
 	}
 
 	_, err := c.Queries.Create(ctx, dataset, &query)
@@ -367,6 +368,26 @@ func TestQuerySpec_EquivalentTo(t *testing.T) {
 				Breakdowns: []string{"column_1"},
 			},
 			client.QuerySpec{},
+			false,
+		},
+		{
+			"Equivalent CompareTimeOffsetSeconds",
+			client.QuerySpec{
+				CompareTimeOffsetSeconds: client.ToPtr((86400)),
+			},
+			client.QuerySpec{
+				CompareTimeOffsetSeconds: client.ToPtr((86400)),
+			},
+			true,
+		},
+		{
+			"Not equivalent CompareTimeOffsetSeconds",
+			client.QuerySpec{
+				CompareTimeOffsetSeconds: client.ToPtr((7200)),
+			},
+			client.QuerySpec{
+				CompareTimeOffsetSeconds: client.ToPtr((3600)),
+			},
 			false,
 		},
 	}

--- a/docs/data-sources/query_specification.md
+++ b/docs/data-sources/query_specification.md
@@ -28,7 +28,7 @@ data "honeycombio_query_specification" "example" {
   filter {
     column = "app.tenant"
     op     = "="
-    value  = "ThatSpecialTenant" 
+    value  = "ThatSpecialTenant"
   }
 
   filter {
@@ -40,9 +40,9 @@ data "honeycombio_query_specification" "example" {
   filter_combination = "AND"
 
   breakdowns = ["app.tenant"]
-    
+
   time_range = 28800 // in seconds, 8 hours
-  
+
   compare_time_offset_seconds = 86400 // in seconds, compare with data from 1 day ago
 }
 
@@ -55,52 +55,52 @@ output "json_query" {
 
 The following arguments are supported:
 
-* `calculation` - (Optional) Zero or more configuration blocks (described below) with the calculations that should be displayed. If no calculations are specified, `COUNT` will be used.
-* `calculated_field` - (Optional) Zero or more configuration blocks (described below) of inline Calculated Fields.
-* `filter` - (Optional) Zero or more configuration blocks (described below) with the filters that should be applied.
-* `filter_combination` - (Optional) How to combine multiple filters, either `AND` (default) or `OR`.
-* `breakdowns` - (Optional) A list of fields to group by.
-* `order` - (Optional) Zero or more configuration blocks (described below) describing how to order the query results. Each term must appear in either `calculation` or `breakdowns`.
-* `having` - (Optional) Zero or more filters used to restrict returned groups in the query result.
-* `limit` - (Optional)  The maximum number of query results, must be between 1 and 1000.
-* `time_range` - (Optional) The time range of the query in seconds, defaults to `7200` (two hours).
-* `start_time` - (Optional) The absolute start time of the query in Unix Time (= seconds since epoch).
-* `end_time` - (Optional) The absolute end time of the query in Unix Time (= seconds since epoch).
-* `granularity` - (Optional) The time resolution of the query’s graph, in seconds. Valid values must be in between the query’s time range /10 at maximum, and /1000 at minimum.
-* `compare_time_offset_seconds` - (Optional) The time offset for comparison queries, in seconds. Used to compare current time range data with data from a previous time period.
+- `calculation` - (Optional) Zero or more configuration blocks (described below) with the calculations that should be displayed. If no calculations are specified, `COUNT` will be used.
+- `calculated_field` - (Optional) Zero or more configuration blocks (described below) of inline Calculated Fields.
+- `filter` - (Optional) Zero or more configuration blocks (described below) with the filters that should be applied.
+- `filter_combination` - (Optional) How to combine multiple filters, either `AND` (default) or `OR`.
+- `breakdowns` - (Optional) A list of fields to group by.
+- `order` - (Optional) Zero or more configuration blocks (described below) describing how to order the query results. Each term must appear in either `calculation` or `breakdowns`.
+- `having` - (Optional) Zero or more filters used to restrict returned groups in the query result.
+- `limit` - (Optional) The maximum number of query results, must be between 1 and 1000.
+- `time_range` - (Optional) The time range of the query in seconds, defaults to `7200` (two hours).
+- `start_time` - (Optional) The absolute start time of the query in Unix Time (= seconds since epoch).
+- `end_time` - (Optional) The absolute end time of the query in Unix Time (= seconds since epoch).
+- `granularity` - (Optional) The time resolution of the query’s graph, in seconds. Valid values must be in between the query’s time range /10 at maximum, and /1000 at minimum.
+- `compare_time_offset_seconds` - (Optional) The time offset for comparison queries, in seconds. Used to compare current time range data with data from a previous time period. Valid values are the query time range, `1800`, `3600`, `7200`, `28800`, `86400`, `604800`, `2419200`, or `15724800`.
 
 ~> **NOTE** It is not allowed to specify all three of `time_range`, `start_time` and `end_time`. For more details about specifying time windows, check [Query specification: A caveat on time](https://docs.honeycomb.io/api/query-specification/#a-caveat-on-time).
 
 Each query configuration may have zero or more `calculation` blocks, which each accept the following arguments:
 
-* `op` - (Required) The operator to apply, see the supported list of calculation operators at [Calculation Operators](https://docs.honeycomb.io/api/query-specification/#calculation-operators).
-* `column` - (Optional) The column to apply the operator to, not needed with `COUNT` or `CONCURRENCY`.
+- `op` - (Required) The operator to apply, see the supported list of calculation operators at [Calculation Operators](https://docs.honeycomb.io/api/query-specification/#calculation-operators).
+- `column` - (Optional) The column to apply the operator to, not needed with `COUNT` or `CONCURRENCY`.
 
 Each query configuration may have zero or more `calculated_field` blocks, which each accept the following arguments:
 
-* `name` - (Required) The name of this Temporary Calculated Field.
-* `expression` - (Required) The formula for your Calculated Field. To learn more about syntax and available functions, and to explore some example formulas, visit the [Calculated Field Formula Reference](https://docs.honeycomb.io/reference/derived-column-formula/).
+- `name` - (Required) The name of this Temporary Calculated Field.
+- `expression` - (Required) The formula for your Calculated Field. To learn more about syntax and available functions, and to explore some example formulas, visit the [Calculated Field Formula Reference](https://docs.honeycomb.io/reference/derived-column-formula/).
 
 Each query configuration may have zero or more `filter` blocks, which each accept the following arguments:
 
-* `column` - (Required) The column to apply the filter to.
-* `op` - (Required) The operator to apply, see the supported list of filter operators at [Filter Operators](https://docs.honeycomb.io/api/query-specification/#filter-operators). Not all operators require a value.
-* `value` - (Optional) The value used for the filter. Not needed if op is `exists` or `not-exists`. Mutually exclusive with the other `value_*` options.
+- `column` - (Required) The column to apply the filter to.
+- `op` - (Required) The operator to apply, see the supported list of filter operators at [Filter Operators](https://docs.honeycomb.io/api/query-specification/#filter-operators). Not all operators require a value.
+- `value` - (Optional) The value used for the filter. Not needed if op is `exists` or `not-exists`. Mutually exclusive with the other `value_*` options.
 
-* -> **NOTE** Filter op `in` and `not-in` expect an array of strings as value. Use the `value` attribute and pass the values in single string separated by `,` without additional spaces (similar to the query builder in the UI). For example: the list `foo`, `bar` becomes `foo,bar`.
+- -> **NOTE** Filter op `in` and `not-in` expect an array of strings as value. Use the `value` attribute and pass the values in single string separated by `,` without additional spaces (similar to the query builder in the UI). For example: the list `foo`, `bar` becomes `foo,bar`.
 
 Each query configuration may have zero or more `order` blocks, which each accept the following arguments. An order term can refer to a `calculation` or a column set in `breakdowns`. When referring to a `calculation`, `op` and `column` must be the same as the calculation.
 
-* `op` - (Optional) The calculation operator to apply, see the supported list of calculation operators at [Calculation Operators](https://docs.honeycomb.io/api/query-specification/#calculation-operators).
-* `column` - (Optional) Either a column present in `breakdown` or a column that `op` applies to.
-* `order` - (Optional) The sort direction, if set must be `ascending` or `descending`.
+- `op` - (Optional) The calculation operator to apply, see the supported list of calculation operators at [Calculation Operators](https://docs.honeycomb.io/api/query-specification/#calculation-operators).
+- `column` - (Optional) Either a column present in `breakdown` or a column that `op` applies to.
+- `order` - (Optional) The sort direction, if set must be `ascending` or `descending`.
 
 Each query configuration may have zero or more `having` blocks, which each accept the following arguments.
 
-* `op` - The operator to apply to filter the query results. One of `=`, `!=`, `>`, `>=`, `<`, or `<=`.
-* `calculate_op` - The calculation operator to apply, supports all of the [Calculation Operators](https://docs.honeycomb.io/api/query-specification/#calculation-operators) with the exception of `HEATMAP`.
-* `column` - The column to apply the `calculate_op` to, not needed with `COUNT` or `CONCURRENCY`.
-* `value` - The value used with `op`. Currently assumed to be a number.
+- `op` - The operator to apply to filter the query results. One of `=`, `!=`, `>`, `>=`, `<`, or `<=`.
+- `calculate_op` - The calculation operator to apply, supports all of the [Calculation Operators](https://docs.honeycomb.io/api/query-specification/#calculation-operators) with the exception of `HEATMAP`.
+- `column` - The column to apply the `calculate_op` to, not needed with `COUNT` or `CONCURRENCY`.
+- `value` - The value used with `op`. Currently assumed to be a number.
 
 ~> **NOTE** A having term's `column`/`calculate_op` pair must have a corresponding `calculation`. There can be multiple `having` blocks for the same `column`/`calculate_op` pair.
 
@@ -108,5 +108,5 @@ Each query configuration may have zero or more `having` blocks, which each accep
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - ID of the query specification.
-* `json` - JSON representation of the query according to the [Query Specification](https://docs.honeycomb.io/api/query-specification/#fields-on-a-query-specification), can be used as input for other resources.
+- `id` - ID of the query specification.
+- `json` - JSON representation of the query according to the [Query Specification](https://docs.honeycomb.io/api/query-specification/#fields-on-a-query-specification), can be used as input for other resources.

--- a/docs/data-sources/query_specification.md
+++ b/docs/data-sources/query_specification.md
@@ -42,6 +42,8 @@ data "honeycombio_query_specification" "example" {
   breakdowns = ["app.tenant"]
     
   time_range = 28800 // in seconds, 8 hours
+  
+  compare_time_offset_seconds = 86400 // in seconds, compare with data from 1 day ago
 }
 
 output "json_query" {
@@ -65,6 +67,7 @@ The following arguments are supported:
 * `start_time` - (Optional) The absolute start time of the query in Unix Time (= seconds since epoch).
 * `end_time` - (Optional) The absolute end time of the query in Unix Time (= seconds since epoch).
 * `granularity` - (Optional) The time resolution of the query’s graph, in seconds. Valid values must be in between the query’s time range /10 at maximum, and /1000 at minimum.
+* `compare_time_offset_seconds` - (Optional) The time offset for comparison queries, in seconds. Used to compare current time range data with data from a previous time period.
 
 ~> **NOTE** It is not allowed to specify all three of `time_range`, `start_time` and `end_time`. For more details about specifying time windows, check [Query specification: A caveat on time](https://docs.honeycomb.io/api/query-specification/#a-caveat-on-time).
 

--- a/docs/data-sources/query_specification.md
+++ b/docs/data-sources/query_specification.md
@@ -43,7 +43,7 @@ data "honeycombio_query_specification" "example" {
     
   time_range = 28800 // in seconds, 8 hours
   
-  compare_time_offset_seconds = 86400 // in seconds, compare with data from 1 day ago
+  compare_time_offset = 86400 // in seconds, compare with data from 1 day ago
 }
 
 output "json_query" {
@@ -67,7 +67,7 @@ The following arguments are supported:
 * `start_time` - (Optional) The absolute start time of the query in Unix Time (= seconds since epoch).
 * `end_time` - (Optional) The absolute end time of the query in Unix Time (= seconds since epoch).
 * `granularity` - (Optional) The time resolution of the query’s graph, in seconds. Valid values must be in between the query’s time range /10 at maximum, and /1000 at minimum.
-* `compare_time_offset_seconds` - (Optional) The time offset for comparison queries, in seconds. Used to compare current time range data with data from a previous time period. Valid values are the query time range, `1800`, `3600`, `7200`, `28800`, `86400`, `604800`, `2419200`, or `15724800`.
+* `compare_time_offset` - (Optional) The time offset for comparison queries, in seconds. Used to compare current time range data with data from a previous time period. Valid values are the query time range, `1800`, `3600`, `7200`, `28800`, `86400`, `604800`, `2419200`, or `15724800`.
 
 ~> **NOTE** It is not allowed to specify all three of `time_range`, `start_time` and `end_time`. For more details about specifying time windows, check [Query specification: A caveat on time](https://docs.honeycomb.io/api/query-specification/#a-caveat-on-time).
 

--- a/docs/data-sources/query_specification.md
+++ b/docs/data-sources/query_specification.md
@@ -28,7 +28,7 @@ data "honeycombio_query_specification" "example" {
   filter {
     column = "app.tenant"
     op     = "="
-    value  = "ThatSpecialTenant"
+    value  = "ThatSpecialTenant" 
   }
 
   filter {
@@ -40,9 +40,9 @@ data "honeycombio_query_specification" "example" {
   filter_combination = "AND"
 
   breakdowns = ["app.tenant"]
-
+    
   time_range = 28800 // in seconds, 8 hours
-
+  
   compare_time_offset_seconds = 86400 // in seconds, compare with data from 1 day ago
 }
 
@@ -55,52 +55,52 @@ output "json_query" {
 
 The following arguments are supported:
 
-- `calculation` - (Optional) Zero or more configuration blocks (described below) with the calculations that should be displayed. If no calculations are specified, `COUNT` will be used.
-- `calculated_field` - (Optional) Zero or more configuration blocks (described below) of inline Calculated Fields.
-- `filter` - (Optional) Zero or more configuration blocks (described below) with the filters that should be applied.
-- `filter_combination` - (Optional) How to combine multiple filters, either `AND` (default) or `OR`.
-- `breakdowns` - (Optional) A list of fields to group by.
-- `order` - (Optional) Zero or more configuration blocks (described below) describing how to order the query results. Each term must appear in either `calculation` or `breakdowns`.
-- `having` - (Optional) Zero or more filters used to restrict returned groups in the query result.
-- `limit` - (Optional) The maximum number of query results, must be between 1 and 1000.
-- `time_range` - (Optional) The time range of the query in seconds, defaults to `7200` (two hours).
-- `start_time` - (Optional) The absolute start time of the query in Unix Time (= seconds since epoch).
-- `end_time` - (Optional) The absolute end time of the query in Unix Time (= seconds since epoch).
-- `granularity` - (Optional) The time resolution of the query’s graph, in seconds. Valid values must be in between the query’s time range /10 at maximum, and /1000 at minimum.
-- `compare_time_offset_seconds` - (Optional) The time offset for comparison queries, in seconds. Used to compare current time range data with data from a previous time period. Valid values are the query time range, `1800`, `3600`, `7200`, `28800`, `86400`, `604800`, `2419200`, or `15724800`.
+* `calculation` - (Optional) Zero or more configuration blocks (described below) with the calculations that should be displayed. If no calculations are specified, `COUNT` will be used.
+* `calculated_field` - (Optional) Zero or more configuration blocks (described below) of inline Calculated Fields.
+* `filter` - (Optional) Zero or more configuration blocks (described below) with the filters that should be applied.
+* `filter_combination` - (Optional) How to combine multiple filters, either `AND` (default) or `OR`.
+* `breakdowns` - (Optional) A list of fields to group by.
+* `order` - (Optional) Zero or more configuration blocks (described below) describing how to order the query results. Each term must appear in either `calculation` or `breakdowns`.
+* `having` - (Optional) Zero or more filters used to restrict returned groups in the query result.
+* `limit` - (Optional)  The maximum number of query results, must be between 1 and 1000.
+* `time_range` - (Optional) The time range of the query in seconds, defaults to `7200` (two hours).
+* `start_time` - (Optional) The absolute start time of the query in Unix Time (= seconds since epoch).
+* `end_time` - (Optional) The absolute end time of the query in Unix Time (= seconds since epoch).
+* `granularity` - (Optional) The time resolution of the query’s graph, in seconds. Valid values must be in between the query’s time range /10 at maximum, and /1000 at minimum.
+* `compare_time_offset_seconds` - (Optional) The time offset for comparison queries, in seconds. Used to compare current time range data with data from a previous time period. Valid values are the query time range, `1800`, `3600`, `7200`, `28800`, `86400`, `604800`, `2419200`, or `15724800`.
 
 ~> **NOTE** It is not allowed to specify all three of `time_range`, `start_time` and `end_time`. For more details about specifying time windows, check [Query specification: A caveat on time](https://docs.honeycomb.io/api/query-specification/#a-caveat-on-time).
 
 Each query configuration may have zero or more `calculation` blocks, which each accept the following arguments:
 
-- `op` - (Required) The operator to apply, see the supported list of calculation operators at [Calculation Operators](https://docs.honeycomb.io/api/query-specification/#calculation-operators).
-- `column` - (Optional) The column to apply the operator to, not needed with `COUNT` or `CONCURRENCY`.
+* `op` - (Required) The operator to apply, see the supported list of calculation operators at [Calculation Operators](https://docs.honeycomb.io/api/query-specification/#calculation-operators).
+* `column` - (Optional) The column to apply the operator to, not needed with `COUNT` or `CONCURRENCY`.
 
 Each query configuration may have zero or more `calculated_field` blocks, which each accept the following arguments:
 
-- `name` - (Required) The name of this Temporary Calculated Field.
-- `expression` - (Required) The formula for your Calculated Field. To learn more about syntax and available functions, and to explore some example formulas, visit the [Calculated Field Formula Reference](https://docs.honeycomb.io/reference/derived-column-formula/).
+* `name` - (Required) The name of this Temporary Calculated Field.
+* `expression` - (Required) The formula for your Calculated Field. To learn more about syntax and available functions, and to explore some example formulas, visit the [Calculated Field Formula Reference](https://docs.honeycomb.io/reference/derived-column-formula/).
 
 Each query configuration may have zero or more `filter` blocks, which each accept the following arguments:
 
-- `column` - (Required) The column to apply the filter to.
-- `op` - (Required) The operator to apply, see the supported list of filter operators at [Filter Operators](https://docs.honeycomb.io/api/query-specification/#filter-operators). Not all operators require a value.
-- `value` - (Optional) The value used for the filter. Not needed if op is `exists` or `not-exists`. Mutually exclusive with the other `value_*` options.
+* `column` - (Required) The column to apply the filter to.
+* `op` - (Required) The operator to apply, see the supported list of filter operators at [Filter Operators](https://docs.honeycomb.io/api/query-specification/#filter-operators). Not all operators require a value.
+* `value` - (Optional) The value used for the filter. Not needed if op is `exists` or `not-exists`. Mutually exclusive with the other `value_*` options.
 
-- -> **NOTE** Filter op `in` and `not-in` expect an array of strings as value. Use the `value` attribute and pass the values in single string separated by `,` without additional spaces (similar to the query builder in the UI). For example: the list `foo`, `bar` becomes `foo,bar`.
+* -> **NOTE** Filter op `in` and `not-in` expect an array of strings as value. Use the `value` attribute and pass the values in single string separated by `,` without additional spaces (similar to the query builder in the UI). For example: the list `foo`, `bar` becomes `foo,bar`.
 
 Each query configuration may have zero or more `order` blocks, which each accept the following arguments. An order term can refer to a `calculation` or a column set in `breakdowns`. When referring to a `calculation`, `op` and `column` must be the same as the calculation.
 
-- `op` - (Optional) The calculation operator to apply, see the supported list of calculation operators at [Calculation Operators](https://docs.honeycomb.io/api/query-specification/#calculation-operators).
-- `column` - (Optional) Either a column present in `breakdown` or a column that `op` applies to.
-- `order` - (Optional) The sort direction, if set must be `ascending` or `descending`.
+* `op` - (Optional) The calculation operator to apply, see the supported list of calculation operators at [Calculation Operators](https://docs.honeycomb.io/api/query-specification/#calculation-operators).
+* `column` - (Optional) Either a column present in `breakdown` or a column that `op` applies to.
+* `order` - (Optional) The sort direction, if set must be `ascending` or `descending`.
 
 Each query configuration may have zero or more `having` blocks, which each accept the following arguments.
 
-- `op` - The operator to apply to filter the query results. One of `=`, `!=`, `>`, `>=`, `<`, or `<=`.
-- `calculate_op` - The calculation operator to apply, supports all of the [Calculation Operators](https://docs.honeycomb.io/api/query-specification/#calculation-operators) with the exception of `HEATMAP`.
-- `column` - The column to apply the `calculate_op` to, not needed with `COUNT` or `CONCURRENCY`.
-- `value` - The value used with `op`. Currently assumed to be a number.
+* `op` - The operator to apply to filter the query results. One of `=`, `!=`, `>`, `>=`, `<`, or `<=`.
+* `calculate_op` - The calculation operator to apply, supports all of the [Calculation Operators](https://docs.honeycomb.io/api/query-specification/#calculation-operators) with the exception of `HEATMAP`.
+* `column` - The column to apply the `calculate_op` to, not needed with `COUNT` or `CONCURRENCY`.
+* `value` - The value used with `op`. Currently assumed to be a number.
 
 ~> **NOTE** A having term's `column`/`calculate_op` pair must have a corresponding `calculation`. There can be multiple `having` blocks for the same `column`/`calculate_op` pair.
 
@@ -108,5 +108,5 @@ Each query configuration may have zero or more `having` blocks, which each accep
 
 In addition to all arguments above, the following attributes are exported:
 
-- `id` - ID of the query specification.
-- `json` - JSON representation of the query according to the [Query Specification](https://docs.honeycomb.io/api/query-specification/#fields-on-a-query-specification), can be used as input for other resources.
+* `id` - ID of the query specification.
+* `json` - JSON representation of the query according to the [Query Specification](https://docs.honeycomb.io/api/query-specification/#fields-on-a-query-specification), can be used as input for other resources.

--- a/example/query/main.tf
+++ b/example/query/main.tf
@@ -1,0 +1,62 @@
+terraform {
+  required_providers {
+    honeycombio = {
+      source = "honeycombio/honeycombio"
+    }
+  }
+}
+
+variable "dataset" {
+  type        = string
+  description = "The dataset to create the query in"
+}
+
+# Create a query specification with compare_time_offset_seconds
+data "honeycombio_query_specification" "comparison_query" {
+  calculation {
+    op = "COUNT"
+  }
+
+  # Filter for successful requests only
+  filter {
+    column = "status_code"
+    op     = "="
+    value  = "200"
+  }
+
+  # Group by service name
+  breakdowns = ["service.name"]
+
+  # Query the last 4 hours
+  time_range = 14400 // 4 hours in seconds
+
+  # Compare with data from 24 hours ago (1 day)
+  compare_time_offset = 86400 // 24 hours in seconds
+
+  # Limit results to top 10 services
+  limit = 10
+
+  # Order by average duration descending
+  order {
+    op     = "AVG"
+    column = "duration_ms"
+    order  = "descending"
+  }
+}
+
+# Create the query using the specification
+resource "honeycombio_query" "comparison_query" {
+  dataset    = var.dataset
+  query_json = data.honeycombio_query_specification.comparison_query.json
+}
+
+# Output the query ID and JSON for reference
+output "query_id" {
+  value       = honeycombio_query.comparison_query.id
+  description = "The ID of the created query"
+}
+
+output "query_json" {
+  value       = data.honeycombio_query_specification.comparison_query.json
+  description = "The JSON specification of the query with comparison"
+}

--- a/internal/models/query.go
+++ b/internal/models/query.go
@@ -9,20 +9,21 @@ type QueryResourceModel struct {
 }
 
 type QuerySpecificationModel struct {
-	ID                types.String                             `tfsdk:"id"`
-	FilterCombination types.String                             `tfsdk:"filter_combination"`
-	Breakdowns        []types.String                           `tfsdk:"breakdowns"`
-	Limit             types.Int64                              `tfsdk:"limit"`
-	TimeRange         types.Int64                              `tfsdk:"time_range"`
-	StartTime         types.Int64                              `tfsdk:"start_time"`
-	EndTime           types.Int64                              `tfsdk:"end_time"`
-	Granularity       types.Int64                              `tfsdk:"granularity"`
-	Calculations      []QuerySpecificationCalculationModel     `tfsdk:"calculation"`
-	CalculatedFields  []QuerySpecificationCalculatedFieldModel `tfsdk:"calculated_field"`
-	Filters           []QuerySpecificationFilterModel          `tfsdk:"filter"`
-	Havings           []QuerySpecificationHavingModel          `tfsdk:"having"`
-	Orders            []QuerySpecificationOrderModel           `tfsdk:"order"`
-	Json              types.String                             `tfsdk:"json"` // Computed JSON query specification output
+	ID                       types.String                             `tfsdk:"id"`
+	FilterCombination        types.String                             `tfsdk:"filter_combination"`
+	Breakdowns               []types.String                           `tfsdk:"breakdowns"`
+	Limit                    types.Int64                              `tfsdk:"limit"`
+	TimeRange                types.Int64                              `tfsdk:"time_range"`
+	StartTime                types.Int64                              `tfsdk:"start_time"`
+	EndTime                  types.Int64                              `tfsdk:"end_time"`
+	Granularity              types.Int64                              `tfsdk:"granularity"`
+	CompareTimeOffsetSeconds types.Int64                              `tfsdk:"compare_time_offset_seconds"`
+	Calculations             []QuerySpecificationCalculationModel     `tfsdk:"calculation"`
+	CalculatedFields         []QuerySpecificationCalculatedFieldModel `tfsdk:"calculated_field"`
+	Filters                  []QuerySpecificationFilterModel          `tfsdk:"filter"`
+	Havings                  []QuerySpecificationHavingModel          `tfsdk:"having"`
+	Orders                   []QuerySpecificationOrderModel           `tfsdk:"order"`
+	Json                     types.String                             `tfsdk:"json"` // Computed JSON query specification output
 }
 
 type QuerySpecificationCalculationModel struct {

--- a/internal/models/query.go
+++ b/internal/models/query.go
@@ -9,21 +9,21 @@ type QueryResourceModel struct {
 }
 
 type QuerySpecificationModel struct {
-	ID                       types.String                             `tfsdk:"id"`
-	FilterCombination        types.String                             `tfsdk:"filter_combination"`
-	Breakdowns               []types.String                           `tfsdk:"breakdowns"`
-	Limit                    types.Int64                              `tfsdk:"limit"`
-	TimeRange                types.Int64                              `tfsdk:"time_range"`
-	StartTime                types.Int64                              `tfsdk:"start_time"`
-	EndTime                  types.Int64                              `tfsdk:"end_time"`
-	Granularity              types.Int64                              `tfsdk:"granularity"`
-	CompareTimeOffsetSeconds types.Int64                              `tfsdk:"compare_time_offset_seconds"`
-	Calculations             []QuerySpecificationCalculationModel     `tfsdk:"calculation"`
-	CalculatedFields         []QuerySpecificationCalculatedFieldModel `tfsdk:"calculated_field"`
-	Filters                  []QuerySpecificationFilterModel          `tfsdk:"filter"`
-	Havings                  []QuerySpecificationHavingModel          `tfsdk:"having"`
-	Orders                   []QuerySpecificationOrderModel           `tfsdk:"order"`
-	Json                     types.String                             `tfsdk:"json"` // Computed JSON query specification output
+	ID                types.String                             `tfsdk:"id"`
+	FilterCombination types.String                             `tfsdk:"filter_combination"`
+	Breakdowns        []types.String                           `tfsdk:"breakdowns"`
+	Limit             types.Int64                              `tfsdk:"limit"`
+	TimeRange         types.Int64                              `tfsdk:"time_range"`
+	StartTime         types.Int64                              `tfsdk:"start_time"`
+	EndTime           types.Int64                              `tfsdk:"end_time"`
+	Granularity       types.Int64                              `tfsdk:"granularity"`
+	CompareTimeOffset types.Int64                              `tfsdk:"compare_time_offset"`
+	Calculations      []QuerySpecificationCalculationModel     `tfsdk:"calculation"`
+	CalculatedFields  []QuerySpecificationCalculatedFieldModel `tfsdk:"calculated_field"`
+	Filters           []QuerySpecificationFilterModel          `tfsdk:"filter"`
+	Havings           []QuerySpecificationHavingModel          `tfsdk:"having"`
+	Orders            []QuerySpecificationOrderModel           `tfsdk:"order"`
+	Json              types.String                             `tfsdk:"json"` // Computed JSON query specification output
 }
 
 type QuerySpecificationCalculationModel struct {

--- a/internal/provider/query_specification_data_source.go
+++ b/internal/provider/query_specification_data_source.go
@@ -89,6 +89,11 @@ func (d *querySpecDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 				Optional:   true,
 				Validators: []validator.Int64{int64validator.AtLeast(0)},
 			},
+			"compare_time_offset_seconds": schema.Int64Attribute{
+				Description: "The time offset for comparison queries, in seconds. " +
+					"Used to compare current time range data with data from a previous time period.",
+				Optional: true,
+			},
 			"json": schema.StringAttribute{
 				Description: "The generated query specification in JSON format.",
 				Computed:    true,
@@ -440,6 +445,9 @@ func (d *querySpecDataSource) Read(ctx context.Context, req datasource.ReadReque
 	}
 	if !data.Granularity.IsNull() {
 		querySpec.Granularity = client.ToPtr(int(data.Granularity.ValueInt64()))
+	}
+	if !data.CompareTimeOffsetSeconds.IsNull() {
+		querySpec.CompareTimeOffsetSeconds = client.ToPtr(int(data.CompareTimeOffsetSeconds.ValueInt64()))
 	}
 
 	if querySpec.TimeRange != nil && querySpec.StartTime != nil && querySpec.EndTime != nil {

--- a/internal/provider/query_specification_data_source.go
+++ b/internal/provider/query_specification_data_source.go
@@ -538,10 +538,15 @@ func (d *querySpecDataSource) ValidateConfig(ctx context.Context, req datasource
 		}
 
 		if !slices.Contains(timeOverTimeOptions, data.CompareTimeOffset.ValueInt64()) {
+			// Convert int to string for the error message
+			timeOverTimeStrings := make([]string, len(timeOverTimeOptions))
+			for i, val := range timeOverTimeOptions {
+				timeOverTimeStrings[i] = strconv.FormatInt(val, 10)
+			}
 			resp.Diagnostics.AddAttributeError(
 				path.Root("compare_time_offset"),
 				"compare_time_offset is an invalid value.",
-				"",
+				"Valid values are: "+strings.Join(timeOverTimeStrings, ", "),
 			)
 		}
 	}

--- a/internal/provider/query_specification_data_source_test.go
+++ b/internal/provider/query_specification_data_source_test.go
@@ -107,7 +107,8 @@ func TestAcc_QuerySpecificationDataSource_basic(t *testing.T) {
   "limit": 250,
   "time_range": 7200,
   "start_time": 1577836800,
-  "granularity": 30
+  "granularity": 30,
+  "compare_time_offset_seconds": 3600
 }`)
 	require.NoError(t, err)
 	resource.Test(t, resource.TestCase{
@@ -181,10 +182,11 @@ data "honeycombio_query_specification" "test" {
         value        = 1000
     }
 
-    limit       = 250
-    time_range  = 7200
-    start_time  = 1577836800
-    granularity = 30
+    limit                       = 250
+    time_range                  = 7200
+    start_time                  = 1577836800
+    granularity                 = 30
+    compare_time_offset_seconds = 3600
 }
 
 output "query_json" {

--- a/internal/provider/query_specification_data_source_test.go
+++ b/internal/provider/query_specification_data_source_test.go
@@ -634,7 +634,7 @@ func TestAcc_QuerySpecificationDataSource_TimeRange_CompareTimeOffsetInvalid(t *
 		Steps: []resource.TestStep{
 			{
 				Config: `
-data "honeycombio_query_specification" "test" {
+data "honeycombio_query_specification" "less_than_time_range" {
   calculation {
     op = "COUNT"
   }
@@ -650,9 +650,37 @@ data "honeycombio_query_specification" "test" {
 }
 
 output "query_json" {
-  value = data.honeycombio_query_specification.test.json
+  value = data.honeycombio_query_specification.less_than_time_range.json
 }`,
 				ExpectError: regexp.MustCompile("compare_time_offset must be greater than the queries time range"),
+			},
+		},
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 testAccPreCheck(t),
+		ProtoV5ProviderFactories: testAccProtoV5MuxServerFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+data "honeycombio_query_specification" "invalid_compare_time_offset" {
+  calculation {
+    op = "COUNT"
+  }
+
+  filter {
+    column = "duration_ms"
+    op     = "="
+    value  = 0
+  }
+
+  compare_time_offset = 1
+}
+
+output "query_json" {
+  value = data.honeycombio_query_specification.invalid_compare_time_offset.json
+}`,
+				ExpectError: regexp.MustCompile("compare_time_offset is an invalid value"),
 			},
 		},
 	})


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Short description of the changes

- Terraform support for new field `compare_time_offset_seconds` in the `queries` API 
- API PR is [here](https://github.com/honeycombio/hound/pull/26488)

## Asana ticket

https://app.asana.com/1/72322038700732/project/1209727892923597/task/1209727895622899?focus=true


## How to verify that this has the expected result

Create a quiery using compare_time_offset_seconds, you should get an error when using an invalid option


These are the valid options (all should be in seconds & can be negative or positive values):
- same time as query time range,
- 30 minutes
- 1 hour
- 2 hours
- 8 hours
- 24 hours
- 7 days
- 28 days
- 182 days