### PR TITLE
feat(d/query_specification): Expanded calculation support

### DIFF
--- a/client/query_spec.go
+++ b/client/query_spec.go
@@ -123,7 +123,7 @@ func (qs *QuerySpec) EquivalentTo(other QuerySpec) bool {
 			// the dataset, otherwise we'll incorrectly assume that empty and COUNT are
 			// the same for metrics (which doesn't have a default).
 			//
-			// We're ignoring this problem for now since COUNT is strongly discouraged
+			// We're ignoring this problem for now since COUNT is disallowed
 			// for use by metrics queries, and often isn't what users actually want.
 			// See https://docs.honeycomb.io/investigate/query/examples-metrics#common-select-operations
 			return c.Op == CalculationOpCount

--- a/client/query_spec.go
+++ b/client/query_spec.go
@@ -31,8 +31,9 @@ type QuerySpec struct {
 	// API. This value should not be set when creating or updating queries.
 	ID *string `json:"id,omitempty"`
 
-	// The calculations to return as a time series and summary table. If no
-	// calculations are provided, COUNT is applied.
+	// The calculations to return as a time series and summary table. For
+	// non-metrics datasets, COUNT is applied if no calculations are provided.
+	// Metrics datasets require at least one explicit calculation.
 	Calculations []CalculationSpec `json:"calculations,omitempty"`
 	// CalculatedFields are temporary Calculated Fields that are
 	// created for the query.
@@ -106,23 +107,31 @@ func (qs *QuerySpec) EquivalentTo(other QuerySpec) bool {
 			}
 		}
 	}
