### PR TITLE
fix: make it possible to delete a dataset [SCALE-588]

### DIFF
--- a/docs/resources/column.md
+++ b/docs/resources/column.md
@@ -5,7 +5,9 @@ This can be used to create, update, and delete columns in a dataset.
 
 ~> **Warning** Deleting a column is a destructive and irreversible operation which also removes the data in the column.
 
--> **Note** Some columns (such as `timestamp` and `duration_ms`) are used as dataset definitions and cannot be deleted independently while the parent dataset exists. When running `terraform destroy`, the provider will skip the individual column delete for these columns and allow the dataset deletion to clean them up. If you remove only a definition column from your configuration without also removing the dataset, Terraform will consider the deletion successful but the column will remain in Honeycomb until the dataset is deleted.
+-> **Note** Some columns (such as `timestamp` and `duration_ms`) are used as dataset definitions and cannot be deleted independently while the parent dataset exists. 
+When running `terraform destroy`, the provider will skip the individual column delete for these columns and allow the dataset deletion to clean them up. 
+If you remove a definition column from your configuration without also removing the dataset, Terraform will consider the deletion successful but the column will remain in Honeycomb until the dataset is deleted.
 
 -> Version 0.38 and later of the Honeycomb Provider include a Feature Toggle which allows the column to be imported and updated automatically if there is a conflict during create instead of throwing an error.
   This is potentially dangerous if the type changes on the update -- switching from `string` to `boolean` and causing dataloss, for example -- and should be used with caution.

--- a/docs/resources/column.md
+++ b/docs/resources/column.md
@@ -5,6 +5,8 @@ This can be used to create, update, and delete columns in a dataset.
 
 ~> **Warning** Deleting a column is a destructive and irreversible operation which also removes the data in the column.
 
+-> **Note** Some columns (such as `timestamp` and `duration_ms`) are used as dataset definitions and cannot be deleted independently while the parent dataset exists. When running `terraform destroy`, the provider will skip the individual column delete for these columns and allow the dataset deletion to clean them up. If you remove only a definition column from your configuration without also removing the dataset, Terraform will consider the deletion successful but the column will remain in Honeycomb until the dataset is deleted.
+
 -> Version 0.38 and later of the Honeycomb Provider include a Feature Toggle which allows the column to be imported and updated automatically if there is a conflict during create instead of throwing an error.
   This is potentially dangerous if the type changes on the update -- switching from `string` to `boolean` and causing dataloss, for example -- and should be used with caution.
 

--- a/internal/provider/column_resource.go
+++ b/internal/provider/column_resource.go
@@ -233,6 +233,14 @@ func (r *columnResource) Delete(ctx context.Context, req resource.DeleteRequest,
 
 	err := r.client.Columns.Delete(ctx, state.Dataset.ValueString(), state.ID.ValueString())
 	if err != nil {
+		var detailedErr client.DetailedError
+		if errors.As(err, &detailedErr) && detailedErr.IsConflict() && strings.Contains(detailedErr.Message, "in use by dataset definition") {
+			// This column is a dataset definition column (e.g. timestamp, duration).
+			// The API blocks individual deletion while the parent dataset exists, but
+			// dataset deletion cleans up columns automatically. If the dataset is also
+			// being destroyed, Terraform will delete it next and the column will be gone.
+			return
+		}
 		resp.Diagnostics.AddError("Error deleting Column", err.Error())
 		return
 	}

--- a/internal/provider/column_resource.go
+++ b/internal/provider/column_resource.go
@@ -239,6 +239,9 @@ func (r *columnResource) Delete(ctx context.Context, req resource.DeleteRequest,
 			// The API blocks individual deletion while the parent dataset exists, but
 			// dataset deletion cleans up columns automatically. If the dataset is also
 			// being destroyed, Terraform will delete it next and the column will be gone.
+			resp.Diagnostics.AddWarning("Column in use by dataset definition",
+				"Column \""+state.Name.ValueString()+"\" was not deleted because it is in use by a dataset definition. "+
+					"Please delete the parent dataset to remove this column.")
 			return
 		}
 		resp.Diagnostics.AddError("Error deleting Column", err.Error())

--- a/internal/provider/column_resource_test.go
+++ b/internal/provider/column_resource_test.go
@@ -215,7 +215,7 @@ type mockColumns struct {
 	deleteErr error
 }
 
-func (m mockColumns) List(_ context.Context, _ string) ([]client.Column, error) { return nil, nil }
+func (m mockColumns) List(_ context.Context, _ string) ([]client.Column, error)  { return nil, nil }
 func (m mockColumns) Get(_ context.Context, _, _ string) (*client.Column, error) { return nil, nil }
 func (m mockColumns) GetByKeyName(_ context.Context, _, _ string) (*client.Column, error) {
 	return nil, nil

--- a/internal/provider/column_resource_test.go
+++ b/internal/provider/column_resource_test.go
@@ -3,19 +3,23 @@ package provider
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"regexp"
 	"testing"
 	"time"
 
+	tfresource "github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	fwtypes "github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/honeycombio/terraform-provider-honeycombio/internal/helper/test"
-
 	"github.com/honeycombio/terraform-provider-honeycombio/client"
+	"github.com/honeycombio/terraform-provider-honeycombio/internal/helper/test"
+	"github.com/honeycombio/terraform-provider-honeycombio/internal/models"
 )
 
 func TestAcc_ColumnResource(t *testing.T) {
@@ -204,6 +208,95 @@ resource "honeycombio_column" "test" {
 			},
 		},
 	})
