### PR TITLE
feat: Add auto_investigate support for burn alerts and triggers

### DIFF
--- a/client/burn_alert.go
+++ b/client/burn_alert.go
@@ -47,6 +47,7 @@ type BurnAlert struct {
 	BudgetRateWindowMinutes               *int                    `json:"budget_rate_window_minutes,omitempty"`
 	BudgetRateDecreaseThresholdPerMillion *int                    `json:"budget_rate_decrease_threshold_per_million,omitempty"`
 	Description                           string                  `json:"description"`
+	AutoInvestigate                       *bool                   `json:"auto_investigate,omitempty"`
 	SLO                                   SLORef                  `json:"slo"`
 	CreatedAt                             time.Time               `json:"created_at,omitempty"`
 	UpdatedAt                             time.Time               `json:"updated_at,omitempty"`

--- a/client/burn_alert_test.go
+++ b/client/burn_alert_test.go
@@ -184,6 +184,7 @@ func TestBurnAlerts(t *testing.T) {
 			data.CreatedAt = burnAlert.CreatedAt
 			data.UpdatedAt = burnAlert.UpdatedAt
 			data.Recipients[0].ID = burnAlert.Recipients[0].ID
+			data.AutoInvestigate = burnAlert.AutoInvestigate
 			assert.Equal(t, data, burnAlert)
 		})
 
@@ -206,6 +207,7 @@ func TestBurnAlerts(t *testing.T) {
 			data.CreatedAt = burnAlert.CreatedAt
 			data.UpdatedAt = burnAlert.UpdatedAt
 			data.Recipients[0].ID = burnAlert.Recipients[0].ID
+			data.AutoInvestigate = burnAlert.AutoInvestigate
 			assert.Equal(t, burnAlert, data)
 		})
 
@@ -232,6 +234,76 @@ func TestBurnAlerts(t *testing.T) {
 			assert.True(t, de.IsNotFound())
 		})
 	}
+}
+
+func TestBurnAlerts_AutoInvestigate(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	c := newTestClient(t)
+	dataset := testDataset(t)
+	testAlertEmail := test.RandomEmail()
+
+	sli, err := c.DerivedColumns.Create(ctx, dataset, &client.DerivedColumn{
+		Alias:      test.RandomStringWithPrefix("test.", 8),
+		Expression: "BOOL(1)",
+	})
+	require.NoError(t, err)
+	slo, err := c.SLOs.Create(ctx, dataset, &client.SLO{
+		Name:             test.RandomStringWithPrefix("test.", 8),
+		TimePeriodDays:   7,
+		TargetPerMillion: 999000,
+		SLI:              client.SLIRef{Alias: sli.Alias},
+	})
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		c.SLOs.Delete(ctx, dataset, slo.ID)
+		c.DerivedColumns.Delete(ctx, dataset, sli.ID)
+	})
+
+	exhaustionMinutes := 60
+
+	t.Run("Create with auto_investigate enabled", func(t *testing.T) {
+		data := &client.BurnAlert{
+			AlertType:         client.BurnAlertAlertTypeExhaustionTime,
+			Description:       "auto investigate burn alert",
+			ExhaustionMinutes: &exhaustionMinutes,
+			AutoInvestigate:   client.ToPtr(true),
+			SLO:               client.SLORef{ID: slo.ID},
+			Recipients: []client.NotificationRecipient{
+				{
+					Type:   "email",
+					Target: testAlertEmail,
+				},
+			},
+		}
+		burnAlert, err := c.BurnAlerts.Create(ctx, dataset, data)
+		require.NoError(t, err)
+		assert.NotEmpty(t, burnAlert.ID)
+
+		t.Cleanup(func() {
+			c.BurnAlerts.Delete(ctx, dataset, burnAlert.ID)
+		})
+
+		t.Run("Get returns auto_investigate", func(t *testing.T) {
+			result, err := c.BurnAlerts.Get(ctx, dataset, burnAlert.ID)
+			require.NoError(t, err)
+			if result.AutoInvestigate != nil {
+				assert.True(t, *result.AutoInvestigate)
+			}
+		})
+
+		t.Run("Update auto_investigate to false", func(t *testing.T) {
+			data.ID = burnAlert.ID
+			data.AutoInvestigate = client.ToPtr(false)
+			updated, err := c.BurnAlerts.Update(ctx, dataset, data)
+			require.NoError(t, err)
+			if updated.AutoInvestigate != nil {
+				assert.False(t, *updated.AutoInvestigate)
+			}
+		})
+	})
 }
 
 func TestBurnAlerts_BurnAlertAlertTypes(t *testing.T) {

--- a/client/trigger.go
+++ b/client/trigger.go
@@ -79,6 +79,9 @@ type Trigger struct {
 	// Recipients are notified when the trigger fires.
 	Recipients      []NotificationRecipient `json:"recipients,omitempty"`
 	BaselineDetails *TriggerBaselineDetails `json:"baseline_details,omitempty"`
+	// AutoInvestigate enables automatic investigation when this trigger fires.
+	// Requires Honeycomb Intelligence to be enabled on the team.
+	AutoInvestigate *bool `json:"auto_investigate,omitempty"`
 	// Tags are used to categorize triggers. They can be used to filtering triggers
 	// and are useful for grouping triggers together.
 	Tags []Tag `json:"tags"`
@@ -162,6 +165,7 @@ func (t *Trigger) MarshalJSON() ([]byte, error) {
 			Recipients:             t.Recipients,
 			EvaluationScheduleType: t.EvaluationScheduleType,
 			EvaluationSchedule:     t.EvaluationSchedule,
+			AutoInvestigate:        t.AutoInvestigate,
 			Tags:                   t.Tags,
 		}
 		return json.Marshal(&struct{ *ATrigger }{ATrigger: a})

--- a/client/trigger_test.go
+++ b/client/trigger_test.go
@@ -151,6 +151,63 @@ func TestTriggers(t *testing.T) {
 	})
 }
 
