### PR TITLE
fix(r/flexible_board): Add limits for preset filters, docs for views

### DIFF
--- a/docs/resources/board_view.md
+++ b/docs/resources/board_view.md
@@ -3,12 +3,12 @@
 page_title: "honeycombio_board_view Resource - honeycombio"
 subcategory: ""
 description: |-
-  Manages a board view in a Honeycomb flexible board.
+  Manages a board view in a Honeycomb flexible board. Maximum of 50 boards views per board.
 ---
 
 # honeycombio_board_view (Resource)
 
-Manages a board view in a Honeycomb flexible board.
+Manages a board view in a Honeycomb flexible board. Maximum of 50 boards views per board.
 
 
 

--- a/docs/resources/flexible_board.md
+++ b/docs/resources/flexible_board.md
@@ -153,7 +153,7 @@ EOF
 
 - `description` (String) The description of the Board. Supports Markdown.
 - `panel` (Block List) List of panels to render on the board. (see [below for nested schema](#nestedblock--panel))
-- `preset_filter` (Block List) List of preset filters for the board. (see [below for nested schema](#nestedblock--preset_filter))
+- `preset_filter` (Block List) List of preset filters for the board. Maximum of 5 preset filters per board. (see [below for nested schema](#nestedblock--preset_filter))
 - `tags` (Map of String) A map of tags to assign to the resource.
 
 ### Read-Only

--- a/internal/provider/board_view_resource.go
+++ b/internal/provider/board_view_resource.go
@@ -60,7 +60,7 @@ func (r *boardViewResource) Configure(_ context.Context, req resource.ConfigureR
 
 func (*boardViewResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description: "Manages a board view in a Honeycomb flexible board.",
+		Description: "Manages a board view in a Honeycomb flexible board. Maximum of 50 boards views per board.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed:    true,

--- a/internal/provider/flexible_board_resource.go
+++ b/internal/provider/flexible_board_resource.go
@@ -294,7 +294,10 @@ func (*flexibleBoardResource) Schema(_ context.Context, _ resource.SchemaRequest
 				},
 			},
 			"preset_filter": schema.ListNestedBlock{
-				Description: "List of preset filters for the board.",
+				Description: "List of preset filters for the board. Maximum of 5 preset filters per board.",
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(5),
+				},
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
 						"column": schema.StringAttribute{


### PR DESCRIPTION
## Which problem is this PR solving?

- tiny dx improvement for preset filter limits that allows the plan to error if user goes beyond limit. The API always has this validation, this helps make the feedback loop faster
