### PR TITLE
Add per-team CODEOWNERS for provider resources

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,10 +5,9 @@
 # all board resources are owned by the growth team
 *board* @honeycombio/growth
 
-# all query, column, trigger, SLO, burn alert, and webhook resources
+# all query, trigger, SLO, burn alert, and webhook resources
 # are owned by app-observability
 *query* @honeycombio/app-observability
-*column* @honeycombio/app-observability
 *trigger* @honeycombio/app-observability
 *slo* @honeycombio/app-observability
 *burn_alert* @honeycombio/app-observability

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,19 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence.
 * @honeycombio/scale
+
+# all board resources are owned by the growth team
+*board* @honeycombio/growth
+
+# all query, dataset, derived column, environment, column, trigger,
+# SLO, burn alert, and webhook resources are owned by app-observability
+*query* @honeycombio/app-observability
+*dataset* @honeycombio/app-observability
+*derived_column* @honeycombio/app-observability
+*environment* @honeycombio/app-observability
+*column* @honeycombio/app-observability
+*trigger* @honeycombio/app-observability
+*slo* @honeycombio/app-observability
+*burn_alert* @honeycombio/app-observability
+*webhook* @honeycombio/app-observability
+*notification* @honeycombio/app-observability

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,12 +5,9 @@
 # all board resources are owned by the growth team
 *board* @honeycombio/growth
 
-# all query, dataset, derived column, environment, column, trigger,
-# SLO, burn alert, and webhook resources are owned by app-observability
+# all query, column, trigger, SLO, burn alert, and webhook resources
+# are owned by app-observability
 *query* @honeycombio/app-observability
-*dataset* @honeycombio/app-observability
-*derived_column* @honeycombio/app-observability
-*environment* @honeycombio/app-observability
 *column* @honeycombio/app-observability
 *trigger* @honeycombio/app-observability
 *slo* @honeycombio/app-observability


### PR DESCRIPTION
Break up CODEOWNERS to assign resource ownership to the most appropriate team based on resource.

