### PR TITLE
feat(client-query, Query Mafs): Initial Setup for Formula Datatypes

### DIFF
--- a/client/query_spec.go
+++ b/client/query_spec.go
@@ -32,7 +32,8 @@ type QuerySpec struct {
 	ID *string `json:"id,omitempty"`
 
 	// The calculations to return as a time series and summary table. If no
-	// calculations are provided, COUNT is applied.
+	// calculations are provided, COUNT is applied. Can be used in formulas, aswell
+	// when calculations are named.
 	Calculations []CalculationSpec `json:"calculations,omitempty"`
 	// CalculatedFields are temporary Calculated Fields that are
 	// created for the query.
@@ -77,6 +78,9 @@ type QuerySpec struct {
 	// The time offset for comparison queries, in seconds. Used to compare current
 	// time range data with data from a previous time period.
 	CompareTimeOffsetSeconds *int `json:"compare_time_offset_seconds,omitempty"`
+	// A list of objects describing named expressions that can be used with named aggregates to calculate the result
+	// of a query
+	Formulas []FormulaSpec `json:"formulas,omitempty"`
 }
 
 // Encode returns the JSON string representation of the QuerySpec.
@@ -175,7 +179,8 @@ func (qs *QuerySpec) EquivalentTo(other QuerySpec) bool {
 
 // CalculationSpec represents a calculation within a query.
 type CalculationSpec struct {
-	Op CalculationOp `json:"op"`
+	Name string        `json:"name"`
+	Op   CalculationOp `json:"op"`
 	// Column to perform the operation on. Not needed with COUNT or CONCURRENCY
 	Column *string `json:"column,omitempty"`
 }
@@ -402,4 +407,10 @@ func HavingOps() []HavingOp {
 		HavingOpLessThan,
 		HavingOpLessThanOrEqual,
 	}
+}
+
+// FormulaSpec describes named expressions that are used to calculate a query result
+type FormulaSpec struct {
+	Name       string `json:"name,omitempty"`
+	Expression string `json:"expression,omitempty"`
 }

--- a/internal/models/query.go
+++ b/internal/models/query.go
@@ -23,10 +23,12 @@ type QuerySpecificationModel struct {
 	Filters           []QuerySpecificationFilterModel          `tfsdk:"filter"`
 	Havings           []QuerySpecificationHavingModel          `tfsdk:"having"`
 	Orders            []QuerySpecificationOrderModel           `tfsdk:"order"`
+	Formulas          []QuerySpecificationFormulaModel         `tfsdk:"formula"`
 	Json              types.String                             `tfsdk:"json"` // Computed JSON query specification output
 }
 
 type QuerySpecificationCalculationModel struct {
+	Name   types.String `tfsdk:"name"`
 	Column types.String `tfsdk:"column"`
 	Op     types.String `tfsdk:"op"`
 }
@@ -47,6 +49,11 @@ type QuerySpecificationHavingModel struct {
 	Column      types.String  `tfsdk:"column"`
 	Op          types.String  `tfsdk:"op"`
 	Value       types.Float64 `tfsdk:"value"`
+}
+
+type QuerySpecificationFormulaModel struct {
+	Name       types.String `tfsdk:"name"`
+	Expression types.String `tfsdk:"expression"`
 }
 
 type QuerySpecificationOrderModel struct {


### PR DESCRIPTION
## Which problem is this PR solving?

- Chips away at #SIG-2720

https://linear.app/honeycombio/issue/SIG-2720/tqmm3-add-formula-support-to-terraform-trigger-sources

## Short description of the changes
This adds in the initial data types needed for query math. Later PRs will use these data types to accomplish the following:
- Trigger Configuration Validation with Formulas
- Crud operations for triggers with formulas.

## How to verify that this has the expected result
Since this is an initial PR, just a PR review to verify the data types look good should be fine. Then, in the subsequent PRs there will be tests to validate the configuration validation and crud operations.
