### PR TITLE
fix: detect calculated_fields changes when diffing trigger/query query_json

### DIFF
--- a/client/query_spec.go
+++ b/client/query_spec.go
@@ -135,10 +135,8 @@ func (qs *QuerySpec) EquivalentTo(other QuerySpec) bool {
 		}
 	}
 
-	if !reflect.DeepEqual(qs.CalculatedFields, other.CalculatedFields) &&
-		// an empty CalculatedFields is equivalent to a nil CalculatedFields
-		((qs.CalculatedFields != nil || len(other.CalculatedFields) != 0) &&
-			(len(qs.CalculatedFields) != 0 || other.CalculatedFields != nil)) {
+	// the exact order of calculated fields does not matter, but their equivalence does
+	if !Equivalent(qs.CalculatedFields, other.CalculatedFields) {
 		return false
 	}
 

--- a/client/query_spec.go
+++ b/client/query_spec.go
@@ -135,6 +135,13 @@ func (qs *QuerySpec) EquivalentTo(other QuerySpec) bool {
 		}
 	}
 
+	if !reflect.DeepEqual(qs.CalculatedFields, other.CalculatedFields) &&
+		// an empty CalculatedFields is equivalent to a nil CalculatedFields
+		((qs.CalculatedFields != nil || len(other.CalculatedFields) != 0) &&
+			(len(qs.CalculatedFields) != 0 || other.CalculatedFields != nil)) {
+		return false
+	}
+
 	// The order of Formulas is important for visualization rendering
 	if !reflect.DeepEqual(qs.Formulas, other.Formulas) &&
 		// an empty Formulas is equivalent to a nil Formulas

