### PR TITLE
rel: Prep release 0.48.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 0.49.0 (May 1, 2026)
+
+## Enhancements
+
+- feat(d/query_specification): Expanded calculation support (#846)
+
+## Housekeeping
+
+- maint(deps): bump the hashicorp group across 1 directory with 2 updates (#848)
+
 # 0.48.0 (Apr 23, 2026)
 
 ## Notes

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ terraform {
   required_providers {
     honeycombio = {
       source  = "honeycombio/honeycombio"
-      version = "~> 0.48.0"
+      version = "~> 0.49.0"
     }
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ terraform {
   required_providers {
     honeycombio = {
       source  = "honeycombio/honeycombio"
-      version = "~> 0.48.0"
+      version = "~> 0.49.0"
     }
   }
 }

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -14,7 +14,7 @@ terraform {
   required_providers {
     honeycombio = {
       source  = "honeycombio/honeycombio"
-      version = "~> 0.48.0"
+      version = "~> 0.49.0"
     }
   }
 }


### PR DESCRIPTION
Prepare release 0.49.0 to ship 2 commits since the April 23rd release.