+}
+
+// mockColumns is a minimal stub of client.Columns for unit tests.
+type mockColumns struct {
+	deleteErr error
+}
+
+func (m mockColumns) List(_ context.Context, _ string) ([]client.Column, error) { return nil, nil }
+func (m mockColumns) Get(_ context.Context, _, _ string) (*client.Column, error) { return nil, nil }
+func (m mockColumns) GetByKeyName(_ context.Context, _, _ string) (*client.Column, error) {
+	return nil, nil
+}
+func (m mockColumns) Create(_ context.Context, _ string, c *client.Column) (*client.Column, error) {
+	return c, nil
+}
+func (m mockColumns) Update(_ context.Context, _ string, c *client.Column) (*client.Column, error) {
+	return c, nil
+}
+func (m mockColumns) Delete(_ context.Context, _, _ string) error { return m.deleteErr }
+
+func Test_columnResource_Delete(t *testing.T) {
+	ctx := context.Background()
+
+	cr := &columnResource{}
+	var schemaResp tfresource.SchemaResponse
+	cr.Schema(ctx, tfresource.SchemaRequest{}, &schemaResp)
+
+	state := tfsdk.State{Schema: schemaResp.Schema}
+	diags := state.Set(ctx, models.ColumnResourceModel{
+		ID:            fwtypes.StringValue("col-123"),
+		Dataset:       fwtypes.StringValue("my-dataset"),
+		Name:          fwtypes.StringValue("duration_ms"),
+		Hidden:        fwtypes.BoolValue(false),
+		Description:   fwtypes.StringValue(""),
+		Type:          fwtypes.StringValue("float"),
+		CreatedAt:     fwtypes.StringValue(""),
+		UpdatedAt:     fwtypes.StringValue(""),
+		LastWrittenAt: fwtypes.StringValue(""),
+	})
+	require.False(t, diags.HasError(), "state setup failed: %v", diags)
+
+	tests := []struct {
+		name        string
+		deleteErr   error
+		wantErrDiag bool
+	}{
+		{
+			name: "succeeds when column is in use by dataset definition",
+			deleteErr: client.DetailedError{
+				Status:  http.StatusConflict,
+				Message: "Column is in use by dataset definition - duration_ms",
+			},
+			wantErrDiag: false,
+		},
+		{
+			name:        "succeeds when delete succeeds",
+			deleteErr:   nil,
+			wantErrDiag: false,
+		},
+		{
+			name: "errors on other conflicts (e.g. in use by derived column)",
+			deleteErr: client.DetailedError{
+				Status:  http.StatusConflict,
+				Message: "Column is in use by 1 derived columns: 'my_dc'",
+			},
+			wantErrDiag: true,
+		},
+		{
+			name: "errors on non-conflict API errors",
+			deleteErr: client.DetailedError{
+				Status:  http.StatusInternalServerError,
+				Message: "internal server error",
+			},
+			wantErrDiag: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &columnResource{
+				client: &client.Client{
+					Columns: mockColumns{deleteErr: tt.deleteErr},
+				},
+			}
+			var resp tfresource.DeleteResponse
+			r.Delete(ctx, tfresource.DeleteRequest{State: state}, &resp)
+			assert.Equal(t, tt.wantErrDiag, resp.Diagnostics.HasError())
+		})
+	}
 }
 
 func testAccEnsureColumnExists(t *testing.T, resource, name string) resource.TestCheckFunc {

--- a/templates/resources/column.md.tmpl
+++ b/templates/resources/column.md.tmpl
@@ -5,6 +5,10 @@ This can be used to create, update, and delete columns in a dataset.
 
 ~> **Warning** Deleting a column is a destructive and irreversible operation which also removes the data in the column.
 
+-> **Note** Some columns (such as `timestamp` and `duration_ms`) are used as dataset definitions and cannot be deleted independently while the parent dataset exists. 
+When running `terraform destroy`, the provider will skip the individual column delete for these columns and allow the dataset deletion to clean them up. 
+If you remove a definition column from your configuration without also removing the dataset, Terraform will consider the deletion successful but the column will remain in Honeycomb until the dataset is deleted.
+
 -> Version 0.38 and later of the Honeycomb Provider include a Feature Toggle which allows the column to be imported and updated automatically if there is a conflict during create instead of throwing an error.
   This is potentially dangerous if the type changes on the update -- switching from `string` to `boolean` and causing dataloss, for example -- and should be used with caution.
 


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

When attempting to delete a dataset that was created with Terraform, the provider attempts to delete the columns in the dataset. But some of those columns are used in dataset definitions, which causes them to fail. But it's not possible to get them out of the definitions, so it becomes impossible to delete the dataset at all with Terraform (it does work if you do it manually).

This PR ignores deletion errors for columns with dataset definitions; Honeycomb still allows deletion of the dataset in this instance, so this allows the intended behavior to work.

In the case where someone attempts to delete only a column, and it's a column used in a dataset definition, the deletion will appear to succeed but the column will still exist. This is now noted in the documentation.

## Short description of the changes

* Conditionally ignore dataset definition errors
* Add a test to verify it works and fails appropriately
* Add a note to docs

## How to verify that this has the expected result

* Create a dataset with the provider
* Send it data with duration_ms
* Delete the dataset -- it should succeed anyway