+func TestTriggers_AutoInvestigate(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	c := newTestClient(t)
+	dataset := testDataset(t)
+
+	t.Run("Create with auto_investigate enabled", func(t *testing.T) {
+		data := &client.Trigger{
+			Name:            test.RandomStringWithPrefix("test.", 8),
+			Description:     "auto investigate trigger",
+			AutoInvestigate: client.ToPtr(true),
+			Query: &client.QuerySpec{
+				Calculations: []client.CalculationSpec{
+					{Op: client.CalculationOpCount},
+				},
+				TimeRange: client.ToPtr(900),
+			},
+			Frequency: 900,
+			Threshold: &client.TriggerThreshold{
+				Op:    client.TriggerThresholdOpGreaterThan,
+				Value: 100,
+			},
+			Recipients: []client.NotificationRecipient{
+				{
+					Type:   client.RecipientTypeMarker,
+					Target: "auto investigate trigger fired",
+				},
+			},
+		}
+		trigger, err := c.Triggers.Create(ctx, dataset, data)
+		require.NoError(t, err)
+		assert.NotEmpty(t, trigger.ID)
+
+		t.Cleanup(func() {
+			c.Triggers.Delete(ctx, dataset, trigger.ID)
+		})
+
+		t.Run("Get returns auto_investigate", func(t *testing.T) {
+			result, err := c.Triggers.Get(ctx, dataset, trigger.ID)
+			require.NoError(t, err)
+			if result.AutoInvestigate != nil {
+				assert.True(t, *result.AutoInvestigate)
+			}
+		})
+
+		t.Run("Update auto_investigate to false", func(t *testing.T) {
+			trigger.AutoInvestigate = client.ToPtr(false)
+			updated, err := c.Triggers.Update(ctx, dataset, trigger)
+			require.NoError(t, err)
+			if updated.AutoInvestigate != nil {
+				assert.False(t, *updated.AutoInvestigate)
+			}
+		})
+	})
+}
+
 func TestMatchesTriggerSubset(t *testing.T) {
 	t.Parallel()
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -131,6 +131,9 @@ provider "honeycombio" {
     dataset {
       import_on_conflict = true
     }
+    intelligence {
+      enabled = true
+    }
   }
 }
 ```
@@ -141,6 +144,7 @@ The `features` block supports the following:
 
 * `column` - (Optional) A `column` block as defined below.
 * `dataset` - (Optional) A `dataset` block as defined below.
+* `intelligence` - (Optional) An `intelligence` block as defined below.
 
 ---
 The `column` block supports the following:
@@ -150,3 +154,9 @@ The `column` block supports the following:
 ---
 The `dataset` block supports the following:
 * `import_on_conflict` - (Optional) This changes the creation behavior of the dataset resource to import and update an existing dataset if it already exists, rather than erroring out. Defaults to `false`.
+
+---
+The `intelligence` block supports the following:
+* `enabled` - (Optional) Set to `true` to enable intelligence features such as `auto_investigate` on triggers and burn alerts. Defaults to `false`.
+
+~> **Note** [Honeycomb Intelligence](https://docs.honeycomb.io/security-compliance/honeycomb-intelligence) must first be enabled for your team in the Honeycomb UI before using this block. The `intelligence` feature block in the provider tells Terraform that your team has Honeycomb Intelligence enabled and unlocks related attributes like `auto_investigate`.

--- a/docs/resources/burn_alert.md
+++ b/docs/resources/burn_alert.md
@@ -155,6 +155,7 @@ resource "honeycombio_burn_alert" "example_alert" {
 ### Optional
 
 - `alert_type` (String) The alert type of this Burn Alert.
+- `auto_investigate` (Boolean) Whether to automatically investigate when this Burn Alert fires. Requires Honeycomb Intelligence to be enabled.
 - `budget_rate_decrease_percent` (Number) The percent the budget has decreased over the budget rate window.
 - `budget_rate_window_minutes` (Number) The time period, in minutes, over which a budget rate will be calculated.
 - `dataset` (String) The dataset this Burn Alert is associated with. Will be deprecated in a future release.

--- a/docs/resources/burn_alert.md
+++ b/docs/resources/burn_alert.md
@@ -155,7 +155,7 @@ resource "honeycombio_burn_alert" "example_alert" {
 ### Optional
 
 - `alert_type` (String) The alert type of this Burn Alert.
-- `auto_investigate` (Boolean) Whether to automatically investigate when this Burn Alert fires. Requires Honeycomb Intelligence to be enabled.
+- `auto_investigate` (Boolean) Whether to automatically investigate when this Burn Alert fires. Requires Honeycomb Intelligence to be enabled for your team in the Honeycomb UI and the intelligence feature block to be set in the provider configuration.
 - `budget_rate_decrease_percent` (Number) The percent the budget has decreased over the budget rate window.
 - `budget_rate_window_minutes` (Number) The time period, in minutes, over which a budget rate will be calculated.
 - `dataset` (String) The dataset this Burn Alert is associated with. Will be deprecated in a future release.

--- a/docs/resources/trigger.md
+++ b/docs/resources/trigger.md
@@ -524,7 +524,7 @@ resource "honeycombio_trigger" "metrics" {
 ### Optional
 
 - `alert_type` (String) Control when the Trigger will send a notification.
-- `auto_investigate` (Boolean) Whether to automatically investigate when this Trigger fires. Requires Honeycomb Intelligence to be enabled.
+- `auto_investigate` (Boolean) Whether to automatically investigate when this Trigger fires. Requires Honeycomb Intelligence to be enabled for your team in the Honeycomb UI and the intelligence feature block to be set in the provider configuration.
 - `baseline_details` (Block List) A configuration block that allows you to receive notifications when the delta between values in your data, compared to a previous time period, cross thresholds you configure. (see [below for nested schema](#nestedblock--baseline_details))
 - `dataset` (String) The dataset this Trigger is associated with.
 - `description` (String) A description of the Trigger.

--- a/docs/resources/trigger.md
+++ b/docs/resources/trigger.md
@@ -524,6 +524,7 @@ resource "honeycombio_trigger" "metrics" {
 ### Optional
 
 - `alert_type` (String) Control when the Trigger will send a notification.
+- `auto_investigate` (Boolean) Whether to automatically investigate when this Trigger fires. Requires Honeycomb Intelligence to be enabled.
 - `baseline_details` (Block List) A configuration block that allows you to receive notifications when the delta between values in your data, compared to a previous time period, cross thresholds you configure. (see [below for nested schema](#nestedblock--baseline_details))
 - `dataset` (String) The dataset this Trigger is associated with.
 - `description` (String) A description of the Trigger.

--- a/internal/features/defaults.go
+++ b/internal/features/defaults.go
@@ -3,8 +3,9 @@ package features
 // DefaultFeatures returns the default features for the provider.
 func DefaultFeatures() *Features {
 	return &Features{
-		Column:  defaultColumnFeatures(),
-		Dataset: defaultDatasetFeatures(),
+		Column:       defaultColumnFeatures(),
+		Dataset:      defaultDatasetFeatures(),
+		Intelligence: defaultIntelligenceFeatures(),
 	}
 }
 
@@ -17,5 +18,11 @@ func defaultColumnFeatures() FeaturesColumn {
 func defaultDatasetFeatures() FeaturesDataset {
 	return FeaturesDataset{
 		ImportOnConflict: false,
+	}
+}
+
+func defaultIntelligenceFeatures() FeaturesIntelligence {
+	return FeaturesIntelligence{
+		Enabled: false,
 	}
 }

--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -4,8 +4,9 @@ import "github.com/hashicorp/terraform-plugin-framework/types"
 
 // Features represents provider-level features.
 type Features struct {
-	Column  FeaturesColumn
-	Dataset FeaturesDataset
+	Column       FeaturesColumn
+	Dataset      FeaturesDataset
+	Intelligence FeaturesIntelligence
 }
 
 // FeaturesColumn represents column-specific features.
@@ -31,9 +32,22 @@ type FeaturesDatasetModel struct {
 	ImportOnConflict types.Bool `tfsdk:"import_on_conflict"`
 }
 
+// FeaturesIntelligence represents Honeycomb Intelligence-specific features.
+type FeaturesIntelligence struct {
+	// Enabled indicates the team has Honeycomb Intelligence enabled,
+	// unlocking features such as auto-investigation on burn alerts and triggers.
+	Enabled bool
+}
+
+// FeaturesIntelligenceModel represents Intelligence features for Terraform schema.
+type FeaturesIntelligenceModel struct {
+	Enabled types.Bool `tfsdk:"enabled"`
+}
+
 type Model struct {
-	Column  []FeaturesColumnModel  `tfsdk:"column"`
-	Dataset []FeaturesDatasetModel `tfsdk:"dataset"`
+	Column       []FeaturesColumnModel       `tfsdk:"column"`
+	Dataset      []FeaturesDatasetModel      `tfsdk:"dataset"`
+	Intelligence []FeaturesIntelligenceModel `tfsdk:"intelligence"`
 }
 
 // Parse converts a Terraform model to internal Features representation for
@@ -58,6 +72,14 @@ func Parse(m []Model) *Features {
 		datasetFeatures := features.Dataset[0]
 		if !datasetFeatures.ImportOnConflict.IsNull() && !datasetFeatures.ImportOnConflict.IsUnknown() {
 			result.Dataset.ImportOnConflict = datasetFeatures.ImportOnConflict.ValueBool()
+		}
+	}
+
+	// parse intelligence features
+	if len(features.Intelligence) > 0 {
+		intelligenceFeatures := features.Intelligence[0]
+		if !intelligenceFeatures.Enabled.IsNull() && !intelligenceFeatures.Enabled.IsUnknown() {
+			result.Intelligence.Enabled = intelligenceFeatures.Enabled.ValueBool()
 		}
 	}
 

--- a/internal/features/features_test.go
+++ b/internal/features/features_test.go
@@ -16,6 +16,7 @@ func TestModelParse(t *testing.T) {
 
 		assert.False(t, features.Column.ImportOnConflict)
 		assert.False(t, features.Dataset.ImportOnConflict)
+		assert.False(t, features.Intelligence.Enabled)
 	})
 
 	t.Run("parses column features", func(t *testing.T) {
@@ -140,6 +141,69 @@ func TestModelParse(t *testing.T) {
 			t.Run(name, func(t *testing.T) {
 				features := Parse(tc.model)
 				assert.Equal(t, tc.expect, features.Dataset.ImportOnConflict)
+			})
+		}
+	})
+
+	t.Run("parses intelligence features", func(t *testing.T) {
+		testCases := map[string]struct {
+			model  []Model
+			expect bool
+		}{
+			"parses Enabled as false": {
+				model: []Model{
+					{
+						Intelligence: []FeaturesIntelligenceModel{
+							{
+								Enabled: types.BoolValue(false),
+							},
+						},
+					},
+				},
+				expect: false,
+			},
+			"parses Enabled as true": {
+				model: []Model{
+					{
+						Intelligence: []FeaturesIntelligenceModel{
+							{
+								Enabled: types.BoolValue(true),
+							},
+						},
+					},
+				},
+				expect: true,
+			},
+			"handles Null": {
+				model: []Model{
+					{
+						Intelligence: []FeaturesIntelligenceModel{
+							{
+								Enabled: types.BoolNull(),
+							},
+						},
+					},
+				},
+				expect: false,
+			},
+			"handles Unknown": {
+				model: []Model{
+					{
+						Intelligence: []FeaturesIntelligenceModel{
+							{
+								Enabled: types.BoolUnknown(),
+							},
+						},
+					},
+				},
+				expect: false,
+			},
+		}
+
+		for name, tc := range testCases {
+			t.Run(name, func(t *testing.T) {
+				features := Parse(tc.model)
+				assert.Equal(t, tc.expect, features.Intelligence.Enabled)
 			})
 		}
 	})

--- a/internal/features/schema.go
+++ b/internal/features/schema.go
@@ -39,11 +39,11 @@ func GetFeaturesBlock() schema.Block {
 					},
 				},
 				"intelligence": schema.ListNestedBlock{
-					MarkdownDescription: "Intelligence features. Enable this block when the team has Honeycomb Intelligence enabled.",
+					MarkdownDescription: "Configuration for teams with Honeycomb Intelligence. Honeycomb Intelligence must first be enabled for your team in the Honeycomb UI before using this block.",
 					NestedObject: schema.NestedBlockObject{
 						Attributes: map[string]schema.Attribute{
 							"enabled": schema.BoolAttribute{
-								MarkdownDescription: "Set to true when the team has Honeycomb Intelligence enabled.",
+								MarkdownDescription: "Set to true to enable intelligence features such as auto_investigate on triggers and burn alerts. Requires Honeycomb Intelligence to be enabled for your team in the Honeycomb UI.",
 								Optional:            true,
 							},
 						},
@@ -97,13 +97,13 @@ func GetPluginSDKFeaturesSchema() *pluginsdk.Schema {
 					Type:        pluginsdk.TypeList,
 					Optional:    true,
 					MaxItems:    1,
-					Description: "Intelligence features. Enable this block when the team has Honeycomb Intelligence enabled.",
+					Description: "Configuration for teams with Honeycomb Intelligence. Honeycomb Intelligence must first be enabled for your team in the Honeycomb UI before using this block.",
 					Elem: &pluginsdk.Resource{
 						Schema: map[string]*pluginsdk.Schema{
 							"enabled": {
 								Type:        pluginsdk.TypeBool,
 								Optional:    true,
-								Description: "Set to true when the team has Honeycomb Intelligence enabled.",
+								Description: "Set to true to enable intelligence features such as auto_investigate on triggers and burn alerts. Requires Honeycomb Intelligence to be enabled for your team in the Honeycomb UI.",
 							},
 						},
 					},

--- a/internal/features/schema.go
+++ b/internal/features/schema.go
@@ -38,6 +38,17 @@ func GetFeaturesBlock() schema.Block {
 						},
 					},
 				},
+				"intelligence": schema.ListNestedBlock{
+					MarkdownDescription: "Intelligence features. Enable this block when the team has Honeycomb Intelligence enabled.",
+					NestedObject: schema.NestedBlockObject{
+						Attributes: map[string]schema.Attribute{
+							"enabled": schema.BoolAttribute{
+								MarkdownDescription: "Set to true when the team has Honeycomb Intelligence enabled.",
+								Optional:            true,
+							},
+						},
+					},
+				},
 			},
 		},
 	}
@@ -78,6 +89,21 @@ func GetPluginSDKFeaturesSchema() *pluginsdk.Schema {
 								Type:        pluginsdk.TypeBool,
 								Optional:    true,
 								Description: "This changes the creation behavior of the dataset resource to import an existing dataset if it already exists, rather than erroring out.",
+							},
+						},
+					},
+				},
+				"intelligence": {
+					Type:        pluginsdk.TypeList,
+					Optional:    true,
+					MaxItems:    1,
+					Description: "Intelligence features. Enable this block when the team has Honeycomb Intelligence enabled.",
+					Elem: &pluginsdk.Resource{
+						Schema: map[string]*pluginsdk.Schema{
+							"enabled": {
+								Type:        pluginsdk.TypeBool,
+								Optional:    true,
+								Description: "Set to true when the team has Honeycomb Intelligence enabled.",
 							},
 						},
 					},

--- a/internal/models/burn_alerts.go
+++ b/internal/models/burn_alerts.go
@@ -8,6 +8,7 @@ type BurnAlertResourceModel struct {
 	BudgetRateWindowMinutes   types.Int64   `tfsdk:"budget_rate_window_minutes"`
 	BudgetRateDecreasePercent types.Float64 `tfsdk:"budget_rate_decrease_percent"`
 	Description               types.String  `tfsdk:"description"`
+	AutoInvestigate           types.Bool    `tfsdk:"auto_investigate"`
 	Dataset                   types.String  `tfsdk:"dataset"`
 	SLOID                     types.String  `tfsdk:"slo_id"`
 	ExhaustionMinutes         types.Int64   `tfsdk:"exhaustion_minutes"`

--- a/internal/models/triggers.go
+++ b/internal/models/triggers.go
@@ -11,6 +11,7 @@ type TriggerResourceModel struct {
 	Dataset            types.String `tfsdk:"dataset"`
 	Description        types.String `tfsdk:"description"`
 	Disabled           types.Bool   `tfsdk:"disabled"`
+	AutoInvestigate    types.Bool   `tfsdk:"auto_investigate"`
 	QueryID            types.String `tfsdk:"query_id"`
 	QueryJson          types.String `tfsdk:"query_json"`
 	AlertType          types.String `tfsdk:"alert_type"`

--- a/internal/provider/burn_alert_resource.go
+++ b/internal/provider/burn_alert_resource.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -21,6 +22,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/honeycombio/terraform-provider-honeycombio/client"
+	"github.com/honeycombio/terraform-provider-honeycombio/internal/features"
 	"github.com/honeycombio/terraform-provider-honeycombio/internal/helper"
 	"github.com/honeycombio/terraform-provider-honeycombio/internal/models"
 )
@@ -34,7 +36,8 @@ var (
 )
 
 type burnAlertResource struct {
-	client *client.Client
+	client  *client.Client
+	feature features.FeaturesIntelligence
 }
 
 func NewBurnAlertResource() resource.Resource {
@@ -57,6 +60,13 @@ func (r *burnAlertResource) Configure(_ context.Context, req resource.ConfigureR
 		return
 	}
 	r.client = c
+
+	f, err := w.Features()
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to get features", err.Error())
+		return
+	}
+	r.feature = f.Intelligence
 }
 
 func (*burnAlertResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
@@ -113,6 +123,12 @@ func (*burnAlertResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				Validators: []validator.String{
 					stringvalidator.LengthAtMost(1023),
 				},
+			},
+			"auto_investigate": schema.BoolAttribute{
+				Optional:    true,
+				Computed:    true,
+				Description: "Whether to automatically investigate when this Burn Alert fires. Requires Honeycomb Intelligence to be enabled.",
+				Default:     booldefault.StaticBool(false),
 			},
 			"exhaustion_minutes": schema.Int64Attribute{
 				Optional:    true,
@@ -244,12 +260,25 @@ func (r *burnAlertResource) Create(ctx context.Context, req resource.CreateReque
 		return
 	}
 
+	if plan.AutoInvestigate.ValueBool() && !r.feature.Enabled {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("auto_investigate"),
+			"Intelligence feature not enabled",
+			"Setting \"auto_investigate\" to true requires the intelligence feature to be enabled in the provider configuration. "+
+				"Add a features block with intelligence { enabled = true } to your provider configuration.",
+		)
+		return
+	}
+
 	// Get attributes from config and construct the create request
 	createRequest := &client.BurnAlert{
 		AlertType:   client.BurnAlertAlertType(plan.AlertType.ValueString()),
 		Recipients:  expandNotificationRecipients(ctx, plan.Recipients, &resp.Diagnostics),
 		SLO:         client.SLORef{ID: plan.SLOID.ValueString()},
 		Description: plan.Description.ValueString(),
+	}
+	if r.feature.Enabled {
+		createRequest.AutoInvestigate = helper.ToPtr(plan.AutoInvestigate.ValueBool())
 	}
 
 	// Process any attributes that could be nil and add them to the create request
@@ -282,6 +311,12 @@ func (r *burnAlertResource) Create(ctx context.Context, req resource.CreateReque
 	// we created them as authored so to avoid matching type-target or ID we can just use the same value
 	state.Recipients = config.Recipients
 	state.SLOID = types.StringValue(burnAlert.SLO.ID)
+
+	if burnAlert.AutoInvestigate != nil {
+		state.AutoInvestigate = types.BoolValue(*burnAlert.AutoInvestigate)
+	} else {
+		state.AutoInvestigate = plan.AutoInvestigate
+	}
 
 	// Process any attributes that could be nil and add them to the state values
 	if burnAlert.ExhaustionMinutes != nil {
@@ -341,6 +376,12 @@ func (r *burnAlertResource) Read(ctx context.Context, req resource.ReadRequest, 
 	state.Recipients = reconcileReadNotificationRecipientState(ctx, burnAlert.Recipients, state.Recipients, &resp.Diagnostics)
 	state.Description = types.StringValue(burnAlert.Description)
 
+	if burnAlert.AutoInvestigate != nil {
+		state.AutoInvestigate = types.BoolValue(*burnAlert.AutoInvestigate)
+	} else if state.AutoInvestigate.IsNull() || state.AutoInvestigate.IsUnknown() {
+		state.AutoInvestigate = types.BoolValue(false)
+	}
+
 	// Process any attributes that could be nil and add them to the state values
 	if burnAlert.ExhaustionMinutes != nil {
 		state.ExhaustionMinutes = types.Int64Value(int64(*burnAlert.ExhaustionMinutes))
@@ -367,6 +408,16 @@ func (r *burnAlertResource) Update(ctx context.Context, req resource.UpdateReque
 		return
 	}
 
+	if plan.AutoInvestigate.ValueBool() && !r.feature.Enabled {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("auto_investigate"),
+			"Intelligence feature not enabled",
+			"Setting \"auto_investigate\" to true requires the intelligence feature to be enabled in the provider configuration. "+
+				"Add a features block with intelligence { enabled = true } to your provider configuration.",
+		)
+		return
+	}
+
 	// Get attributes from config and construct the update request
 	updateRequest := &client.BurnAlert{
 		ID:          plan.ID.ValueString(),
@@ -374,6 +425,9 @@ func (r *burnAlertResource) Update(ctx context.Context, req resource.UpdateReque
 		Recipients:  expandNotificationRecipients(ctx, plan.Recipients, &resp.Diagnostics),
 		SLO:         client.SLORef{ID: plan.SLOID.ValueString()},
 		Description: plan.Description.ValueString(),
+	}
+	if r.feature.Enabled {
+		updateRequest.AutoInvestigate = helper.ToPtr(plan.AutoInvestigate.ValueBool())
 	}
 
 	// Process any attributes that could be nil and add them to the update request
@@ -412,6 +466,12 @@ func (r *burnAlertResource) Update(ctx context.Context, req resource.UpdateReque
 	state.Recipients = config.Recipients
 	state.SLOID = types.StringValue(burnAlert.SLO.ID)
 	state.Description = types.StringValue(burnAlert.Description)
+
+	if burnAlert.AutoInvestigate != nil {
+		state.AutoInvestigate = types.BoolValue(*burnAlert.AutoInvestigate)
+	} else {
+		state.AutoInvestigate = plan.AutoInvestigate
+	}
 
 	// Process any attributes that could be nil and add them to the state values
 	if burnAlert.ExhaustionMinutes != nil {

--- a/internal/provider/burn_alert_resource.go
+++ b/internal/provider/burn_alert_resource.go
@@ -127,7 +127,7 @@ func (*burnAlertResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 			"auto_investigate": schema.BoolAttribute{
 				Optional:    true,
 				Computed:    true,
-				Description: "Whether to automatically investigate when this Burn Alert fires. Requires Honeycomb Intelligence to be enabled.",
+				Description: "Whether to automatically investigate when this Burn Alert fires. Requires Honeycomb Intelligence to be enabled for your team in the Honeycomb UI and the intelligence feature block to be set in the provider configuration.",
 				Default:     booldefault.StaticBool(false),
 			},
 			"exhaustion_minutes": schema.Int64Attribute{
@@ -263,9 +263,9 @@ func (r *burnAlertResource) Create(ctx context.Context, req resource.CreateReque
 	if plan.AutoInvestigate.ValueBool() && !r.feature.Enabled {
 		resp.Diagnostics.AddAttributeError(
 			path.Root("auto_investigate"),
-			"Intelligence feature not enabled",
-			"Setting \"auto_investigate\" to true requires the intelligence feature to be enabled in the provider configuration. "+
-				"Add a features block with intelligence { enabled = true } to your provider configuration.",
+			"Honeycomb Intelligence not configured",
+			"Setting \"auto_investigate\" to true requires Honeycomb Intelligence to be enabled for your team and the intelligence feature block to be configured in the provider. "+
+				"Ensure Honeycomb Intelligence is enabled in the Honeycomb UI, then add a features block with intelligence { enabled = true } to your provider configuration.",
 		)
 		return
 	}
@@ -312,13 +312,12 @@ func (r *burnAlertResource) Create(ctx context.Context, req resource.CreateReque
 	state.Recipients = config.Recipients
 	state.SLOID = types.StringValue(burnAlert.SLO.ID)
 
+	// Process any attributes that could be nil and add them to the state values
 	if burnAlert.AutoInvestigate != nil {
 		state.AutoInvestigate = types.BoolValue(*burnAlert.AutoInvestigate)
 	} else {
 		state.AutoInvestigate = plan.AutoInvestigate
 	}
-
-	// Process any attributes that could be nil and add them to the state values
 	if burnAlert.ExhaustionMinutes != nil {
 		state.ExhaustionMinutes = types.Int64Value(int64(*burnAlert.ExhaustionMinutes))
 	}
@@ -376,13 +375,12 @@ func (r *burnAlertResource) Read(ctx context.Context, req resource.ReadRequest, 
 	state.Recipients = reconcileReadNotificationRecipientState(ctx, burnAlert.Recipients, state.Recipients, &resp.Diagnostics)
 	state.Description = types.StringValue(burnAlert.Description)
 
+	// Process any attributes that could be nil and add them to the state values
 	if burnAlert.AutoInvestigate != nil {
 		state.AutoInvestigate = types.BoolValue(*burnAlert.AutoInvestigate)
 	} else if state.AutoInvestigate.IsNull() || state.AutoInvestigate.IsUnknown() {
 		state.AutoInvestigate = types.BoolValue(false)
 	}
-
-	// Process any attributes that could be nil and add them to the state values
 	if burnAlert.ExhaustionMinutes != nil {
 		state.ExhaustionMinutes = types.Int64Value(int64(*burnAlert.ExhaustionMinutes))
 	}
@@ -411,9 +409,9 @@ func (r *burnAlertResource) Update(ctx context.Context, req resource.UpdateReque
 	if plan.AutoInvestigate.ValueBool() && !r.feature.Enabled {
 		resp.Diagnostics.AddAttributeError(
 			path.Root("auto_investigate"),
-			"Intelligence feature not enabled",
-			"Setting \"auto_investigate\" to true requires the intelligence feature to be enabled in the provider configuration. "+
-				"Add a features block with intelligence { enabled = true } to your provider configuration.",
+			"Honeycomb Intelligence not configured",
+			"Setting \"auto_investigate\" to true requires Honeycomb Intelligence to be enabled for your team and the intelligence feature block to be configured in the provider. "+
+				"Ensure Honeycomb Intelligence is enabled in the Honeycomb UI, then add a features block with intelligence { enabled = true } to your provider configuration.",
 		)
 		return
 	}
@@ -467,13 +465,12 @@ func (r *burnAlertResource) Update(ctx context.Context, req resource.UpdateReque
 	state.SLOID = types.StringValue(burnAlert.SLO.ID)
 	state.Description = types.StringValue(burnAlert.Description)
 
+	// Process any attributes that could be nil and add them to the state values
 	if burnAlert.AutoInvestigate != nil {
 		state.AutoInvestigate = types.BoolValue(*burnAlert.AutoInvestigate)
 	} else {
 		state.AutoInvestigate = plan.AutoInvestigate
 	}
-
-	// Process any attributes that could be nil and add them to the state values
 	if burnAlert.ExhaustionMinutes != nil {
 		state.ExhaustionMinutes = types.Int64Value(int64(*burnAlert.ExhaustionMinutes))
 	}

--- a/internal/provider/burn_alert_resource_test.go
+++ b/internal/provider/burn_alert_resource_test.go
@@ -967,6 +967,100 @@ func getNewDatasetAndSLO(t *testing.T) (string, string) {
 	return dataset.Slug, slo.ID
 }
 
+func TestAcc_BurnAlertResource_autoInvestigate(t *testing.T) {
+	dataset, sloID := burnAlertAccTestSetup(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 testAccPreCheck(t),
+		ProtoV5ProviderFactories: testAccProtoV5MuxServerFactory,
+		CheckDestroy:             testAccEnsureBurnAlertDestroyed(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfigBurnAlertAutoInvestigate(dataset, sloID, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("honeycombio_burn_alert.test", "id"),
+					resource.TestCheckResourceAttr("honeycombio_burn_alert.test", "auto_investigate", "true"),
+				),
+			},
+			{
+				Config: testAccConfigBurnAlertAutoInvestigate(dataset, sloID, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("honeycombio_burn_alert.test", "id"),
+					resource.TestCheckResourceAttr("honeycombio_burn_alert.test", "auto_investigate", "false"),
+				),
+			},
+			{
+				ResourceName:            "honeycombio_burn_alert.test",
+				ImportStateIdPrefix:     fmt.Sprintf("%v/", dataset),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"recipient"},
+			},
+		},
+	})
+}
+
+func testAccConfigBurnAlertAutoInvestigate(dataset, sloID string, autoInvestigate bool) string {
+	return fmt.Sprintf(`
+provider "honeycombio" {
+  features {
+    intelligence {
+      enabled = true
+    }
+  }
+}
+
+resource "honeycombio_burn_alert" "test" {
+  exhaustion_minutes = 60
+  auto_investigate   = %[3]t
+
+  dataset = "%[1]s"
+  slo_id  = "%[2]s"
+
+  recipient {
+    type   = "email"
+    target = "%[4]s"
+  }
+}`, dataset, sloID, autoInvestigate, test.RandomEmail())
+}
+
+func TestAcc_BurnAlertResource_autoInvestigateNoDiffOnUpgrade(t *testing.T) {
+	dataset, sloID := burnAlertAccTestSetup(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 testAccPreCheck(t),
+		ProtoV5ProviderFactories: testAccProtoV5MuxServerFactory,
+		CheckDestroy:             testAccEnsureBurnAlertDestroyed(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfigBurnAlertWithoutAutoInvestigate(dataset, sloID),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("honeycombio_burn_alert.test", "id"),
+					resource.TestCheckResourceAttr("honeycombio_burn_alert.test", "auto_investigate", "false"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
+			},
+		},
+	})
+}
+
+func testAccConfigBurnAlertWithoutAutoInvestigate(dataset, sloID string) string {
+	return fmt.Sprintf(`
+resource "honeycombio_burn_alert" "test" {
+  exhaustion_minutes = 60
+
+  dataset = "%[1]s"
+  slo_id  = "%[2]s"
+
+  recipient {
+    type   = "email"
+    target = "%[3]s"
+  }
+}`, dataset, sloID, test.RandomEmail())
+}
+
 func testAccConfigBurnAlert_withoutDescription(exhaustionMinutes int, dataset, sloID, pdseverity string) string {
 	return fmt.Sprintf(`
 resource "honeycombio_pagerduty_recipient" "test" {

--- a/internal/provider/trigger_resource.go
+++ b/internal/provider/trigger_resource.go
@@ -26,6 +26,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
 	"github.com/honeycombio/terraform-provider-honeycombio/client"
+	"github.com/honeycombio/terraform-provider-honeycombio/internal/features"
 	"github.com/honeycombio/terraform-provider-honeycombio/internal/helper"
 	"github.com/honeycombio/terraform-provider-honeycombio/internal/helper/modifiers"
 	"github.com/honeycombio/terraform-provider-honeycombio/internal/helper/validation"
@@ -45,7 +46,8 @@ func NewTriggerResource() resource.Resource {
 }
 
 type triggerResource struct {
-	client *client.Client
+	client  *client.Client
+	feature features.FeaturesIntelligence
 }
 
 // matches HH:mm timestamps with optional leading 0
@@ -99,6 +101,12 @@ func (r *triggerResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				Optional:    true,
 				Computed:    true,
 				Description: "The state of the Trigger. If true, the Trigger will not be run.",
+				Default:     booldefault.StaticBool(false),
+			},
+			"auto_investigate": schema.BoolAttribute{
+				Optional:    true,
+				Computed:    true,
+				Description: "Whether to automatically investigate when this Trigger fires. Requires Honeycomb Intelligence to be enabled.",
 				Default:     booldefault.StaticBool(false),
 			},
 			"query_id": schema.StringAttribute{
@@ -257,6 +265,13 @@ func (r *triggerResource) Configure(_ context.Context, req resource.ConfigureReq
 		return
 	}
 	r.client = c
+
+	f, err := w.Features()
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to get features", err.Error())
+		return
+	}
+	r.feature = f.Intelligence
 }
 
 func (r *triggerResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
@@ -264,6 +279,16 @@ func (r *triggerResource) Create(ctx context.Context, req resource.CreateRequest
 	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if plan.AutoInvestigate.ValueBool() && !r.feature.Enabled {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("auto_investigate"),
+			"Intelligence feature not enabled",
+			"Setting \"auto_investigate\" to true requires the intelligence feature to be enabled in the provider configuration. "+
+				"Add a features block with intelligence { enabled = true } to your provider configuration.",
+		)
 		return
 	}
 
@@ -283,6 +308,9 @@ func (r *triggerResource) Create(ctx context.Context, req resource.CreateRequest
 		EvaluationSchedule: expandTriggerEvaluationSchedule(ctx, plan.EvaluationSchedule, &resp.Diagnostics),
 		BaselineDetails:    expandBaselineDetails(ctx, plan.BaselineDetails, &resp.Diagnostics),
 		Tags:               planTags,
+	}
+	if r.feature.Enabled {
+		newTrigger.AutoInvestigate = helper.ToPtr(plan.AutoInvestigate.ValueBool())
 	}
 	if resp.Diagnostics.HasError() {
 		return
@@ -323,6 +351,11 @@ func (r *triggerResource) Create(ctx context.Context, req resource.CreateRequest
 	state.Name = types.StringValue(trigger.Name)
 	state.Description = types.StringValue(trigger.Description)
 	state.Disabled = types.BoolValue(trigger.Disabled)
+	if trigger.AutoInvestigate != nil {
+		state.AutoInvestigate = types.BoolValue(*trigger.AutoInvestigate)
+	} else {
+		state.AutoInvestigate = plan.AutoInvestigate
+	}
 	state.AlertType = types.StringValue(string(trigger.AlertType))
 	state.Threshold = flattenTriggerThreshold(ctx, trigger.Threshold, &resp.Diagnostics)
 	state.Frequency = types.Int64Value(int64(trigger.Frequency))
@@ -387,6 +420,11 @@ func (r *triggerResource) Read(ctx context.Context, req resource.ReadRequest, re
 	state.Name = types.StringValue(trigger.Name)
 	state.Description = types.StringValue(trigger.Description)
 	state.Disabled = types.BoolValue(trigger.Disabled)
+	if trigger.AutoInvestigate != nil {
+		state.AutoInvestigate = types.BoolValue(*trigger.AutoInvestigate)
+	} else if state.AutoInvestigate.IsNull() || state.AutoInvestigate.IsUnknown() {
+		state.AutoInvestigate = types.BoolValue(false)
+	}
 	state.AlertType = types.StringValue(string(trigger.AlertType))
 	state.Threshold = flattenTriggerThreshold(ctx, trigger.Threshold, &resp.Diagnostics)
 	state.Frequency = types.Int64Value(int64(trigger.Frequency))
@@ -431,6 +469,16 @@ func (r *triggerResource) Update(ctx context.Context, req resource.UpdateRequest
 		return
 	}
 
+	if plan.AutoInvestigate.ValueBool() && !r.feature.Enabled {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("auto_investigate"),
+			"Intelligence feature not enabled",
+			"Setting \"auto_investigate\" to true requires the intelligence feature to be enabled in the provider configuration. "+
+				"Add a features block with intelligence { enabled = true } to your provider configuration.",
+		)
+		return
+	}
+
 	planTags, diags := helper.MapToTags(ctx, plan.Tags)
 	if diags.HasError() {
 		return
@@ -448,6 +496,9 @@ func (r *triggerResource) Update(ctx context.Context, req resource.UpdateRequest
 		EvaluationSchedule: expandTriggerEvaluationSchedule(ctx, plan.EvaluationSchedule, &resp.Diagnostics),
 		BaselineDetails:    expandBaselineDetails(ctx, plan.BaselineDetails, &resp.Diagnostics),
 		Tags:               planTags,
+	}
+	if r.feature.Enabled {
+		updatedTrigger.AutoInvestigate = helper.ToPtr(plan.AutoInvestigate.ValueBool())
 	}
 	if resp.Diagnostics.HasError() {
 		return
@@ -495,6 +546,11 @@ func (r *triggerResource) Update(ctx context.Context, req resource.UpdateRequest
 	state.Name = types.StringValue(trigger.Name)
 	state.Description = types.StringValue(trigger.Description)
 	state.Disabled = types.BoolValue(trigger.Disabled)
+	if trigger.AutoInvestigate != nil {
+		state.AutoInvestigate = types.BoolValue(*trigger.AutoInvestigate)
+	} else {
+		state.AutoInvestigate = plan.AutoInvestigate
+	}
 	state.AlertType = types.StringValue(string(trigger.AlertType))
 	state.Frequency = types.Int64Value(int64(trigger.Frequency))
 	state.Threshold = flattenTriggerThreshold(ctx, trigger.Threshold, &resp.Diagnostics)

--- a/internal/provider/trigger_resource.go
+++ b/internal/provider/trigger_resource.go
@@ -106,7 +106,7 @@ func (r *triggerResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 			"auto_investigate": schema.BoolAttribute{
 				Optional:    true,
 				Computed:    true,
-				Description: "Whether to automatically investigate when this Trigger fires. Requires Honeycomb Intelligence to be enabled.",
+				Description: "Whether to automatically investigate when this Trigger fires. Requires Honeycomb Intelligence to be enabled for your team in the Honeycomb UI and the intelligence feature block to be set in the provider configuration.",
 				Default:     booldefault.StaticBool(false),
 			},
 			"query_id": schema.StringAttribute{
@@ -285,9 +285,9 @@ func (r *triggerResource) Create(ctx context.Context, req resource.CreateRequest
 	if plan.AutoInvestigate.ValueBool() && !r.feature.Enabled {
 		resp.Diagnostics.AddAttributeError(
 			path.Root("auto_investigate"),
-			"Intelligence feature not enabled",
-			"Setting \"auto_investigate\" to true requires the intelligence feature to be enabled in the provider configuration. "+
-				"Add a features block with intelligence { enabled = true } to your provider configuration.",
+			"Honeycomb Intelligence not configured",
+			"Setting \"auto_investigate\" to true requires Honeycomb Intelligence to be enabled for your team and the intelligence feature block to be configured in the provider. "+
+				"Ensure Honeycomb Intelligence is enabled in the Honeycomb UI, then add a features block with intelligence { enabled = true } to your provider configuration.",
 		)
 		return
 	}
@@ -472,9 +472,9 @@ func (r *triggerResource) Update(ctx context.Context, req resource.UpdateRequest
 	if plan.AutoInvestigate.ValueBool() && !r.feature.Enabled {
 		resp.Diagnostics.AddAttributeError(
 			path.Root("auto_investigate"),
-			"Intelligence feature not enabled",
-			"Setting \"auto_investigate\" to true requires the intelligence feature to be enabled in the provider configuration. "+
-				"Add a features block with intelligence { enabled = true } to your provider configuration.",
+			"Honeycomb Intelligence not configured",
+			"Setting \"auto_investigate\" to true requires Honeycomb Intelligence to be enabled for your team and the intelligence feature block to be configured in the provider. "+
+				"Ensure Honeycomb Intelligence is enabled in the Honeycomb UI, then add a features block with intelligence { enabled = true } to your provider configuration.",
 		)
 		return
 	}

--- a/internal/provider/trigger_resource_test.go
+++ b/internal/provider/trigger_resource_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/honeycombio/terraform-provider-honeycombio/client"
@@ -1301,6 +1302,141 @@ resource honeycombio_trigger "test" {
 			},
 		},
 	})
+}
+
+func TestAcc_TriggerResource_autoInvestigate(t *testing.T) {
+	dataset := testAccDataset()
+	name := test.RandomStringWithPrefix("test.", 20)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 testAccPreCheck(t),
+		ProtoV5ProviderFactories: testAccProtoV5MuxServerFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfigTriggerAutoInvestigate(dataset, name, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccEnsureTriggerExists(t, "honeycombio_trigger.test"),
+					resource.TestCheckResourceAttr("honeycombio_trigger.test", "name", name),
+					resource.TestCheckResourceAttr("honeycombio_trigger.test", "auto_investigate", "true"),
+				),
+			},
+			{
+				Config: testAccConfigTriggerAutoInvestigate(dataset, name, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccEnsureTriggerExists(t, "honeycombio_trigger.test"),
+					resource.TestCheckResourceAttr("honeycombio_trigger.test", "auto_investigate", "false"),
+				),
+			},
+			{
+				ResourceName:            "honeycombio_trigger.test",
+				ImportStateIdPrefix:     fmt.Sprintf("%v/", dataset),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"recipient", "query_id", "query_json"},
+			},
+		},
+	})
+}
+
+func testAccConfigTriggerAutoInvestigate(dataset, name string, autoInvestigate bool) string {
+	return fmt.Sprintf(`
+provider "honeycombio" {
+  features {
+    intelligence {
+      enabled = true
+    }
+  }
+}
+
+data "honeycombio_query_specification" "test" {
+  calculation {
+    op = "COUNT"
+  }
+
+  time_range = 1800
+}
+
+resource "honeycombio_query" "test" {
+  dataset    = "%[1]s"
+  query_json = data.honeycombio_query_specification.test.json
+}
+
+resource "honeycombio_trigger" "test" {
+  name             = "%[2]s"
+  dataset          = "%[1]s"
+  auto_investigate = %[3]t
+
+  query_id = honeycombio_query.test.id
+
+  threshold {
+    op    = ">"
+    value = 100
+  }
+
+  frequency = 1800
+
+  recipient {
+    type   = "email"
+    target = "%[4]s"
+  }
+}`, dataset, name, autoInvestigate, test.RandomEmail())
+}
+
+func TestAcc_TriggerResource_autoInvestigateNoDiffOnUpgrade(t *testing.T) {
+	dataset := testAccDataset()
+	name := test.RandomStringWithPrefix("test.", 20)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 testAccPreCheck(t),
+		ProtoV5ProviderFactories: testAccProtoV5MuxServerFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfigTriggerWithoutAutoInvestigate(dataset, name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccEnsureTriggerExists(t, "honeycombio_trigger.test"),
+					resource.TestCheckResourceAttr("honeycombio_trigger.test", "auto_investigate", "false"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
+			},
+		},
+	})
+}
+
+func testAccConfigTriggerWithoutAutoInvestigate(dataset, name string) string {
+	return fmt.Sprintf(`
+data "honeycombio_query_specification" "test" {
+  calculation {
+    op = "COUNT"
+  }
+
+  time_range = 1800
+}
+
+resource "honeycombio_query" "test" {
+  dataset    = "%[1]s"
+  query_json = data.honeycombio_query_specification.test.json
+}
+
+resource "honeycombio_trigger" "test" {
+  name    = "%[2]s"
+  dataset = "%[1]s"
+
+  query_id = honeycombio_query.test.id
+
+  threshold {
+    op    = ">"
+    value = 100
+  }
+
+  frequency = 1800
+
+  recipient {
+    type   = "email"
+    target = "%[3]s"
+  }
+}`, dataset, name, test.RandomEmail())
 }
 
 func testAccConfigBasicTriggerTest(dataset, name, pdseverity string) string {

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -131,6 +131,9 @@ provider "honeycombio" {
     dataset {
       import_on_conflict = true
     }
+    intelligence {
+      enabled = true
+    }
   }
 }
 ```
@@ -141,6 +144,7 @@ The `features` block supports the following:
 
 * `column` - (Optional) A `column` block as defined below.
 * `dataset` - (Optional) A `dataset` block as defined below.
+* `intelligence` - (Optional) An `intelligence` block as defined below.
 
 ---
 The `column` block supports the following:
@@ -150,3 +154,9 @@ The `column` block supports the following:
 ---
 The `dataset` block supports the following:
 * `import_on_conflict` - (Optional) This changes the creation behavior of the dataset resource to import and update an existing dataset if it already exists, rather than erroring out. Defaults to `false`.
+
+---
+The `intelligence` block supports the following:
+* `enabled` - (Optional) Set to `true` to enable intelligence features such as `auto_investigate` on triggers and burn alerts. Defaults to `false`.
+
+~> **Note** [Honeycomb Intelligence](https://docs.honeycomb.io/security-compliance/honeycomb-intelligence) must first be enabled for your team in the Honeycomb UI before using this block. The `intelligence` feature block in the provider tells Terraform that your team has Honeycomb Intelligence enabled and unlocks related attributes like `auto_investigate`.


### PR DESCRIPTION
## Summary

This adds support for auto investigations on burn alerts and triggers for teams with Honeycomb Intelligence enabled.

A new `intelligence` block has been added to the provider's `features` configuration. Teams with Intelligence enabled should set `enabled = true` to unlock the `auto_investigate` attribute on burn alert and trigger resources. Teams without Intelligence are unaffected — upgrading to this version produces no diff on existing resources.

When `auto_investigate` is set to `true` without the intelligence feature enabled, the provider returns a clear validation error guiding the user to enable it.

## Sample Configuration

```hcl
provider "honeycombio" {
  features {
    intelligence {
      enabled = true
    }
  }
}

resource "honeycombio_burn_alert" "example" {
  exhaustion_minutes = 60
  auto_investigate   = true

  dataset = "my-dataset"
  slo_id  = honeycombio_slo.example.id

  recipient {
    type   = "email"
    target = "oncall@example.com"
  }
}

resource "honeycombio_trigger" "example" {
  name             = "High error rate"
  dataset          = "my-dataset"
  auto_investigate = true

  query_json = data.honeycombio_query_specification.errors.json

  threshold {
    op    = ">"
    value = 100
  }

  frequency = 900

  recipient {
    type   = "email"
    target = "oncall@example.com"
  }
}
```

## Testing

After building the provider locally (`go build -o terraform-provider-honeycombio`), you can test with:

```bash
# Plan to see the new attribute
terraform plan

# Apply to create/update resources with auto_investigate
terraform apply

# Verify no diff on a clean run
terraform plan  # should show "No changes"
```

To verify the upgrade path (existing resources without `auto_investigate`), run `terraform plan` against an existing state — it should show no changes