+
 	if !calcMatch {
-		// 'COUNT' is the default Calculation and equivalent to an empty Calculations -- check that before we give up
-		defaultCalc := []CalculationSpec{{Op: CalculationOpCount}}
-		qsC, oC := defaultCalc, defaultCalc
-		if len(qs.Calculations) != 0 {
-			qsC = qs.Calculations
-		}
-		if len(other.Calculations) != 0 {
-			oC = other.Calculations
-		}
-		if len(qsC) != len(oC) {
-			return false
-		}
-		for i := range qsC {
-			if !qsC[i].EquivalentTo(oC[i]) {
+		// isDefaultBareCalc reports whether calcs matches dataset-level defaults filled in by the API.
+		isDefaultBareCalc := func(calcs []CalculationSpec) bool {
+			if len(calcs) != 1 {
 				return false
 			}
+			c := calcs[0]
+			if c.Column != nil || c.Name != nil || len(c.Filters) != 0 {
+				return false
+			}
+
+			// We _should_ check that the default matches the expected default from the
+			// the dataset, otherwise we'll incorrectly assume that empty and COUNT are
+			// the same for metrics (which doesn't have a default).
+			//
+			// We're ignoring this problem for now since COUNT is strongly discouraged
+			// for use by metrics queries, and often isn't what users actually want.
+			// See https://docs.honeycomb.io/investigate/query/examples-metrics#common-select-operations
+			return c.Op == CalculationOpCount
+		}
+
+		if !isDefaultBareCalc(qs.Calculations) && len(qs.Calculations) != 0 ||
+			!isDefaultBareCalc(other.Calculations) && len(other.Calculations) != 0 {
+			return false
 		}
 	}
 
@@ -193,7 +202,7 @@ func (qs *QuerySpec) EquivalentTo(other QuerySpec) bool {
 // CalculationSpec represents a calculation within a query.
 type CalculationSpec struct {
 	Op CalculationOp `json:"op"`
-	// Column to perform the operation on. Not needed with COUNT or CONCURRENCY
+	// Column to perform the operation on. Not relevant or optional for some calculations.
 	Column *string `json:"column,omitempty"`
 	// Name is an optional identifier for the calculation.
 	// Required when using calculation filters or when referencing the calculation in a formula.
@@ -267,10 +276,20 @@ const (
 	CalculationOpRateAvg       CalculationOp = "RATE_AVG"
 	CalculationOpRateSum       CalculationOp = "RATE_SUM"
 	CalculationOpRateMax       CalculationOp = "RATE_MAX"
+
+	// The below calculations are only applicable for the metrics dataset
+	// Right now, this is only validated at apply-time.
+	CalculationOpCountDatapoints CalculationOp = "COUNT_DATAPOINTS"
+	CalculationOpHistogramCount  CalculationOp = "HISTOGRAM_COUNT"
 )
 
 func (c CalculationOp) IsUnaryOp() bool {
-	return c == CalculationOpCount || c == CalculationOpConcurrency
+	return c == CalculationOpConcurrency
+}
+
+// AllowsOptionalColumn returns true for ops where `column` need not be supplied
+func (c CalculationOp) AllowsOptionalColumn() bool {
+	return c == CalculationOpCountDatapoints || c == CalculationOpCount
 }
 
 // CalculationOps returns an exhaustive list of Calculation Operators.
@@ -305,6 +324,8 @@ func HavingCalculationOps() []CalculationOp {
 		CalculationOpRateAvg,
 		CalculationOpRateSum,
 		CalculationOpRateMax,
+		CalculationOpCountDatapoints,
+		CalculationOpHistogramCount,
 	}
 }
 

--- a/client/query_spec_test.go
+++ b/client/query_spec_test.go
@@ -131,10 +131,10 @@ func TestQuerySpec_EquivalentTo(t *testing.T) {
 			false,
 		},
 		{
-			"default w/ column is not equivalent to empty",
+			"non-COUNT default is not equivalent to empty",
 			client.QuerySpec{
 				Calculations: []client.CalculationSpec{
-					{Op: "COUNT_DATAPOINTS", Column: client.ToPtr("http.client.request.duration")},
+					{Op: "COUNT_DATAPOINTS"},
 				},
 				TimeRange:   client.ToPtr(client.DefaultQueryTimeRange),
 				Granularity: client.ToPtr(0),

--- a/client/query_spec_test.go
+++ b/client/query_spec_test.go
@@ -102,9 +102,7 @@ func TestQuerySpec_EquivalentTo(t *testing.T) {
 			"Empty Defaults",
 			client.QuerySpec{
 				Calculations: []client.CalculationSpec{
-					{
-						Op: "COUNT",
-					},
+					{Op: "COUNT"},
 				},
 				FilterCombination: "AND",
 				TimeRange:         client.ToPtr(client.DefaultQueryTimeRange),
@@ -116,6 +114,36 @@ func TestQuerySpec_EquivalentTo(t *testing.T) {
 			},
 			client.QuerySpec{},
 			true,
+		},
+		{
+			"default w/ column is not equivalent to empty",
+			client.QuerySpec{
+				Calculations: []client.CalculationSpec{
+					{Op: "COUNT", Column: client.ToPtr("name")},
+				},
+				TimeRange:   client.ToPtr(client.DefaultQueryTimeRange),
+				Granularity: client.ToPtr(0),
+				Breakdowns:  []string{},
+				Orders:      []client.OrderSpec{},
+				Limit:       client.ToPtr(client.DefaultQueryLimit),
+			},
+			client.QuerySpec{},
+			false,
+		},
+		{
+			"default w/ column is not equivalent to empty",
+			client.QuerySpec{
+				Calculations: []client.CalculationSpec{
+					{Op: "COUNT_DATAPOINTS", Column: client.ToPtr("http.client.request.duration")},
+				},
+				TimeRange:   client.ToPtr(client.DefaultQueryTimeRange),
+				Granularity: client.ToPtr(0),
+				Breakdowns:  []string{},
+				Orders:      []client.OrderSpec{},
+				Limit:       client.ToPtr(client.DefaultQueryLimit),
+			},
+			client.QuerySpec{},
+			false,
 		},
 		{
 			"Equivalent but shuffled",
@@ -533,6 +561,28 @@ func TestQuerySpec_EquivalentTo(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.want, tt.a.EquivalentTo(tt.b))
+		})
+	}
+}
+
+func TestCalculationOp_ColumnCategories(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		op                    client.CalculationOp
+		wantUnary             bool
+		wantAllowsOptionalCol bool
+	}{
+		{client.CalculationOpCount, false, true},
+		{client.CalculationOpCountDatapoints, false, true},
+		{client.CalculationOpConcurrency, true, false},
+		{client.CalculationOpAvg, false, false},
+		{client.CalculationOpHistogramCount, false, false},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.op), func(t *testing.T) {
+			assert.Equal(t, tt.wantUnary, tt.op.IsUnaryOp())
+			assert.Equal(t, tt.wantAllowsOptionalCol, tt.op.AllowsOptionalColumn())
 		})
 	}
 }

