### PR TITLE
feat: add threshold type to chart settings

### DIFF
--- a/client/board.go
+++ b/client/board.go
@@ -109,11 +109,21 @@ type BoardQueryVisualizationSettings struct {
 	Charts               []*ChartSettings `json:"charts,omitempty"`
 }
 
+type Threshold struct {
+	Value      float64 `json:"value"`
+	Label      string  `json:"label"`
+	Color      int     `json:"color"`
+	Operation  int     `json:"operation"`
+	LineStyle  int     `json:"lineStyle"`
+	ChartIndex int     `json:"chartIndex"`
+}
+
 type ChartSettings struct {
-	ChartType         string `json:"chart_type,omitempty"` // "default", "line", "stacked", "stat", "tsbar"
-	ChartIndex        int    `json:"chart_index"`
-	OmitMissingValues bool   `json:"omit_missing_values,omitempty"`
-	UseLogScale       bool   `json:"log_scale,omitempty"`
+	ChartType         string       `json:"chart_type,omitempty"` // "default", "line", "stacked", "stat", "tsbar"
+	ChartIndex        int          `json:"chart_index"`
+	OmitMissingValues bool         `json:"omit_missing_values,omitempty"`
+	UseLogScale       bool         `json:"log_scale,omitempty"`
+	Thresholds        []*Threshold `json:"thresholds,omitempty"`
 }
 
 type BoardSLOPanel struct {

--- a/internal/models/flexible_board.go
+++ b/internal/models/flexible_board.go
@@ -114,11 +114,30 @@ var VisualizationSettingsModelAttrType = map[string]attr.Type{
 	},
 }
 
+type ThresholdModel struct {
+	Value      types.Float64 `tfsdk:"value"`
+	Label      types.String  `tfsdk:"label"`
+	Color      types.Int64   `tfsdk:"color"`
+	Operation  types.Int64   `tfsdk:"operation"`
+	LineStyle  types.Int64   `tfsdk:"line_style"`
+	ChartIndex types.Int64   `tfsdk:"chart_index"`
+}
+
+var ThresholdModelAttrType = map[string]attr.Type{
+	"value":       types.Float64Type,
+	"label":       types.StringType,
+	"color":       types.Int64Type,
+	"operation":   types.Int64Type,
+	"line_style":  types.Int64Type,
+	"chart_index": types.Int64Type,
+}
+
 type ChartSettingsModel struct {
 	ChartType         types.String `tfsdk:"chart_type"`
 	ChartIndex        types.Int64  `tfsdk:"chart_index"`
 	OmitMissingValues types.Bool   `tfsdk:"omit_missing_values"`
 	LogScale          types.Bool   `tfsdk:"use_log_scale"`
+	Thresholds        types.List   `tfsdk:"thresholds"` // List of ThresholdModel
 }
 
 var ChartSettingsModelAttrType = map[string]attr.Type{
@@ -126,6 +145,11 @@ var ChartSettingsModelAttrType = map[string]attr.Type{
 	"chart_index":         types.Int64Type,
 	"omit_missing_values": types.BoolType,
 	"use_log_scale":       types.BoolType,
+	"thresholds": types.ListType{
+		ElemType: types.ObjectType{
+			AttrTypes: ThresholdModelAttrType,
+		},
+	},
 }
 
 // This is the old version of the BoardPanelModel


### PR DESCRIPTION
## Overview

I am being moved off the thresholds project for now, but wanted to push up a quick draft PR while I still have mental context, for whenever we pick up this work again. This PR is largely untested, and will need to ship _after_ the public API functionality for thresholds is added.

## Which problem is this PR solving?

Adding thresholds support to chart settings.

## Short description of the changes

## How to verify that this has the expected result
