### PR TITLE
feat(calculated-fields): Update Syntax Validator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/hashicorp/terraform-plugin-mux v0.21.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.38.1
 	github.com/hashicorp/terraform-plugin-testing v1.14.0
-	github.com/honeycombio/honeycomb-derived-column-validator v0.1.0
+	github.com/honeycombio/honeycomb-derived-column-validator v0.2.0
 	github.com/joho/godotenv v1.5.1
 	github.com/stretchr/testify v1.11.1
 )

--- a/go.sum
+++ b/go.sum
@@ -137,8 +137,8 @@ github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S
 github.com/hashicorp/terraform-svchost v0.1.1/go.mod h1:mNsjQfZyf/Jhz35v6/0LWcv26+X7JPS+buii2c9/ctc=
 github.com/hashicorp/yamux v0.1.2 h1:XtB8kyFOyHXYVFnwT5C3+Bdo8gArse7j2AQ0DA0Uey8=
 github.com/hashicorp/yamux v0.1.2/go.mod h1:C+zze2n6e/7wshOZep2A70/aQU6QBRWJO/G6FT1wIns=
-github.com/honeycombio/honeycomb-derived-column-validator v0.1.0 h1:lP7CnzE59xRlvvZsmiQ9Vt5c3fF6q4taFLSYRbIf114=
-github.com/honeycombio/honeycomb-derived-column-validator v0.1.0/go.mod h1:HcOfP9e3riQs0XHFDdEGIQjMmKsX7Tynbio5AGcL3uo=
+github.com/honeycombio/honeycomb-derived-column-validator v0.2.0 h1:skWuV7K5+G8y6PmuzwPeHoEf+0xGaY6eF+q1CaNTwRo=
+github.com/honeycombio/honeycomb-derived-column-validator v0.2.0/go.mod h1:HcOfP9e3riQs0XHFDdEGIQjMmKsX7Tynbio5AGcL3uo=
 github.com/huandu/xstrings v1.3.3 h1:/Gcsuc1x8JVbJ9/rlye4xZnVAbEkGauT8lbebqcQws4=
 github.com/huandu/xstrings v1.3.3/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=

--- a/internal/helper/validation/valid_calculated_field_test.go
+++ b/internal/helper/validation/valid_calculated_field_test.go
@@ -43,6 +43,13 @@ func Test_IsValidCalculatedFieldValidator(t *testing.T) {
 			val:         types.StringValue(`IF(AND(NOT(EXISTS($trace.parent_id)),EXISTS($duration_ms)),LTE($duration_ms,300)),`),
 			expectError: true,
 		},
+		"valid timeseries function": {
+			val: types.StringValue(`MAX(LAST(1))`),
+		},
+		"nested timeseries functions": {
+			val:         types.StringValue(`RATE(LAST(1))`),
+			expectError: true,
+		},
 	}
 
 	for name, tc := range testCases {


### PR DESCRIPTION
## Which problem is this PR solving?

Plan-time Calculated Field (fka Derived Columns) validation is not aware of timeseries aggregates.

Fixes: https://linear.app/honeycombio/issue/APPO11Y-3759

## Short description of the changes

Upgrades Calculated Fields (fka Derived Columns) to recognize timeseries operations.
* Note that these operations are only applicable in limited circumstances (ad-hoc DCs + Metrics 2.0)
* The correctness here is limited to syntax correctness; semantic correctness is still enforced by the Public API.

These changes shouldn't need to be gated by Metrics 2.0 enablement; it will also unblock at least 1 customer in the Metrics Beta program.

## How to verify that this has the expected result

Test automation here is sufficient.