--- a/docs/data-sources/query_specification.md
+++ b/docs/data-sources/query_specification.md
@@ -58,7 +58,7 @@ output "json_query" {
 
 - `breakdowns` (List of String) A list of fields to group results by.
 - `calculated_field` (Block List) Zero or more configuration blocks describing the Calculated Fields to create for use in this query. (see [below for nested schema](#nestedblock--calculated_field))
-- `calculation` (Block List) Zero or more configuration blocks describing the calculations to return as a time series and summary table. If no calculations are provided, "COUNT" is assumed. (see [below for nested schema](#nestedblock--calculation))
+- `calculation` (Block List) Zero or more configuration blocks describing the calculations to return as a time series and summary table. If no calculations are provided, "COUNT" is assumed for non-metrics datasets. Explicit calculations are strongly encouraged. (see [below for nested schema](#nestedblock--calculation))
 - `compare_time_offset` (Number) The time offset for comparison queries, in seconds. Used to compare current time range data with data from a previous time period.
 - `end_time` (Number) The absolute end time of the query's time range, in seconds since the Unix epoch.
 - `filter` (Block List) Zero or more configuration blocks describing the filters to apply to the query results. (see [below for nested schema](#nestedblock--filter))
@@ -94,7 +94,7 @@ Required:
 
 Optional:
 
-- `column` (String) The column to apply the operator on. Not allowed with "COUNT" or "CONCURRENCY", required for all other operators.
+- `column` (String) The column to apply the operator on. Not allowed with "CONCURRENCY", optional for "COUNT" and "COUNT_DATAPOINTS", required for all other operators.
 - `filter` (Block List) Zero or more configuration blocks describing filters to apply to this specific calculation. (see [below for nested schema](#nestedblock--calculation--filter))
 - `filter_combination` (String) How to combine multiple calculation filters. Defaults to "AND".
 - `name` (String) The name of the calculation. Required when using calculation filters or when referencing the calculation in a formula.
@@ -146,7 +146,7 @@ Required:
 
 Optional:
 
-- `column` (String) The column to filter on. Not allowed with "COUNT".
+- `column` (String) The column to filter on.
 
 
 <a id="nestedblock--order"></a>
@@ -163,3 +163,5 @@ Optional:
 -> **NOTE** Filter op `in` and `not-in` expect an array of strings as value. Use the `value` attribute and pass the values in a single string separated by `,` without additional spaces (similar to the query builder in the UI). For example: the list `foo`, `bar` becomes `foo,bar`.
 
 ~> **NOTE** A `having` block's `column`/`calculate_op` pair must have a corresponding `calculation`. There can be multiple `having` blocks for the same `column`/`calculate_op` pair.
+
+-> **NOTE** The `COUNT_DATAPOINTS` and `HISTOGRAM_COUNT` calculation operators are only valid against metrics datasets.

--- a/examples/samples/metrics/README.md
+++ b/examples/samples/metrics/README.md
@@ -1,0 +1,27 @@
+# Honeycomb Metrics Example
+
+End-to-end sample showing how to use metrics-only calculation operators in
+Terraform-managed Honeycomb resources:
+
+- `COUNT_DATAPOINTS` — counts the number of datapoints reported by a metrics
+  dataset. The `column` is optional; omit it for a total or set it to scope
+  to a specific metric.
+- `HISTOGRAM_COUNT` — counts events recorded in a histogram-typed metric
+  column. The `column` is required.
+
+The example wires the same query specifications into both alerting (triggers)
+and visualization (a flexible board), so you can see how the operators flow
+through each consumer.
+
+## Requirements
+
+- A Honeycomb metrics dataset with the metrics referenced in `main.tf`
+  (`app.cumulative`, `app.histogram`). You can seed an example metrics
+  dataset with `scripts/setup-metrics`.
+
+## Usage
+
+```sh
+terraform init
+terraform plan -var dataset=<your-metrics-dataset>
+```

--- a/examples/samples/metrics/board.tf
+++ b/examples/samples/metrics/board.tf
@@ -1,0 +1,50 @@
+# Flexible board surfacing the metrics queries side-by-side.
+resource "honeycombio_flexible_board" "metrics_overview" {
+  name        = "Metrics overview"
+  description = "Datapoint and histogram volume for the metrics pipeline."
+
+  panel {
+    type = "query"
+    position {
+      x_coordinate = 0
+      y_coordinate = 0
+      width        = 6
+      height       = 6
+    }
+    query_panel {
+      query_id            = honeycombio_query.datapoints_total.id
+      query_annotation_id = honeycombio_query_annotation.datapoints_total.id
+      query_style         = "graph"
+    }
+  }
+
+  panel {
+    type = "query"
+    position {
+      x_coordinate = 6
+      y_coordinate = 0
+      width        = 6
+      height       = 6
+    }
+    query_panel {
+      query_id            = honeycombio_query.datapoints_for_metric.id
+      query_annotation_id = honeycombio_query_annotation.datapoints_for_metric.id
+      query_style         = "graph"
+    }
+  }
+
+  panel {
+    type = "query"
+    position {
+      x_coordinate = 0
+      y_coordinate = 6
+      width        = 12
+      height       = 6
+    }
+    query_panel {
+      query_id            = honeycombio_query.histogram_events.id
+      query_annotation_id = honeycombio_query_annotation.histogram_events.id
+      query_style         = "graph"
+    }
+  }
+}

--- a/examples/samples/metrics/main.tf
+++ b/examples/samples/metrics/main.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    honeycombio = {
+      source = "honeycombio/honeycombio"
+    }
+  }
+}
+
+variable "dataset" {
+  description = "A Honeycomb metrics dataset. Calculations like COUNT_DATAPOINTS and HISTOGRAM_COUNT are only valid against metrics datasets."
+  type        = string
+}

--- a/examples/samples/metrics/queries.tf
+++ b/examples/samples/metrics/queries.tf
@@ -1,0 +1,67 @@
+data "honeycombio_query_specification" "datapoints_total" {
+  calculation {
+    op = "COUNT_DATAPOINTS"
+  }
+
+  time_range  = 1800
+  granularity = 60
+}
+
+data "honeycombio_query_specification" "datapoints_for_metric" {
+  calculation {
+    op     = "COUNT_DATAPOINTS"
+    column = "app.cumulative"
+  }
+
+  breakdowns = ["node.name"]
+
+  time_range  = 1800
+  granularity = 60
+}
+
+data "honeycombio_query_specification" "histogram_events" {
+  calculation {
+    op     = "HISTOGRAM_COUNT"
+    column = "app.histogram"
+  }
+
+  time_range  = 1800
+  granularity = 60
+}
+
+# Saved queries + annotations so the queries can be referenced by boards and triggers
+resource "honeycombio_query" "datapoints_total" {
+  dataset    = var.dataset
+  query_json = data.honeycombio_query_specification.datapoints_total.json
+}
+
+resource "honeycombio_query_annotation" "datapoints_total" {
+  dataset     = var.dataset
+  query_id    = honeycombio_query.datapoints_total.id
+  name        = "Total datapoints"
+  description = "Total datapoints reported across all metrics"
+}
+
+resource "honeycombio_query" "datapoints_for_metric" {
+  dataset    = var.dataset
+  query_json = data.honeycombio_query_specification.datapoints_for_metric.json
+}
+
+resource "honeycombio_query_annotation" "datapoints_for_metric" {
+  dataset     = var.dataset
+  query_id    = honeycombio_query.datapoints_for_metric.id
+  name        = "Datapoint volume by node"
+  description = "Per-node datapoint volume for app.cumulative over the last 30 minutes"
+}
+
+resource "honeycombio_query" "histogram_events" {
+  dataset    = var.dataset
+  query_json = data.honeycombio_query_specification.histogram_events.json
+}
+
+resource "honeycombio_query_annotation" "histogram_events" {
+  dataset     = var.dataset
+  query_id    = honeycombio_query.histogram_events.id
+  name        = "Histogram event count"
+  description = "Number of events recorded in app.histogram"
+}

--- a/examples/samples/metrics/triggers.tf
+++ b/examples/samples/metrics/triggers.tf
@@ -1,0 +1,42 @@
+# Fires when no datapoints are reported, typically a sign that a metrics
+# emitter has stopped.
+resource "honeycombio_trigger" "datapoint_volume_drop" {
+  name        = "Datapoint volume drop"
+  description = "Fires when no datapoints are reported."
+  dataset     = var.dataset
+
+  query_json = data.honeycombio_query_specification.datapoints_total.json
+
+  frequency = 900
+
+  threshold {
+    op    = "<"
+    value = 1
+  }
+
+  recipient {
+    type   = "email"
+    target = "hello@example.com"
+  }
+}
+
+# Fires when histogram event volume falls below an expected floor.
+resource "honeycombio_trigger" "histogram_event_drop" {
+  name        = "Histogram event volume drop"
+  description = "Fires when histogram event volume falls below an expected floor."
+  dataset     = var.dataset
+
+  query_json = data.honeycombio_query_specification.histogram_events.json
+
+  frequency = 900
+
+  threshold {
+    op    = "<"
+    value = 1
+  }
+
+  recipient {
+    type   = "email"
+    target = "hello@example.com"
+  }
+}

--- a/examples/samples/query/main.tf
+++ b/examples/samples/query/main.tf
@@ -14,7 +14,8 @@ variable "dataset" {
 # Create a query specification with compare_time_offset_seconds
 data "honeycombio_query_specification" "comparison_query" {
   calculation {
-    op = "COUNT"
+    op = "AVG"
+    column = "duration_ms"
   }
 
   # Filter for successful requests only

--- a/internal/helper/validation/query_spec_test.go
+++ b/internal/helper/validation/query_spec_test.go
@@ -29,6 +29,15 @@ func Test_QuerySpecValidator(t *testing.T) {
 		"valid query spec": {
 			val: types.StringValue(`{"calculations": [{"op": "COUNT"}]}`),
 		},
+		"valid COUNT_DATAPOINTS without column": {
+			val: types.StringValue(`{"calculations": [{"op": "COUNT_DATAPOINTS"}]}`),
+		},
+		"valid COUNT_DATAPOINTS with column": {
+			val: types.StringValue(`{"calculations": [{"op": "COUNT_DATAPOINTS", "column": "app.cumulative"}]}`),
+		},
+		"valid HISTOGRAM_COUNT": {
+			val: types.StringValue(`{"calculations": [{"op": "HISTOGRAM_COUNT", "column": "request.duration"}]}`),
+		},
 		"invalid json": {
 			val:         types.StringValue("whoop"),
 			expectError: true,

--- a/internal/helper/validation/query_spec_test.go
+++ b/internal/helper/validation/query_spec_test.go
@@ -26,8 +26,11 @@ func Test_QuerySpecValidator(t *testing.T) {
 		"null": {
 			val: types.StringNull(),
 		},
-		"valid query spec": {
+		"valid COUNT without column": {
 			val: types.StringValue(`{"calculations": [{"op": "COUNT"}]}`),
+		},
+		"valid COUNT with column": {
+			val: types.StringValue(`{"calculations": [{"op": "COUNT", "column": "app.cumulative"}]}`),
 		},
 		"valid COUNT_DATAPOINTS without column": {
 			val: types.StringValue(`{"calculations": [{"op": "COUNT_DATAPOINTS"}]}`),

--- a/internal/provider/query_resource_test.go
+++ b/internal/provider/query_resource_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -216,25 +217,119 @@ resource "honeycombio_query" "test" {
 	})
 }
 
+func TestAcc_QueryResourceWith_Metrics(t *testing.T) {
+	dataset := testAccMetricsDataset(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 testAccPreCheck(t),
+		ProtoV5ProviderFactories: testAccProtoV5MuxServerFactory,
+		Steps: []resource.TestStep{
+			{
+				// COUNT_DATAPOINTS with no column (dataset-level default form)
+				Config: testAccConfigQuery(dataset, calculationBlock("COUNT_DATAPOINTS", "")),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccEnsureQueryExists(t, "honeycombio_query.test"),
+					resource.TestCheckResourceAttrWith("honeycombio_query.test", "query_json", testAccCheckQueryJSON(func(q client.QuerySpec) error {
+						if len(q.Calculations) != 1 {
+							return fmt.Errorf("expected 1 calculation, got %d", len(q.Calculations))
+						}
+						if q.Calculations[0].Op != client.CalculationOpCountDatapoints {
+							return fmt.Errorf("expected COUNT_DATAPOINTS, got %s", q.Calculations[0].Op)
+						}
+						if q.Calculations[0].Column != nil {
+							return fmt.Errorf("expected no column on COUNT_DATAPOINTS, got %q", *q.Calculations[0].Column)
+						}
+						return nil
+					})),
+				),
+			},
+			{
+				Config: testAccConfigQuery(dataset, calculationBlock("COUNT_DATAPOINTS", "app.cumulative")),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccEnsureQueryExists(t, "honeycombio_query.test"),
+					resource.TestCheckResourceAttrWith("honeycombio_query.test", "query_json", testAccCheckQueryJSON(func(q client.QuerySpec) error {
+						if len(q.Calculations) != 1 {
+							return fmt.Errorf("expected 1 calculation, got %d", len(q.Calculations))
+						}
+						if q.Calculations[0].Op != client.CalculationOpCountDatapoints {
+							return fmt.Errorf("expected COUNT_DATAPOINTS, got %s", q.Calculations[0].Op)
+						}
+						if q.Calculations[0].Column == nil || *q.Calculations[0].Column != "app.cumulative" {
+							return fmt.Errorf("expected column app.cumulative, got %v", q.Calculations[0].Column)
+						}
+						return nil
+					})),
+				),
+			},
+			{
+				// HISTOGRAM_COUNT requires a histogram-typed column. The
+				// metrics dataset seeded by scripts/setup-metrics is expected
+				// to include a histogram column named `app.histogram`.
+				Config: testAccConfigQuery(dataset, calculationBlock("HISTOGRAM_COUNT", "app.histogram")),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccEnsureQueryExists(t, "honeycombio_query.test"),
+					resource.TestCheckResourceAttrWith("honeycombio_query.test", "query_json", testAccCheckQueryJSON(func(q client.QuerySpec) error {
+						if len(q.Calculations) != 1 {
+							return fmt.Errorf("expected 1 calculation, got %d", len(q.Calculations))
+						}
+						if q.Calculations[0].Op != client.CalculationOpHistogramCount {
+							return fmt.Errorf("expected HISTOGRAM_COUNT, got %s", q.Calculations[0].Op)
+						}
+						if q.Calculations[0].Column == nil || *q.Calculations[0].Column != "app.histogram" {
+							return fmt.Errorf("expected column app.histogram, got %v", q.Calculations[0].Column)
+						}
+						return nil
+					})),
+				),
+			},
+		},
+	})
+}
+
+func calculationBlock(op, column string) string {
+	if column == "" {
+		return fmt.Sprintf(`
+calculation {
+  op = "%s"
+}`, op)
+	}
+
+	return fmt.Sprintf(`
+calculation {
+	op = "%s"
+	column = "%s"
+}`, op, column)
+}
+
+func filterBlock(column, op string, value float64) string {
+	return fmt.Sprintf(`
+filter {
+	column = "%s"
+	op     = "%s"
+	value  = %f
+}`, column, op, value)
+}
+
 func testAccConfigBasicQueryTest(dataset, column string, value float64) string {
+	return testAccConfigQuery(dataset,
+		calculationBlock("AVG", column),
+		filterBlock(column, ">", value),
+	)
+}
+
+func testAccConfigQuery(dataset string, blocks ...string) string {
+	allBlocks := strings.Join(blocks, "\n")
 	return fmt.Sprintf(`
 data "honeycombio_query_specification" "test" {
-  calculation {
-    op     = "AVG"
-    column = "%[2]s"
-  }
+	%[2]s
 
-  filter {
-    column = "%[2]s"
-    op     = ">"
-    value  = %[3]f
-  }
+  time_range = 1800
 }
 
 resource "honeycombio_query" "test" {
   dataset    = "%[1]s"
   query_json = data.honeycombio_query_specification.test.json
-}`, dataset, column, value)
+}`, dataset, allBlocks)
 }
 
 func testAccEnsureQueryExists(t *testing.T, name string) resource.TestCheckFunc {

--- a/internal/provider/query_resource_test.go
+++ b/internal/provider/query_resource_test.go
@@ -225,6 +225,20 @@ func TestAcc_QueryResourceWithMetrics(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5MuxServerFactory,
 		Steps: []resource.TestStep{
 			{
+				// query_spec form rejects COUNT default
+				Config:      testAccConfigQuery(dataset),
+				ExpectError: regexp.MustCompile(`(?i)operation not allowed in metrics dataset: COUNT`),
+			},
+			{
+				// query_json form rejects empty calculation
+				Config: fmt.Sprintf(`
+resource "honeycombio_query" "test" {
+	dataset    = "%s"
+	query_json = "{}"
+}`, dataset),
+				ExpectError: regexp.MustCompile(`(?i)metrics datasets require at least one calculation`),
+			},
+			{
 				// COUNT_DATAPOINTS with no column (dataset-level default form)
 				Config: testAccConfigQuery(dataset, calculationBlock("COUNT_DATAPOINTS", "")),
 				Check: resource.ComposeAggregateTestCheckFunc(

--- a/internal/provider/query_resource_test.go
+++ b/internal/provider/query_resource_test.go
@@ -217,7 +217,7 @@ resource "honeycombio_query" "test" {
 	})
 }
 
-func TestAcc_QueryResourceWith_Metrics(t *testing.T) {
+func TestAcc_QueryResourceWithMetrics(t *testing.T) {
 	dataset := testAccMetricsDataset(t)
 
 	resource.Test(t, resource.TestCase{

--- a/internal/provider/query_specification_data_source.go
+++ b/internal/provider/query_specification_data_source.go
@@ -421,8 +421,9 @@ func (d *querySpecDataSource) Read(ctx context.Context, req datasource.ReadReque
 		calculations = append(calculations, calculation)
 	}
 
-	// none have been provided. As this can potentially cause an infinite diff
-	// we'll set the default here if we haven't parsed any
+	// For non-metrics datasets, COUNT is the default calculation and will be returned
+	// by the API if none have been provided. As this can potentially cause an infinite
+	// diff we'll set the COUNT default here if we haven't parsed any
 	if len(calculations) == 0 {
 		calculations = []client.CalculationSpec{{Op: client.CalculationOpCount}}
 	}

--- a/internal/provider/query_specification_data_source.go
+++ b/internal/provider/query_specification_data_source.go
@@ -117,7 +117,8 @@ func (d *querySpecDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 		Blocks: map[string]schema.Block{
 			"calculation": schema.ListNestedBlock{
 				Description: "Zero or more configuration blocks describing the calculations to return as a time series and summary table. " +
-					"If no calculations are provided, \"COUNT\" is assumed.",
+					"If no calculations are provided, \"COUNT\" is assumed for non-metrics datasets. " +
+					"Explicit calculations are strongly encouraged.",
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
 						"op": schema.StringAttribute{
@@ -130,7 +131,7 @@ func (d *querySpecDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 						},
 						"column": schema.StringAttribute{
 							Description: "The column to apply the operator on. " +
-								"Not allowed with \"COUNT\" or \"CONCURRENCY\", required for all other operators.",
+								"Not allowed with \"CONCURRENCY\", optional for \"COUNT\" and \"COUNT_DATAPOINTS\", required for all other operators.",
 							Optional: true,
 						},
 						"name": schema.StringAttribute{
@@ -246,7 +247,7 @@ func (d *querySpecDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 							},
 						},
 						"column": schema.StringAttribute{
-							Description: "The column to filter on. Not allowed with \"COUNT\".",
+							Description: "The column to filter on.",
 							Optional:    true,
 						},
 						"op": schema.StringAttribute{
@@ -319,13 +320,16 @@ func (d *querySpecDataSource) Read(ctx context.Context, req datasource.ReadReque
 			Name:   c.Name.ValueStringPointer(),
 		}
 
-		if calculation.Op.IsUnaryOp() && calculation.Column != nil {
+		switch {
+		case calculation.Op.AllowsOptionalColumn():
+			// column may be present or absent; no validation needed
+		case calculation.Op.IsUnaryOp() && calculation.Column != nil:
 			resp.Diagnostics.AddAttributeError(
 				path.Root("calculation").AtListIndex(i).AtName("column"),
 				"column is not allowed with operator "+c.Op.ValueString(),
 				"",
 			)
-		} else if !calculation.Op.IsUnaryOp() && calculation.Column == nil {
+		case !calculation.Op.IsUnaryOp() && calculation.Column == nil:
 			resp.Diagnostics.AddAttributeError(
 				path.Root("calculation").AtListIndex(i).AtName("op"),
 				c.Op.ValueString()+" requires a column",
@@ -416,7 +420,7 @@ func (d *querySpecDataSource) Read(ctx context.Context, req datasource.ReadReque
 
 		calculations = append(calculations, calculation)
 	}
-	// 'COUNT' is the default calculation and will be returned by the API if
+
 	// none have been provided. As this can potentially cause an infinite diff
 	// we'll set the default here if we haven't parsed any
 	if len(calculations) == 0 {
@@ -527,14 +531,16 @@ func (d *querySpecDataSource) Read(ctx context.Context, req datasource.ReadReque
 			Value:       h.Value.ValueFloat64(),
 		}
 
-		if having.CalculateOp.IsUnaryOp() && having.Column != nil {
+		switch {
+		case having.CalculateOp.AllowsOptionalColumn():
+			// column may be present or absent; no validation needed
+		case having.CalculateOp.IsUnaryOp() && having.Column != nil:
 			resp.Diagnostics.AddAttributeError(
 				path.Root("having").AtListIndex(i).AtName("calculate_op"),
 				h.CalculateOp.ValueString()+" should not have an accompanying column",
 				"",
 			)
-		}
-		if !having.CalculateOp.IsUnaryOp() && having.Column == nil {
+		case !having.CalculateOp.IsUnaryOp() && having.Column == nil:
 			resp.Diagnostics.AddAttributeError(
 				path.Root("having").AtListIndex(i).AtName("calculate_op"),
 				h.CalculateOp.ValueString()+" requires a column",

--- a/internal/provider/query_specification_data_source_test.go
+++ b/internal/provider/query_specification_data_source_test.go
@@ -220,22 +220,63 @@ var testStepsQueryValidationChecks_calculation = []resource.TestStep{
 		Config: `
 data "honeycombio_query_specification" "test" {
   calculation {
-    op     = "COUNT"
-    column = "we-should-not-specify-a-column-with-COUNT"
-  }
-}`,
-		PlanOnly:    true,
-		ExpectError: regexp.MustCompile("column is not allowed with operator COUNT"),
-	},
-	{
-		Config: `
-data "honeycombio_query_specification" "test" {
-  calculation {
     op     = "AVG"
   }
 }`,
 		PlanOnly:    true,
 		ExpectError: regexp.MustCompile("AVG requires a colum"),
+	},
+	{
+		Config: `
+data "honeycombio_query_specification" "test" {
+  calculation {
+    op = "HISTOGRAM_COUNT"
+  }
+}`,
+		PlanOnly:    true,
+		ExpectError: regexp.MustCompile("HISTOGRAM_COUNT requires a column"),
+	},
+	{
+		Config: `
+data "honeycombio_query_specification" "test" {
+  calculation {
+    op     = "COUNT"
+    column = "*"
+  }
+}`,
+		PlanOnly: true,
+	},
+	{
+		// COUNT_DATAPOINTS accepts no column (metrics datasets)
+		Config: `
+data "honeycombio_query_specification" "test" {
+  calculation {
+    op = "COUNT_DATAPOINTS"
+  }
+}`,
+		PlanOnly: true,
+	},
+	{
+		// COUNT_DATAPOINTS also accepts a column (metrics datasets)
+		Config: `
+data "honeycombio_query_specification" "test" {
+  calculation {
+    op     = "COUNT_DATAPOINTS"
+    column = "app.cumulative"
+  }
+}`,
+		PlanOnly: true,
+	},
+	{
+		// HISTOGRAM_COUNT accepts a column
+		Config: `
+data "honeycombio_query_specification" "test" {
+  calculation {
+    op     = "HISTOGRAM_COUNT"
+    column = "request.duration"
+  }
+}`,
+		PlanOnly: true,
 	},
 	{
 		Config: `
@@ -389,19 +430,6 @@ var testStepsQueryValidationChecks_having = []resource.TestStep{
 		Config: `
 data "honeycombio_query_specification" "test" {
   having {
-    calculate_op = "COUNT"
-    column       = "we-should-not-specify-a-column-with-COUNT"
-    op           = ">"
-    value        = 1
-  }
-}`,
-		PlanOnly:    true,
-		ExpectError: regexp.MustCompile("COUNT should not have an accompanying column"),
-	},
-	{
-		Config: `
-data "honeycombio_query_specification" "test" {
-  having {
     calculate_op = "CONCURRENCY"
     column       = "we-should-not-specify-a-column-with-CONCURRENCY"
     op           = ">"
@@ -435,6 +463,66 @@ data "honeycombio_query_specification" "test" {
 }`,
 		PlanOnly:    true,
 		ExpectError: regexp.MustCompile("P95 missing matching calculation"),
+	},
+	{
+		Config: `
+data "honeycombio_query_specification" "test" {
+  having {
+    calculate_op = "HISTOGRAM_COUNT"
+    op           = ">"
+    value        = 1
+  }
+}`,
+		PlanOnly:    true,
+		ExpectError: regexp.MustCompile("HISTOGRAM_COUNT requires a column"),
+	},
+	{
+		Config: `
+data "honeycombio_query_specification" "test" {
+  calculation {
+    op = "COUNT"
+		column = "*"
+  }
+  having {
+    calculate_op = "COUNT"
+    column       = "*"
+    op           = ">"
+    value        = 1
+  }
+}`,
+		PlanOnly: true,
+	},
+	{
+		Config: `
+data "honeycombio_query_specification" "test" {
+  calculation {
+    op = "COUNT_DATAPOINTS"
+  }
+
+  having {
+    calculate_op = "COUNT_DATAPOINTS"
+    op           = ">"
+    value        = 1
+  }
+}`,
+		PlanOnly: true,
+	},
+	{
+		Config: `
+data "honeycombio_query_specification" "test" {
+  calculation {
+    op     = "COUNT_DATAPOINTS"
+    column = "app.cumulative"
+  }
+
+  having {
+    calculate_op = "COUNT_DATAPOINTS"
+    column       = "app.cumulative"
+    op           = ">"
+    value        = 1
+  }
+}`,
+		PlanOnly: true,
 	},
 }
 

--- a/templates/data-sources/query_specification.md.tmpl
+++ b/templates/data-sources/query_specification.md.tmpl
@@ -16,3 +16,5 @@ It is also valid to use literal JSON strings in your configuration or to use the
 -> **NOTE** Filter op `in` and `not-in` expect an array of strings as value. Use the `value` attribute and pass the values in a single string separated by `,` without additional spaces (similar to the query builder in the UI). For example: the list `foo`, `bar` becomes `foo,bar`.
 
 ~> **NOTE** A `having` block's `column`/`calculate_op` pair must have a corresponding `calculation`. There can be multiple `having` blocks for the same `column`/`calculate_op` pair.
+
+-> **NOTE** The `COUNT_DATAPOINTS` and `HISTOGRAM_COUNT` calculation operators are only valid against metrics datasets.


### PR DESCRIPTION
## Which problem is this PR solving?

Updates the query specification data source to allow the following:
* COUNT w/ a column
* COUNT_DATAPOINTS w/ and w/o a column
* HISTOGRAM_COUNT w/ a column

Fixes: https://linear.app/honeycombio/issue/APPO11Y-4275

## Short description of the changes

Honeycomb metrics support for improved timeseries aggregation included two new calculations (also known as aggregates). These have been added to the API, but were not usable in the provider unless the query was manually constructed with JSON. 

* The changes here will allow us to validate the new calculations during planning without throwing an error.
* Metrics datasets currently require a calculation and rejects an empty calculation block in either spec or JSON form.
  * UI-side also prefers the COUNT_DATAPOINTS aggregate since COUNT is less meaningful. 
  * Unfortunately, it's a bit difficult to check that an aggregate is applied for metrics at plan time since the query data sources don't have dataset information.
  * Open to suggestions here, but I'm mostly deferring this as an apply-time problem since its a bit niche, and mentioned in the docs that calculations are strongly encouraged.
* The COUNT(...) inclusion is mostly a drive-by; I am happy to leave it separate if we prefer; but this has been out for a while now, and I was a bit surprised to find that we didn't support this.

## How to verify that this has the expected result

I've added unit tests and acceptance tests.
* Similar to the metrics acceptance tests for triggers, this cannot run in CI today because we cannot appropriately clean up metrics datasets.
* I've verified that they run locally.

```
λ gotestsum --debug --format=testname -- -count=10 -race -parallel=8 ./... -run '(?i)metric' | grep -v EMPTY
exec: [go test -json -count=10 -race -parallel=8 ./... -run (?i)metric]
go test pid: 23669
PASS internal/provider.TestAcc_QueryResourceWith_Metrics (7.57s)
PASS internal/provider.TestAcc_TriggerResourceWithMetrics (5.68s)
PASS internal/provider.TestAcc_QueryResourceWith_Metrics (7.29s)
PASS internal/provider.TestAcc_TriggerResourceWithMetrics (5.36s)
...
```

I've also added examples on various other integrations with this specification with our other entities, like boards, triggers, etc, that we can use for verification.