--- a/client/query_spec_test.go
+++ b/client/query_spec_test.go
@@ -558,30 +558,6 @@ func TestQuerySpec_EquivalentTo(t *testing.T) {
 			true,
 		},
 		{
-			"Equivalent calculated fields",
-			client.QuerySpec{
-				CalculatedFields: []client.CalculatedFieldSpec{
-					{Name: "is_error", Expression: "GTE($status_code, 500)"},
-				},
-			},
-			client.QuerySpec{
-				CalculatedFields: []client.CalculatedFieldSpec{
-					{Name: "is_error", Expression: "GTE($status_code, 500)"},
-				},
-			},
-			true,
-		},
-		{
-			"Empty calculated fields equivalent to nil",
-			client.QuerySpec{
-				CalculatedFields: []client.CalculatedFieldSpec{},
-			},
-			client.QuerySpec{
-				CalculatedFields: nil,
-			},
-			true,
-		},
-		{
 			"Added calculated field is not equivalent",
 			client.QuerySpec{
 				CalculatedFields: []client.CalculatedFieldSpec{
@@ -589,16 +565,6 @@ func TestQuerySpec_EquivalentTo(t *testing.T) {
 				},
 			},
 			client.QuerySpec{},
-			false,
-		},
-		{
-			"Removed calculated field is not equivalent",
-			client.QuerySpec{},
-			client.QuerySpec{
-				CalculatedFields: []client.CalculatedFieldSpec{
-					{Name: "is_error", Expression: "GTE($status_code, 500)"},
-				},
-			},
 			false,
 		},
 		{
@@ -614,36 +580,6 @@ func TestQuerySpec_EquivalentTo(t *testing.T) {
 				},
 			},
 			false,
-		},
-		{
-			"Different calculated field name is not equivalent",
-			client.QuerySpec{
-				CalculatedFields: []client.CalculatedFieldSpec{
-					{Name: "is_error", Expression: "GTE($status_code, 500)"},
-				},
-			},
-			client.QuerySpec{
-				CalculatedFields: []client.CalculatedFieldSpec{
-					{Name: "error", Expression: "GTE($status_code, 500)"},
-				},
-			},
-			false,
-		},
-		{
-			"Reordered calculated fields are equivalent",
-			client.QuerySpec{
-				CalculatedFields: []client.CalculatedFieldSpec{
-					{Name: "is_error", Expression: "GTE($status_code, 500)"},
-					{Name: "is_slow", Expression: "GTE($duration_ms, 500)"},
-				},
-			},
-			client.QuerySpec{
-				CalculatedFields: []client.CalculatedFieldSpec{
-					{Name: "is_slow", Expression: "GTE($duration_ms, 500)"},
-					{Name: "is_error", Expression: "GTE($status_code, 500)"},
-				},
-			},
-			true,
 		},
 	}
 	for _, tt := range tests {

--- a/client/query_spec_test.go
+++ b/client/query_spec_test.go
@@ -630,7 +630,7 @@ func TestQuerySpec_EquivalentTo(t *testing.T) {
 			false,
 		},
 		{
-			"Reordered calculated fields are not equivalent",
+			"Reordered calculated fields are equivalent",
 			client.QuerySpec{
 				CalculatedFields: []client.CalculatedFieldSpec{
 					{Name: "is_error", Expression: "GTE($status_code, 500)"},
@@ -643,7 +643,7 @@ func TestQuerySpec_EquivalentTo(t *testing.T) {
 					{Name: "is_error", Expression: "GTE($status_code, 500)"},
 				},
 			},
-			false,
+			true,
 		},
 	}
 	for _, tt := range tests {

--- a/client/query_spec_test.go
+++ b/client/query_spec_test.go
@@ -557,6 +557,94 @@ func TestQuerySpec_EquivalentTo(t *testing.T) {
 			},
 			true,
 		},
+		{
+			"Equivalent calculated fields",
+			client.QuerySpec{
+				CalculatedFields: []client.CalculatedFieldSpec{
+					{Name: "is_error", Expression: "GTE($status_code, 500)"},
+				},
+			},
+			client.QuerySpec{
+				CalculatedFields: []client.CalculatedFieldSpec{
+					{Name: "is_error", Expression: "GTE($status_code, 500)"},
+				},
+			},
+			true,
+		},
+		{
+			"Empty calculated fields equivalent to nil",
+			client.QuerySpec{
+				CalculatedFields: []client.CalculatedFieldSpec{},
+			},
+			client.QuerySpec{
+				CalculatedFields: nil,
+			},
+			true,
+		},
+		{
+			"Added calculated field is not equivalent",
+			client.QuerySpec{
+				CalculatedFields: []client.CalculatedFieldSpec{
+					{Name: "is_error", Expression: "GTE($status_code, 500)"},
+				},
+			},
+			client.QuerySpec{},
+			false,
+		},
+		{
+			"Removed calculated field is not equivalent",
+			client.QuerySpec{},
+			client.QuerySpec{
+				CalculatedFields: []client.CalculatedFieldSpec{
+					{Name: "is_error", Expression: "GTE($status_code, 500)"},
+				},
+			},
+			false,
+		},
+		{
+			"Different calculated field expression is not equivalent",
+			client.QuerySpec{
+				CalculatedFields: []client.CalculatedFieldSpec{
+					{Name: "is_error", Expression: "GTE($status_code, 500)"},
+				},
+			},
+			client.QuerySpec{
+				CalculatedFields: []client.CalculatedFieldSpec{
+					{Name: "is_error", Expression: "GTE($status_code, 400)"},
+				},
+			},
+			false,
+		},
+		{
+			"Different calculated field name is not equivalent",
+			client.QuerySpec{
+				CalculatedFields: []client.CalculatedFieldSpec{
+					{Name: "is_error", Expression: "GTE($status_code, 500)"},
+				},
+			},
+			client.QuerySpec{
+				CalculatedFields: []client.CalculatedFieldSpec{
+					{Name: "error", Expression: "GTE($status_code, 500)"},
+				},
+			},
+			false,
+		},
+		{
+			"Reordered calculated fields are not equivalent",
+			client.QuerySpec{
+				CalculatedFields: []client.CalculatedFieldSpec{
+					{Name: "is_error", Expression: "GTE($status_code, 500)"},
+					{Name: "is_slow", Expression: "GTE($duration_ms, 500)"},
+				},
+			},
+			client.QuerySpec{
+				CalculatedFields: []client.CalculatedFieldSpec{
+					{Name: "is_slow", Expression: "GTE($duration_ms, 500)"},
+					{Name: "is_error", Expression: "GTE($status_code, 500)"},
+				},
+			},
+			false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/docs/resources/trigger.md
+++ b/docs/resources/trigger.md
@@ -605,7 +605,7 @@ Optional:
 - `exceeded_limit` (Number) The number of times the threshold is met before an alert is sent. Defaults to 1.
 
 -> **NOTE** The query used in a Trigger must follow a strict subset. It supports two query shapes:
-**Standard:** The query must contain *exactly one* non-having calculation (without names or aggregate filters) and may only contain `calculation`, `filter`, `filter_combination`, `having` (at most 1), and `breakdowns` fields.
+**Standard:** The query must contain *exactly one* non-having calculation (without names or aggregate filters) and may only contain `calculation`, `calculated_field`, `filter`, `filter_combination`, `having` (at most 1), and `breakdowns` fields.
 **Formula:** The query must contain *exactly one* formula with up to 100 named calculations. When calculations use names or aggregate-level filters, global filters cannot be used — use calculation-level filters instead.
 The query's duration cannot be more than four times the trigger frequency (i.e. `duration <= frequency*4`).
 See [A Caveat on Time](https://docs.honeycomb.io/working-with-your-data/query-specification/#a-caveat-on-time)) for more information on specifying a query's duration.

--- a/internal/provider/trigger_resource_test.go
+++ b/internal/provider/trigger_resource_test.go
@@ -2256,6 +2256,90 @@ resource "honeycombio_trigger" "test" {
 }`, dataset, name)
 }
 
+func TestAcc_TriggerResourceWithCalculatedField(t *testing.T) {
+	dataset := testAccDataset()
+	name := test.RandomStringWithPrefix("test.", 20)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 testAccPreCheck(t),
+		ProtoV6ProviderFactories: testAccProtoV6MuxServerFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfigTriggerWithCalculatedField(dataset, name, "IF(GT($duration_ms, 500), 1, 0)"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccEnsureTriggerExists(t, "honeycombio_trigger.test"),
+					resource.TestCheckResourceAttrWith("honeycombio_trigger.test", "query_json", testAccCheckQueryJSON(func(q client.QuerySpec) error {
+						if len(q.CalculatedFields) != 1 {
+							return fmt.Errorf("expected 1 calculated field, got %d", len(q.CalculatedFields))
+						}
+						if q.CalculatedFields[0].Expression != "IF(GT($duration_ms, 500), 1, 0)" {
+							return fmt.Errorf("unexpected calculated field expression: %q", q.CalculatedFields[0].Expression)
+						}
+						return nil
+					})),
+				),
+			},
+			{
+				// update only the calculated_field expression
+				Config: testAccConfigTriggerWithCalculatedField(dataset, name, "IF(GT($duration_ms, 1000), 1, 0)"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccEnsureTriggerExists(t, "honeycombio_trigger.test"),
+					resource.TestCheckResourceAttrWith("honeycombio_trigger.test", "query_json", testAccCheckQueryJSON(func(q client.QuerySpec) error {
+						if len(q.CalculatedFields) != 1 {
+							return fmt.Errorf("expected 1 calculated field, got %d", len(q.CalculatedFields))
+						}
+						if q.CalculatedFields[0].Expression != "IF(GT($duration_ms, 1000), 1, 0)" {
+							return fmt.Errorf("calculated field expression was not updated, got %q", q.CalculatedFields[0].Expression)
+						}
+						return nil
+					})),
+				),
+			},
+			{
+				ResourceName:        "honeycombio_trigger.test",
+				ImportStateIdPrefix: fmt.Sprintf("%v/", dataset),
+				ImportState:         true,
+			},
+		},
+	})
+}
+
+func testAccConfigTriggerWithCalculatedField(dataset, name, expression string) string {
+	return fmt.Sprintf(`
+data "honeycombio_query_specification" "test" {
+  calculated_field {
+    name       = "is_slow"
+    expression = %[3]q
+  }
+
+  calculation {
+    op     = "SUM"
+    column = "is_slow"
+  }
+
+  time_range = 900
+}
+
+resource "honeycombio_trigger" "test" {
+  name    = "%[2]s"
+  dataset = "%[1]s"
+
+  query_json = data.honeycombio_query_specification.test.json
+
+  frequency = 900
+
+  threshold {
+    op    = ">"
+    value = 0
+  }
+
+  recipient {
+    type   = "marker"
+    target = "Calculated field trigger fired"
+  }
+}`, dataset, name, expression)
+}
+
 func TestAcc_TriggerResourceWithMetrics(t *testing.T) {
 	dataset := testAccMetricsDataset(t)
 	name := test.RandomStringWithPrefix("test.", 20)

--- a/templates/resources/trigger.md.tmpl
+++ b/templates/resources/trigger.md.tmpl
@@ -47,7 +47,7 @@ Creates a trigger. For more information about triggers, check out [Alert with Tr
 {{ .SchemaMarkdown | trimspace }}
 
 -> **NOTE** The query used in a Trigger must follow a strict subset. It supports two query shapes:
-**Standard:** The query must contain *exactly one* non-having calculation (without names or aggregate filters) and may only contain `calculation`, `filter`, `filter_combination`, `having` (at most 1), and `breakdowns` fields.
+**Standard:** The query must contain *exactly one* non-having calculation (without names or aggregate filters) and may only contain `calculation`, `calculated_field`, `filter`, `filter_combination`, `having` (at most 1), and `breakdowns` fields.
 **Formula:** The query must contain *exactly one* formula with up to 100 named calculations. When calculations use names or aggregate-level filters, global filters cannot be used — use calculation-level filters instead.
 The query's duration cannot be more than four times the trigger frequency (i.e. `duration <= frequency*4`).
 See [A Caveat on Time](https://docs.honeycomb.io/working-with-your-data/query-specification/#a-caveat-on-time)) for more information on specifying a query's duration.


### PR DESCRIPTION
### Problem

When you add, change, or remove an inline `calculated_field` in the `query_json` of a `honeycombio_trigger` or `honeycombio_query` that already exists, `terraform plan` reports no change and the update is skipped. The same `calculated_field` is applied when the resource is first created, and the API evaluates it when the trigger runs.

This is a problem when moving a trigger off a persistent derived column to an inline `calculated_field`: the derived column is destroyed, but the stored trigger query still references it, and the plan shows nothing.

### Cause

`query_json` diffs are suppressed by the `EquivalentQuerySpec` plan modifier, which delegates to `client.QuerySpec.EquivalentTo`. That method compared every query field except `CalculatedFields`, so two specs differing only by `calculated_fields` were treated as equivalent.

### Fix

Compare `CalculatedFields` in `EquivalentTo` the same way as `Formulas`: order-sensitive, with an empty slice treated as equivalent to nil. `honeycombio_query` uses the same comparison, so it is fixed too.

### Tests & docs

- Unit cases in `client/query_spec_test.go` covering equal / nil-vs-empty / added / removed / changed-expression / changed-name / reordered.
- Acceptance test `TestAcc_TriggerResourceWithCalculatedField` exercising a calculated-field-only trigger update (calculation and threshold held constant).
- Doc note now lists `calculated_field` as a supported Standard trigger-query field.

Fixes #852