### PR TITLE
feat(client): pace and absorb API rate limits so runs slow down instead of failing

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -132,6 +132,11 @@ func NewClientWithConfig(config *Config) (*Client, error) {
 		headers: make(http.Header),
 	}
 
+	// Proactively pace requests to stay within the API's advertised rate
+	// limits, falling back to the reactive backoff below for anything the
+	// gate cannot foresee.
+	cfg.HTTPClient.Transport = limits.NewRateLimitingTransport(cfg.HTTPClient.Transport)
+
 	client.httpClient = &retryablehttp.Client{
 		Backoff:      limits.RetryHTTPBackoff,
 		CheckRetry:   limits.RetryHTTPCheck,

--- a/client/client.go
+++ b/client/client.go
@@ -46,6 +46,10 @@ type Config struct {
 	HTTPClient *http.Client
 	// Optionally set the user agent to send with all requests, defaults to "go-honeycombio".
 	UserAgent string
+	// Optionally set the number of times a rate-limited (HTTP 429) request is
+	// replayed — waiting out the rate limit window each time — before the 429
+	// is surfaced. Defaults to limits.DefaultRateLimitRetries.
+	RateLimitRetries int
 }
 
 // Client to interact with Honeycomb.
@@ -76,11 +80,12 @@ type Client struct {
 // DefaultConfig returns a Config initilized with default values.
 func DefaultConfig() *Config {
 	c := &Config{
-		APIKey:     os.Getenv(DefaultAPIKeyEnv),
-		APIUrl:     os.Getenv(DefaultAPIEndpointEnv),
-		Debug:      false,
-		HTTPClient: cleanhttp.DefaultPooledClient(),
-		UserAgent:  defaultUserAgent,
+		APIKey:           os.Getenv(DefaultAPIKeyEnv),
+		APIUrl:           os.Getenv(DefaultAPIEndpointEnv),
+		Debug:            false,
+		HTTPClient:       cleanhttp.DefaultPooledClient(),
+		UserAgent:        defaultUserAgent,
+		RateLimitRetries: limits.DefaultRateLimitRetries,
 	}
 
 	// if API Key is still unset, try using the legacy environment variable
@@ -117,6 +122,9 @@ func NewClientWithConfig(config *Config) (*Client, error) {
 	if config.HTTPClient != nil {
 		cfg.HTTPClient = config.HTTPClient
 	}
+	if config.RateLimitRetries != 0 {
+		cfg.RateLimitRetries = config.RateLimitRetries
+	}
 
 	if cfg.APIKey == "" {
 		return nil, errors.New("APIKey must be configured")
@@ -133,9 +141,10 @@ func NewClientWithConfig(config *Config) (*Client, error) {
 	}
 
 	// Proactively pace requests to stay within the API's advertised rate
-	// limits, falling back to the reactive backoff below for anything the
-	// gate cannot foresee.
-	cfg.HTTPClient.Transport = limits.NewRateLimitingTransport(cfg.HTTPClient.Transport)
+	// limits and absorb 429s (up to RateLimitRetries) by waiting out the
+	// window, falling back to the reactive backoff below for 5xx/transport
+	// errors.
+	cfg.HTTPClient.Transport = limits.NewRateLimitingTransport(cfg.HTTPClient.Transport, cfg.RateLimitRetries)
 
 	client.httpClient = &retryablehttp.Client{
 		Backoff:      limits.RetryHTTPBackoff,

--- a/client/internal/limits/limits.go
+++ b/client/internal/limits/limits.go
@@ -85,8 +85,14 @@ func rateLimitBackoff(mini, maxi time.Duration, r *http.Response) time.Duration 
 	return mini + jitter
 }
 
-// retryHTTPCheck is a retryablehttp.CheckRetry function that will
-// retry on a 429 or any 5xx status code
+// RetryHTTPCheck is a retryablehttp.CheckRetry function that retries on
+// transport errors and any 5xx status code.
+//
+// HTTP 429s are deliberately not retried here: the RateLimitingTransport sits
+// below retryablehttp and absorbs rate limiting itself (waiting out the window
+// and replaying the request up to its configured limit), so by the time a 429
+// reaches this check that budget is already spent and the response should be
+// surfaced rather than retried again.
 func RetryHTTPCheck(
 	ctx context.Context,
 	r *http.Response,
@@ -99,7 +105,7 @@ func RetryHTTPCheck(
 		return true, err
 	}
 	if r != nil {
-		if r.StatusCode == http.StatusTooManyRequests || r.StatusCode >= 500 {
+		if r.StatusCode >= 500 {
 			return true, nil
 		}
 	}

--- a/client/internal/limits/ratelimiter.go
+++ b/client/internal/limits/ratelimiter.go
@@ -210,10 +210,13 @@ func (t *RateLimitingTransport) acquire(ctx context.Context, b *bucket) error {
 // observe updates the bucket from a response's rate limit headers. Responses
 // without usable headers leave the bucket unchanged.
 //
-// The server's remaining count is authoritative and overwrites our local
-// estimate. Requests still in flight when this response was produced are not
-// yet reflected in it, so the estimate can run briefly optimistic under high
-// concurrency; the reactive backoff absorbs the occasional resulting 429.
+// The server's reported remaining count is taken as the latest truth. Under
+// concurrency, responses arrive out of order and several requests are in flight
+// at once, so the gate's view is necessarily approximate and it can admit a
+// little more than a window strictly allows. That is fine by design: the
+// resulting 429s are absorbed (see RoundTrip), so over-issuing costs some extra
+// waiting, never a failure. The gate keeps the common case smooth; it is not a
+// perfect distributed counter.
 func (b *bucket) observe(h http.Header, now time.Time) {
 	v := h.Get(HeaderRateLimit)
 	if v == "" {

--- a/client/internal/limits/ratelimiter.go
+++ b/client/internal/limits/ratelimiter.go
@@ -1,0 +1,264 @@
+package limits
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/dunglas/httpsfv"
+)
+
+// errInvalidPolicy is returned when the RateLimit-Policy header is missing or
+// cannot be parsed into a usable window.
+var errInvalidPolicy = errors.New("invalid ratelimit policy header")
+
+const (
+	// HeaderRateLimitPolicy is the (draft07) IETF header describing the active
+	// rate limit policy. The value is a Structured Field list of Items, each
+	// whose value is the request limit and whose "w" parameter is the window
+	// length in seconds, e.g. "120;w=60".
+	HeaderRateLimitPolicy = "RateLimit-Policy"
+
+	// defaultWindow is assumed when the server does not advertise a window via
+	// the RateLimit-Policy header. Honeycomb's APIs use a one-minute window.
+	defaultWindow = time.Minute
+
+	// resetPadding is added to the time we wait for a window to reset. The
+	// server reports the reset as a whole number of seconds (truncated), so the
+	// true boundary can be up to a second later than reported; padding avoids
+	// waking early and immediately drawing a 429.
+	resetPadding = time.Second
+)
+
+// RateLimitingTransport is an http.RoundTripper that proactively keeps the
+// client within Honeycomb's advertised rate limits.
+//
+// Honeycomb enforces a fixed-window limit server-side, scoped per-team,
+// per-resource, and per-action: each window grants a fixed number of requests
+// (e.g. 120 reads/minute), refilled in full at the next window boundary rather
+// than trickled back continuously. Every response — including a 429 — reports
+// the active limit, the requests remaining in the window, and the seconds until
+// it resets, via the RateLimit and RateLimit-Policy headers.
+//
+// This transport mirrors that model. It keeps a per-(method, resource) bucket
+// seeded from those headers and, while a bucket still has budget, passes
+// requests straight through — so workloads that fit within the limit behave
+// exactly as they would without it. Only once a bucket's budget is exhausted
+// does it pause new requests until the window resets, then resume. This turns a
+// large plan, apply, or refresh from a burst of HTTP 429s and retry-backoff
+// into smooth, predictable throughput.
+//
+// It complements rather than replaces the reactive RetryHTTPBackoff: the gate
+// prevents the 429s it can foresee, and the backoff remains the safety net for
+// the first request to a bucket (before any limit is known) and for budget
+// shared with other clients.
+type RateLimitingTransport struct {
+	base  http.RoundTripper
+	clock func() time.Time
+	sleep func(context.Context, time.Duration) error
+
+	mu      sync.Mutex
+	buckets map[string]*bucket
+}
+
+// bucket tracks the server's reported rate limit state for a single
+// (method, resource) pair.
+type bucket struct {
+	mu sync.Mutex
+
+	known     bool          // whether the limit headers have been observed yet
+	limit     int           // requests permitted per window
+	remaining int           // requests remaining in the current window
+	window    time.Duration // length of the window
+	resetAt   time.Time     // when the current window resets
+}
+
+// NewRateLimitingTransport wraps base with proactive client-side rate limiting.
+// If base is nil, http.DefaultTransport is used.
+func NewRateLimitingTransport(base http.RoundTripper) *RateLimitingTransport {
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	return &RateLimitingTransport{
+		base:    base,
+		clock:   time.Now,
+		sleep:   sleepFor,
+		buckets: make(map[string]*bucket),
+	}
+}
+
+// RoundTrip waits until the bucket for this request has budget, performs the
+// request, and updates the bucket from the response's rate limit headers.
+func (t *RateLimitingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	b := t.bucketFor(bucketKey(req.Method, req.URL.Path))
+
+	if err := t.acquire(req.Context(), b); err != nil {
+		return nil, err
+	}
+
+	resp, err := t.base.RoundTrip(req)
+	if err != nil {
+		return resp, err
+	}
+
+	b.observe(resp.Header, t.clock())
+	return resp, nil
+}
+
+func (t *RateLimitingTransport) bucketFor(key string) *bucket {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if b, ok := t.buckets[key]; ok {
+		return b
+	}
+	b := &bucket{}
+	t.buckets[key] = b
+	return b
+}
+
+// acquire blocks until the bucket can admit another request. Until the first
+// response has been observed the limit is unknown and requests pass through
+// unimpeded, leaving the reactive backoff to handle any miss.
+func (t *RateLimitingTransport) acquire(ctx context.Context, b *bucket) error {
+	for {
+		b.mu.Lock()
+		now := t.clock()
+
+		if !b.known {
+			b.mu.Unlock()
+			return nil
+		}
+
+		// Roll the window over once we've reached its reset, optimistically
+		// assuming a full refill; the next observed response corrects it.
+		if !now.Before(b.resetAt) {
+			b.remaining = b.limit
+			b.resetAt = now.Add(b.window)
+		}
+
+		if b.remaining > 0 {
+			b.remaining--
+			b.mu.Unlock()
+			return nil
+		}
+
+		wait := b.resetAt.Sub(now) + resetPadding
+		b.mu.Unlock()
+
+		if err := t.sleep(ctx, wait); err != nil {
+			return err
+		}
+		// re-evaluate now that the window should have reset
+	}
+}
+
+// observe updates the bucket from a response's rate limit headers. Responses
+// without usable headers leave the bucket unchanged.
+//
+// The server's remaining count is authoritative and overwrites our local
+// estimate. Requests still in flight when this response was produced are not
+// yet reflected in it, so the estimate can run briefly optimistic under high
+// concurrency; the reactive backoff absorbs the occasional resulting 429.
+func (b *bucket) observe(h http.Header, now time.Time) {
+	v := h.Get(HeaderRateLimit)
+	if v == "" {
+		return
+	}
+	limit, remaining, reset, err := parseRateLimitHeader(v)
+	if err != nil {
+		return
+	}
+
+	window := defaultWindow
+	if w, err := parseRateLimitPolicyWindow(h.Get(HeaderRateLimitPolicy)); err == nil && w > 0 {
+		window = w
+	}
+
+	b.mu.Lock()
+	b.known = true
+	b.limit = int(limit)
+	b.remaining = int(remaining)
+	b.window = window
+	b.resetAt = now.Add(time.Duration(reset) * time.Second)
+	b.mu.Unlock()
+}
+
+// bucketKey derives a rate limit bucket from the request method and path.
+//
+// Honeycomb scopes its limits per-resource, so the API version and resource
+// collection — the first two path segments — form the bucket. All
+// "/1/triggers/<dataset>" requests therefore share a bucket, mirroring the
+// server's per-target accounting, while e.g. triggers and SLOs are paced
+// independently.
+func bucketKey(method, path string) string {
+	segs := strings.SplitN(strings.TrimPrefix(path, "/"), "/", 3)
+
+	var resource string
+	switch {
+	case len(segs) >= 2:
+		resource = segs[0] + "/" + segs[1]
+	case len(segs) == 1:
+		resource = segs[0]
+	}
+
+	return method + " " + resource
+}
+
+// parseRateLimitPolicyWindow returns the window length from a RateLimit-Policy
+// header value such as "120;w=60". When several policies are listed the
+// shortest window is used, as that is the binding constraint for pacing.
+func parseRateLimitPolicyWindow(h string) (time.Duration, error) {
+	if h == "" {
+		return 0, errInvalidPolicy
+	}
+
+	list, err := httpsfv.UnmarshalList([]string{h})
+	if err != nil {
+		return 0, errInvalidPolicy
+	}
+
+	var shortest time.Duration
+	for _, member := range list {
+		item, isItem := member.(httpsfv.Item)
+		if !isItem {
+			continue
+		}
+		w, ok := item.Params.Get("w")
+		if !ok {
+			continue
+		}
+		seconds, ok := w.(int64)
+		if !ok || seconds <= 0 {
+			continue
+		}
+		window := time.Duration(seconds) * time.Second
+		if shortest == 0 || window < shortest {
+			shortest = window
+		}
+	}
+
+	if shortest == 0 {
+		return 0, errInvalidPolicy
+	}
+	return shortest, nil
+}
+
+// sleepFor blocks for d or until ctx is cancelled, whichever comes first.
+func sleepFor(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/client/internal/limits/ratelimiter.go
+++ b/client/internal/limits/ratelimiter.go
@@ -1,8 +1,10 @@
 package limits
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"io"
 	"net/http"
 	"strings"
 	"sync"
@@ -31,6 +33,13 @@ const (
 	// true boundary can be up to a second later than reported; padding avoids
 	// waking early and immediately drawing a 429.
 	resetPadding = time.Second
+
+	// DefaultRateLimitRetries is the default number of times a rate-limited
+	// (HTTP 429) request is replayed — waiting out the window each time —
+	// before the 429 is surfaced. It matches the prior reactive retry budget so
+	// the default behaviour is unchanged; raise it (via the provider's
+	// rate_limit_retries) to ride out more contention without failing.
+	DefaultRateLimitRetries = 10
 )
 
 // RateLimitingTransport is an http.RoundTripper that proactively keeps the
@@ -51,14 +60,20 @@ const (
 // large plan, apply, or refresh from a burst of HTTP 429s and retry-backoff
 // into smooth, predictable throughput.
 //
-// It complements rather than replaces the reactive RetryHTTPBackoff: the gate
-// prevents the 429s it can foresee, and the backoff remains the safety net for
-// the first request to a bucket (before any limit is known) and for budget
-// shared with other clients.
+// The gate prevents the 429s it can foresee. For those it cannot — the first
+// request to a bucket before any limit is known, or budget shared with other
+// concurrent clients — the transport treats a 429 not as a failure but as the
+// server saying "come back when the window resets": it waits out the window and
+// replays the request, up to maxRetries times. Because a rate-limited request
+// is retried rather than failed, contention slows a run down instead of
+// breaking it. maxRetries bounds this so a pathologically starved request still
+// eventually surfaces the 429 (real, non-rate-limit errors and 5xx remain the
+// job of the reactive RetryHTTPBackoff).
 type RateLimitingTransport struct {
-	base  http.RoundTripper
-	clock func() time.Time
-	sleep func(context.Context, time.Duration) error
+	base       http.RoundTripper
+	clock      func() time.Time
+	sleep      func(context.Context, time.Duration) error
+	maxRetries int
 
 	mu      sync.Mutex
 	buckets map[string]*bucket
@@ -77,35 +92,71 @@ type bucket struct {
 }
 
 // NewRateLimitingTransport wraps base with proactive client-side rate limiting.
-// If base is nil, http.DefaultTransport is used.
-func NewRateLimitingTransport(base http.RoundTripper) *RateLimitingTransport {
+// If base is nil, http.DefaultTransport is used. maxRetries bounds how many
+// times a 429'd request is replayed (waiting out the window each time) before
+// the 429 is surfaced; values <= 0 fall back to DefaultRateLimitRetries.
+func NewRateLimitingTransport(base http.RoundTripper, maxRetries int) *RateLimitingTransport {
 	if base == nil {
 		base = http.DefaultTransport
 	}
+	if maxRetries <= 0 {
+		maxRetries = DefaultRateLimitRetries
+	}
 	return &RateLimitingTransport{
-		base:    base,
-		clock:   time.Now,
-		sleep:   sleepFor,
-		buckets: make(map[string]*bucket),
+		base:       base,
+		clock:      time.Now,
+		sleep:      sleepFor,
+		maxRetries: maxRetries,
+		buckets:    make(map[string]*bucket),
 	}
 }
 
-// RoundTrip waits until the bucket for this request has budget, performs the
-// request, and updates the bucket from the response's rate limit headers.
+// RoundTrip paces the request against its bucket, performs it, and updates the
+// bucket from the response headers. A 429 is absorbed — the window is waited
+// out and the request replayed — up to maxRetries times before being surfaced.
 func (t *RateLimitingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	b := t.bucketFor(bucketKey(req.Method, req.URL.Path))
 
-	if err := t.acquire(req.Context(), b); err != nil {
-		return nil, err
+	// Buffer the body so the request can be replayed across rate-limit waits.
+	// Request bodies here are small JSON payloads.
+	var body []byte
+	if req.Body != nil && req.Body != http.NoBody {
+		var err error
+		if body, err = io.ReadAll(req.Body); err != nil {
+			_ = req.Body.Close()
+			return nil, err
+		}
+		_ = req.Body.Close()
 	}
-
-	resp, err := t.base.RoundTrip(req)
-	if err != nil {
-		return resp, err
+	rewind := func() {
+		if body != nil {
+			req.Body = io.NopCloser(bytes.NewReader(body))
+		}
 	}
+	rewind()
 
-	b.observe(resp.Header, t.clock())
-	return resp, nil
+	for attempt := 0; ; attempt++ {
+		if err := t.acquire(req.Context(), b); err != nil {
+			return nil, err
+		}
+
+		resp, err := t.base.RoundTrip(req)
+		if err != nil {
+			return resp, err
+		}
+		b.observe(resp.Header, t.clock())
+
+		if resp.StatusCode != http.StatusTooManyRequests || attempt >= t.maxRetries {
+			return resp, nil
+		}
+
+		// Absorb the 429: make sure the bucket will block until the window
+		// resets (observe has normally recorded it; ensureBlocked is a guard for
+		// a 429 that arrives without usable headers), then replay the request.
+		b.ensureBlocked(resp.Header, t.clock())
+		drainClose(resp.Body)
+		rewind()
+	}
 }
 
 func (t *RateLimitingTransport) bucketFor(key string) *bucket {
@@ -187,6 +238,35 @@ func (b *bucket) observe(h http.Header, now time.Time) {
 	b.mu.Unlock()
 }
 
+// ensureBlocked guarantees the bucket will make the next acquire wait, so a 429
+// is never replayed in a hot loop. Normally observe has already recorded a
+// future reset from the RateLimit header; this only acts when a 429 arrived
+// without usable headers, falling back to the Retry-After value or one window.
+func (b *bucket) ensureBlocked(h http.Header, now time.Time) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.known && b.remaining <= 0 && b.resetAt.After(now) {
+		return
+	}
+
+	wait := defaultWindow
+	if ra := h.Get(HeaderRetryAfter); ra != "" {
+		if when, err := time.Parse(http.TimeFormat, ra); err == nil {
+			if d := when.Sub(now); d > 0 {
+				wait = d
+			}
+		}
+	}
+
+	b.known = true
+	b.remaining = 0
+	if b.window == 0 {
+		b.window = defaultWindow
+	}
+	b.resetAt = now.Add(wait)
+}
+
 // bucketKey derives a rate limit bucket from the request method and path.
 //
 // Honeycomb scopes its limits per-resource, so the API version and resource
@@ -260,5 +340,14 @@ func sleepFor(ctx context.Context, d time.Duration) error {
 		return ctx.Err()
 	case <-timer.C:
 		return nil
+	}
+}
+
+// drainClose drains and closes a response body so its connection can be reused
+// before the request is replayed.
+func drainClose(rc io.ReadCloser) {
+	if rc != nil {
+		_, _ = io.Copy(io.Discard, rc)
+		_ = rc.Close()
 	}
 }

--- a/client/internal/limits/ratelimiter_test.go
+++ b/client/internal/limits/ratelimiter_test.go
@@ -163,7 +163,7 @@ func (s *fakeFixedWindow) RoundTrip(req *http.Request) (*http.Response, error) {
 // newTestTransport wraps base in a RateLimitingTransport driven by a virtual
 // clock that only advances when the gate sleeps, making pacing deterministic.
 func newTestTransport(base http.RoundTripper, now *time.Time) *RateLimitingTransport {
-	tr := NewRateLimitingTransport(base)
+	tr := NewRateLimitingTransport(base, DefaultRateLimitRetries)
 	tr.clock = func() time.Time { return *now }
 	tr.sleep = func(_ context.Context, d time.Duration) error {
 		*now = now.Add(d)
@@ -256,7 +256,7 @@ func TestRateLimitingTransport_ContextCancelledWhileWaiting(t *testing.T) {
 	now := start
 
 	srv := &fakeFixedWindow{limit: 1, window: time.Minute, clock: func() time.Time { return now }}
-	tr := NewRateLimitingTransport(srv)
+	tr := NewRateLimitingTransport(srv, DefaultRateLimitRetries)
 	tr.clock = func() time.Time { return now }
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -277,4 +277,70 @@ func TestRateLimitingTransport_ContextCancelledWhileWaiting(t *testing.T) {
 	require.NoError(t, err)
 	_, err = tr.RoundTrip(req2)
 	assert.ErrorIs(t, err, context.Canceled)
+}
+
+// roundTripFunc adapts a function to an http.RoundTripper.
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func TestRateLimitingTransport_Absorbs429(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	now := start
+
+	// First call is rate limited; the retry succeeds.
+	calls := 0
+	base := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		calls++
+		h := make(http.Header)
+		h.Set(HeaderRateLimitPolicy, "120;w=60")
+		if calls == 1 {
+			h.Set(HeaderRateLimit, "limit=120, remaining=0, reset=30")
+			return &http.Response{StatusCode: http.StatusTooManyRequests, Header: h, Body: http.NoBody, Request: r}, nil
+		}
+		h.Set(HeaderRateLimit, "limit=120, remaining=119, reset=60")
+		return &http.Response{StatusCode: http.StatusOK, Header: h, Body: http.NoBody, Request: r}, nil
+	})
+
+	tr := newTestTransport(base, &now)
+
+	req, err := http.NewRequest(http.MethodGet, "https://api.honeycomb.io/1/triggers/x", nil)
+	require.NoError(t, err)
+	resp, err := tr.RoundTrip(req)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode, "the 429 should be absorbed and the request retried")
+	assert.Equal(t, 2, calls)
+	assert.GreaterOrEqual(t, now.Sub(start), 30*time.Second, "should have waited out the window before retrying")
+}
+
+func TestRateLimitingTransport_AbsorbRespectsMax(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	now := start
+
+	// Always rate limited: the transport should give up after maxRetries and
+	// surface the 429 rather than looping forever.
+	calls := 0
+	base := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		calls++
+		h := make(http.Header)
+		h.Set(HeaderRateLimitPolicy, "120;w=60")
+		h.Set(HeaderRateLimit, "limit=120, remaining=0, reset=1")
+		return &http.Response{StatusCode: http.StatusTooManyRequests, Header: h, Body: http.NoBody, Request: r}, nil
+	})
+
+	tr := newTestTransport(base, &now)
+	tr.maxRetries = 2
+
+	req, err := http.NewRequest(http.MethodGet, "https://api.honeycomb.io/1/triggers/x", nil)
+	require.NoError(t, err)
+	resp, err := tr.RoundTrip(req)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusTooManyRequests, resp.StatusCode, "after maxRetries the 429 should surface")
+	assert.Equal(t, 3, calls, "1 initial attempt + 2 retries")
 }

--- a/client/internal/limits/ratelimiter_test.go
+++ b/client/internal/limits/ratelimiter_test.go
@@ -3,8 +3,10 @@ package limits
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"net/http"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -343,4 +345,168 @@ func TestRateLimitingTransport_AbsorbRespectsMax(t *testing.T) {
 
 	assert.Equal(t, http.StatusTooManyRequests, resp.StatusCode, "after maxRetries the 429 should surface")
 	assert.Equal(t, 3, calls, "1 initial attempt + 2 retries")
+}
+
+// reorderingTransport delays each response by a small random amount *after* the
+// inner transport has produced it. The fake server stamps each response's
+// "remaining" count at processing time, so delaying delivery shuffles the order
+// in which the gate observes those counts relative to the order they were
+// produced. That reproduces the real-world condition — stale, out-of-order
+// rate limit observations — that stresses the gate's bookkeeping under
+// concurrency, rather than relying on incidental goroutine scheduling.
+type reorderingTransport struct {
+	inner http.RoundTripper
+	max   time.Duration
+}
+
+func (r *reorderingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := r.inner.RoundTrip(req)
+	if err == nil && r.max > 0 {
+		//nolint:gosec // non-cryptographic jitter is fine for a test
+		time.Sleep(time.Duration(rand.Int63n(int64(r.max))))
+	}
+	return resp, err
+}
+
+// scaledClock reports a simulated time that advances at a fixed multiple of
+// real time. It lets the test use a realistic minute-long window — so the
+// integer-second RateLimit/reset headers stay meaningful, exactly as in
+// production — while the whole test still completes in milliseconds. It is safe
+// for concurrent use: Now derives purely from the (immutable) real start time,
+// with no shared mutable state.
+type scaledClock struct {
+	realStart time.Time
+	simStart  time.Time
+	scale     int64 // simulated nanoseconds per real nanosecond
+}
+
+func newScaledClock(scale int64) *scaledClock {
+	return &scaledClock{
+		realStart: time.Now(),
+		simStart:  time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		scale:     scale,
+	}
+}
+
+func (c *scaledClock) Now() time.Time {
+	return c.simStart.Add(time.Since(c.realStart) * time.Duration(c.scale))
+}
+
+// sleep blocks for the real-time equivalent of a simulated duration.
+func (c *scaledClock) sleep(ctx context.Context, sim time.Duration) error {
+	return sleepFor(ctx, sim/time.Duration(c.scale))
+}
+
+// TestRateLimitingTransport_ConcurrentLoad drives the gate the way Terraform
+// does: many goroutines hammering a single bucket at once (mirroring
+// -parallelism) with out-of-order rate limit observations.
+//
+// Under concurrency the gate's view is approximate, so the server will reject
+// some requests — that is expected and acceptable. What this test guarantees is
+// that those 429s are absorbed and replayed, so no job fails. (That the gate
+// *prevents* 429s in the first place is shown by
+// TestRateLimitingTransport_GateAvoidsBurstRejections.)
+func TestRateLimitingTransport_ConcurrentLoad(t *testing.T) {
+	t.Parallel()
+
+	const (
+		limit   = 30          // per-window server budget
+		window  = time.Minute // realistic window; integer-second headers stay meaningful
+		workers = 10          // < limit, mirrors Terraform parallelism below the budget
+		jobs    = 150         // > limit, forces pacing across several windows
+	)
+
+	clk := newScaledClock(1000) // 1ms real == 1s simulated: a 60s window elapses in 60ms
+	srv := &fakeFixedWindow{limit: limit, window: window, clock: clk.Now}
+	base := &reorderingTransport{inner: srv, max: 200 * time.Microsecond}
+	tr := NewRateLimitingTransport(base, DefaultRateLimitRetries)
+	tr.clock = clk.Now
+	tr.sleep = clk.sleep
+
+	work := make(chan int, jobs)
+	for i := range jobs {
+		work <- i
+	}
+	close(work)
+
+	var wg sync.WaitGroup
+	var got200, got429 int64
+	for range workers {
+		wg.Go(func() {
+			for range work {
+				req, err := http.NewRequest(http.MethodGet, "https://api.honeycomb.io/1/triggers/__all__", nil)
+				if err != nil {
+					t.Errorf("building request: %v", err)
+					return
+				}
+				resp, err := tr.RoundTrip(req)
+				if err != nil {
+					t.Errorf("RoundTrip: %v", err)
+					return
+				}
+				switch resp.StatusCode {
+				case http.StatusOK:
+					atomic.AddInt64(&got200, 1)
+				case http.StatusTooManyRequests:
+					atomic.AddInt64(&got429, 1)
+				}
+			}
+		})
+	}
+	wg.Wait()
+
+	require.Equal(t, int64(jobs), got200+got429, "every job should produce a response")
+	assert.Zerof(t, got429,
+		"client saw %d unrecovered HTTP 429(s): a job failed under concurrency instead of being retried", got429)
+
+	// Server-side rejections are expected here and are not a failure: they were
+	// absorbed and replayed. Logged for visibility into how much the gate
+	// over-issued under this load.
+	srv.mu.Lock()
+	rejected := srv.rejected
+	srv.mu.Unlock()
+	t.Logf("server rejected %d/%d request(s) under concurrency; all were absorbed", rejected, jobs)
+}
+
+// TestRateLimitingTransport_GateAvoidsBurstRejections shows the gate doing its
+// job. Given a burst that oversubscribes a window's budget, the gate paces the
+// requests across windows so the server rejects none — whereas the same burst
+// sent without the gate piles into a single window and most are rejected. This
+// is the proactive value the gate adds on top of the (reactive) 429 absorb.
+func TestRateLimitingTransport_GateAvoidsBurstRejections(t *testing.T) {
+	t.Parallel()
+
+	const (
+		limit  = 20
+		window = time.Minute
+		jobs   = 100
+	)
+
+	sendAll := func(rt http.RoundTripper) {
+		for range jobs {
+			req, err := http.NewRequest(http.MethodGet, "https://api.honeycomb.io/1/triggers/__all__", nil)
+			require.NoError(t, err)
+			resp, err := rt.RoundTrip(req)
+			require.NoError(t, err)
+			_ = resp.Body.Close()
+		}
+	}
+
+	// Without the gate: a fast burst with no pacing. Time is frozen, modelling
+	// every request landing within a single window — so only one window's budget
+	// succeeds and the rest are rejected.
+	frozen := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	naive := &fakeFixedWindow{limit: limit, window: window, clock: func() time.Time { return frozen }}
+	sendAll(naive)
+
+	// With the gate: the same load, paced. A virtual clock advances only when the
+	// gate sleeps, so the burst is spread across windows and nothing is rejected.
+	now := frozen
+	gated := &fakeFixedWindow{limit: limit, window: window, clock: func() time.Time { return now }}
+	sendAll(newTestTransport(gated, &now))
+
+	assert.Equal(t, jobs-limit, naive.rejected,
+		"without the gate, every request beyond the first window's budget is rejected")
+	assert.Zero(t, gated.rejected,
+		"with the gate, the burst is paced across windows and the server rejects nothing")
 }

--- a/client/internal/limits/ratelimiter_test.go
+++ b/client/internal/limits/ratelimiter_test.go
@@ -1,0 +1,280 @@
+package limits
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBucketKey(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		method string
+		path   string
+		want   string
+	}{
+		{"v1 collection", http.MethodGet, "/1/triggers/__all__", "GET 1/triggers"},
+		{"v1 item", http.MethodPut, "/1/slos/prod/abc123", "PUT 1/slos"},
+		{"v1 create", http.MethodPost, "/1/burn_alerts/prod", "POST 1/burn_alerts"},
+		{"v2 nested", http.MethodGet, "/2/teams/foo/api-keys", "GET 2/teams"},
+		{"single segment", http.MethodGet, "/1", "GET 1"},
+		{"no leading slash", http.MethodGet, "1/triggers/ds", "GET 1/triggers"},
+		{"empty path", http.MethodGet, "", "GET "},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, bucketKey(tc.method, tc.path))
+		})
+	}
+}
+
+func TestParseRateLimitPolicyWindow(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		header  string
+		want    time.Duration
+		wantErr bool
+	}{
+		{"single policy", "120;w=60", time.Minute, false},
+		{"shortest of several", "100;w=100, 1000;w=3600", 100 * time.Second, false},
+		{"empty", "", 0, true},
+		{"no window param", "120", 0, true},
+		{"garbage", "not a header", 0, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseRateLimitPolicyWindow(tc.header)
+			if tc.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestBucketObserve(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	t.Run("seeds from headers", func(t *testing.T) {
+		var b bucket
+		h := make(http.Header)
+		h.Set(HeaderRateLimit, "limit=120, remaining=42, reset=30")
+		h.Set(HeaderRateLimitPolicy, "120;w=60")
+
+		b.observe(h, now)
+
+		assert.True(t, b.known)
+		assert.Equal(t, 120, b.limit)
+		assert.Equal(t, 42, b.remaining)
+		assert.Equal(t, time.Minute, b.window)
+		assert.Equal(t, now.Add(30*time.Second), b.resetAt)
+	})
+
+	t.Run("defaults window when policy absent", func(t *testing.T) {
+		var b bucket
+		h := make(http.Header)
+		h.Set(HeaderRateLimit, "limit=100, remaining=10, reset=15")
+
+		b.observe(h, now)
+
+		assert.Equal(t, defaultWindow, b.window)
+	})
+
+	t.Run("ignores responses without rate limit headers", func(t *testing.T) {
+		var b bucket
+		b.observe(make(http.Header), now)
+		assert.False(t, b.known)
+	})
+}
+
+// fakeFixedWindow is an http.RoundTripper that emulates Honeycomb's
+// server-side fixed-window limiter: a fixed budget per window, scoped
+// per-resource exactly as the real server scopes per-target, refilled in full
+// at the next window boundary, advertising the standard RateLimit headers and
+// returning 429 when the budget is exhausted.
+type fakeFixedWindow struct {
+	limit  int
+	window time.Duration
+	clock  func() time.Time
+
+	mu       sync.Mutex
+	windows  map[string]*serverWindow
+	rejected int
+}
+
+type serverWindow struct {
+	end       time.Time
+	remaining int
+}
+
+func (s *fakeFixedWindow) RoundTrip(req *http.Request) (*http.Response, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.windows == nil {
+		s.windows = make(map[string]*serverWindow)
+	}
+
+	now := s.clock()
+	key := bucketKey(req.Method, req.URL.Path)
+	w := s.windows[key]
+	if w == nil || now.After(w.end) {
+		w = &serverWindow{end: now.Add(s.window), remaining: s.limit}
+		s.windows[key] = w
+	}
+
+	status := http.StatusOK
+	if w.remaining > 0 {
+		w.remaining--
+	} else {
+		s.rejected++
+		status = http.StatusTooManyRequests
+	}
+
+	resetSecs := int(w.end.Sub(now).Seconds())
+	h := make(http.Header)
+	h.Set(HeaderRateLimit, fmt.Sprintf("limit=%d, remaining=%d, reset=%d", s.limit, w.remaining, resetSecs))
+	h.Set(HeaderRateLimitPolicy, fmt.Sprintf("%d;w=%d", s.limit, int(s.window.Seconds())))
+
+	return &http.Response{
+		StatusCode: status,
+		Header:     h,
+		Body:       http.NoBody,
+		Request:    req,
+	}, nil
+}
+
+// newTestTransport wraps base in a RateLimitingTransport driven by a virtual
+// clock that only advances when the gate sleeps, making pacing deterministic.
+func newTestTransport(base http.RoundTripper, now *time.Time) *RateLimitingTransport {
+	tr := NewRateLimitingTransport(base)
+	tr.clock = func() time.Time { return *now }
+	tr.sleep = func(_ context.Context, d time.Duration) error {
+		*now = now.Add(d)
+		return nil
+	}
+	return tr
+}
+
+func TestRateLimitingTransport_GatesOnBudget(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	now := start
+
+	srv := &fakeFixedWindow{limit: 3, window: time.Minute, clock: func() time.Time { return now }}
+	tr := newTestTransport(srv, &now)
+
+	const n = 10
+	for i := 0; i < n; i++ {
+		req, err := http.NewRequest(http.MethodGet, "https://api.honeycomb.io/1/triggers/__all__", nil)
+		require.NoError(t, err)
+
+		resp, err := tr.RoundTrip(req)
+		require.NoError(t, err)
+		require.Equalf(t, http.StatusOK, resp.StatusCode, "request %d was rate limited", i)
+	}
+
+	// With a budget of 3/window, 10 requests span 4 windows, so the gate must
+	// have paused across 3 window boundaries — and never drawn a 429.
+	assert.Zero(t, srv.rejected, "gate should have prevented every 429")
+	assert.GreaterOrEqual(t, now.Sub(start), 3*srv.window)
+}
+
+func TestRateLimitingTransport_PassesThroughWithinBudget(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	now := start
+
+	// Budget comfortably exceeds the number of requests: nothing should pause.
+	srv := &fakeFixedWindow{limit: 120, window: time.Minute, clock: func() time.Time { return now }}
+	tr := newTestTransport(srv, &now)
+
+	for i := 0; i < 20; i++ {
+		req, err := http.NewRequest(http.MethodGet, "https://api.honeycomb.io/1/triggers/__all__", nil)
+		require.NoError(t, err)
+
+		resp, err := tr.RoundTrip(req)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+	}
+
+	assert.Equal(t, start, now, "no pacing should occur while within budget")
+	assert.Zero(t, srv.rejected)
+}
+
+func TestRateLimitingTransport_SeparateBucketsPerResource(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	now := start
+
+	srv := &fakeFixedWindow{limit: 2, window: time.Minute, clock: func() time.Time { return now }}
+	tr := newTestTransport(srv, &now)
+
+	// Alternating between two resources should let four requests through
+	// without pausing, since each resource has its own budget of two.
+	paths := []string{
+		"https://api.honeycomb.io/1/triggers/__all__",
+		"https://api.honeycomb.io/1/slos/__all__",
+		"https://api.honeycomb.io/1/triggers/__all__",
+		"https://api.honeycomb.io/1/slos/__all__",
+	}
+	for _, p := range paths {
+		req, err := http.NewRequest(http.MethodGet, p, nil)
+		require.NoError(t, err)
+
+		resp, err := tr.RoundTrip(req)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+	}
+
+	assert.Equal(t, start, now, "independent buckets should not pace each other")
+}
+
+func TestRateLimitingTransport_ContextCancelledWhileWaiting(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	now := start
+
+	srv := &fakeFixedWindow{limit: 1, window: time.Minute, clock: func() time.Time { return now }}
+	tr := NewRateLimitingTransport(srv)
+	tr.clock = func() time.Time { return now }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	tr.sleep = func(_ context.Context, _ time.Duration) error {
+		// Simulate the caller cancelling the context while the gate is waiting.
+		cancel()
+		return ctx.Err()
+	}
+
+	// First request consumes the only token in the window.
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.honeycomb.io/1/triggers/__all__", nil)
+	require.NoError(t, err)
+	_, err = tr.RoundTrip(req)
+	require.NoError(t, err)
+
+	// Second request must wait for the window to reset; cancellation aborts it.
+	req2, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.honeycomb.io/1/triggers/__all__", nil)
+	require.NoError(t, err)
+	_, err = tr.RoundTrip(req2)
+	assert.ErrorIs(t, err, context.Canceled)
+}

--- a/client/v2/client.go
+++ b/client/v2/client.go
@@ -37,6 +37,10 @@ type Config struct {
 	Debug        bool
 	HTTPClient   *http.Client
 	UserAgent    string
+	// Number of times a rate-limited (HTTP 429) request is replayed — waiting
+	// out the window each time — before the 429 is surfaced. 0 uses
+	// limits.DefaultRateLimitRetries.
+	RateLimitRetries int
 }
 
 type Client struct {
@@ -118,13 +122,14 @@ func NewClientWithConfig(config *Config) (*Client, error) {
 		},
 	}
 	// Proactively pace requests to stay within the API's advertised rate
-	// limits, falling back to the reactive backoff below for anything the
-	// gate cannot foresee.
+	// limits and absorb 429s (up to RateLimitRetries) by waiting out the
+	// window, falling back to the reactive backoff below for 5xx/transport
+	// errors.
 	httpClient := config.HTTPClient
 	if httpClient == nil {
 		httpClient = cleanhttp.DefaultPooledClient()
 	}
-	httpClient.Transport = limits.NewRateLimitingTransport(httpClient.Transport)
+	httpClient.Transport = limits.NewRateLimitingTransport(httpClient.Transport, config.RateLimitRetries)
 
 	client.http = &retryablehttp.Client{
 		Backoff:      limits.RetryHTTPBackoff,

--- a/client/v2/client.go
+++ b/client/v2/client.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	cleanhttp "github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/hashicorp/jsonapi"
 
@@ -116,11 +117,20 @@ func NewClientWithConfig(config *Config) (*Client, error) {
 			"User-Agent":    {config.UserAgent},
 		},
 	}
+	// Proactively pace requests to stay within the API's advertised rate
+	// limits, falling back to the reactive backoff below for anything the
+	// gate cannot foresee.
+	httpClient := config.HTTPClient
+	if httpClient == nil {
+		httpClient = cleanhttp.DefaultPooledClient()
+	}
+	httpClient.Transport = limits.NewRateLimitingTransport(httpClient.Transport)
+
 	client.http = &retryablehttp.Client{
 		Backoff:      limits.RetryHTTPBackoff,
 		CheckRetry:   limits.RetryHTTPCheck,
 		ErrorHandler: retryablehttp.PassthroughErrorHandler,
-		HTTPClient:   config.HTTPClient,
+		HTTPClient:   httpClient,
 		RetryWaitMin: 200 * time.Millisecond,
 		RetryWaitMax: time.Minute,
 		RetryMax:     10,

--- a/docs/index.md
+++ b/docs/index.md
@@ -97,6 +97,19 @@ The key pair can be set with the `api_key_id` and `api_key_secret` arguments, or
 
 ~> **Note** Hard-coding API keys in any Terraform configuration is not recommended. Consider using the one of the environment variable options.
 
+## Rate Limiting
+
+The Honeycomb API enforces per-team rate limits, scoped per-resource and per-action (for example, reads of triggers are limited independently of reads of SLOs).
+Each limit is a fixed budget of requests per minute that is replenished at the start of each minute.
+
+The provider paces itself to stay within these limits automatically — no configuration is required.
+It reads the rate limit reported on each API response and, when a resource's budget for the current window is exhausted, briefly pauses requests to that resource until the window resets, then resumes.
+Workloads that fit within the limit are unaffected; large plans, applies, or refreshes are smoothed out rather than failing with `HTTP 429` errors.
+
+Because the limits are enforced **per-team**, all Environments managed under the same team share a budget.
+If you run several `terraform` operations against the same team concurrently, they share that budget and may still encounter rate limiting; reducing `-parallelism` or the number of concurrent runs can help.
+If you consistently hit rate limits, contact Honeycomb Support to discuss raising your team's limits.
+
 ## Argument Reference
 
 Arguments accepted by this provider include:

--- a/docs/index.md
+++ b/docs/index.md
@@ -103,12 +103,15 @@ The Honeycomb API enforces per-team rate limits, scoped per-resource and per-act
 Each limit is a fixed budget of requests per minute that is replenished at the start of each minute.
 
 The provider paces itself to stay within these limits automatically — no configuration is required.
-It reads the rate limit reported on each API response and, when a resource's budget for the current window is exhausted, briefly pauses requests to that resource until the window resets, then resumes.
-Workloads that fit within the limit are unaffected; large plans, applies, or refreshes are smoothed out rather than failing with `HTTP 429` errors.
+It reads the rate limit reported on each API response and, when a resource's budget for the current window is exhausted, pauses requests to that resource until the window resets, then resumes.
+Workloads that fit within the limit are unaffected.
+
+If a request is rate limited anyway, the provider treats the `HTTP 429` as "try again when the window resets" rather than as a failure: it waits out the window and replays the request, up to `rate_limit_retries` times (default `10`).
+This means rate limiting slows a run down instead of failing it.
 
 Because the limits are enforced **per-team**, all Environments managed under the same team share a budget.
-If you run several `terraform` operations against the same team concurrently, they share that budget and may still encounter rate limiting; reducing `-parallelism` or the number of concurrent runs can help.
-If you consistently hit rate limits, contact Honeycomb Support to discuss raising your team's limits.
+If you run several `terraform` operations against the same team concurrently, they share that budget — each run paces itself, but collectively they can still exceed the limit and spend longer retrying.
+For that case, raising `rate_limit_retries` keeps runs from failing (at the cost of slower runs); reducing `-parallelism` or the number of concurrent runs reduces the contention; and if you consistently hit limits, contact Honeycomb Support to discuss raising your team's limits.
 
 ## Argument Reference
 
@@ -119,6 +122,7 @@ Arguments accepted by this provider include:
 * `api_key_secret` - (Optional) The secret portion of the Honeycomb Management API key to use. It can also be set via the `HONEYCOMB_KEY_SECRET` environment variable.
 * `api_url` - (Optional) Override the URL of the Honeycomb.io API. It can also be set using `HONEYCOMB_API_ENDPOINT`. Defaults to `https://api.honeycomb.io`.
 * `debug` - (Optional) Enable to log additional debug information. To view the logs, set `TF_LOG` to at least debug.
+* `rate_limit_retries` - (Optional) The number of times a rate-limited (`HTTP 429`) request is replayed — waiting out the rate limit window each time — before the error is surfaced. Increase this to ride out heavier rate-limit contention without failing, at the cost of slower runs. It can also be set using `HONEYCOMB_RATE_LIMIT_RETRIES`. Defaults to `10`.
 * `features` - (Optional) The features block allows customization of the behavior of the Honeycomb Provider. Full details documented below.
 
 At least one of `api_key`, or the `api_key_id` and `api_key_secret` pair must be configured.

--- a/docs/index.md
+++ b/docs/index.md
@@ -100,10 +100,10 @@ The key pair can be set with the `api_key_id` and `api_key_secret` arguments, or
 ## Rate Limiting
 
 The Honeycomb API enforces per-team rate limits, scoped per-resource and per-action (for example, reads of triggers are limited independently of reads of SLOs).
-Each limit is a fixed budget of requests per minute that is replenished at the start of each minute.
+Each limit is a fixed budget of requests per window — one minute — refilled in full when the window resets.
 
 The provider paces itself to stay within these limits automatically — no configuration is required.
-It reads the rate limit reported on each API response and, when a resource's budget for the current window is exhausted, pauses requests to that resource until the window resets, then resumes.
+It reads the rate limit headers returned on each API response, and when a resource's budget for the current window is exhausted it pauses requests to that resource until the window resets, then resumes.
 Workloads that fit within the limit are unaffected.
 
 If a request is rate limited anyway, the provider treats the `HTTP 429` as "try again when the window resets" rather than as a failure: it waits out the window and replays the request, up to `rate_limit_retries` times (default `10`).

--- a/honeycombio/provider.go
+++ b/honeycombio/provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -50,6 +51,11 @@ func Provider(version string) *schema.Provider {
 				Optional:    true,
 				Description: "Enable the API client's debug logs. By default, a `TF_LOG` setting of debug or higher will enable this.",
 			},
+			"rate_limit_retries": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "The number of times a rate-limited (`HTTP 429`) request is replayed — waiting out the rate limit window each time — before the error is surfaced. Increase this to ride out heavier rate-limit contention (for example, many concurrent runs against the same team) without failing, at the cost of slower runs. It can also be set via the `HONEYCOMB_RATE_LIMIT_RETRIES` environment variable. Defaults to `10`. Values below `1` use the default.",
+			},
 			"features": features.GetPluginSDKFeaturesSchema(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
@@ -88,14 +94,25 @@ func Provider(version string) *schema.Provider {
 			debug = v.(bool)
 		}
 
+		rateLimitRetries := 0
+		if v := os.Getenv("HONEYCOMB_RATE_LIMIT_RETRIES"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil {
+				rateLimitRetries = n
+			}
+		}
+		if v, ok := d.GetOk("rate_limit_retries"); ok {
+			rateLimitRetries = v.(int)
+		}
+
 		// if the API key is set, use it to create the client
 		// we now rely on the Framework version of the provider to validate the configuration
 		if apiKey != "" {
 			config := &honeycombio.Config{
-				APIKey:    apiKey,
-				APIUrl:    d.Get("api_url").(string),
-				UserAgent: provider.UserAgent("terraform-provider-honeycombio", version),
-				Debug:     debug,
+				APIKey:           apiKey,
+				APIUrl:           d.Get("api_url").(string),
+				UserAgent:        provider.UserAgent("terraform-provider-honeycombio", version),
+				Debug:            debug,
+				RateLimitRetries: rateLimitRetries,
 			}
 			c, err := honeycombio.NewClientWithConfig(config)
 			if err != nil {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -32,12 +33,13 @@ type HoneycombioProvider struct {
 
 // HoneycombioProviderModel describes the provider data model.
 type HoneycombioProviderModel struct {
-	APIKey    types.String     `tfsdk:"api_key"`
-	KeyID     types.String     `tfsdk:"api_key_id"`
-	KeySecret types.String     `tfsdk:"api_key_secret"`
-	APIUrl    types.String     `tfsdk:"api_url"`
-	Debug     types.Bool       `tfsdk:"debug"`
-	Features  []features.Model `tfsdk:"features"`
+	APIKey           types.String     `tfsdk:"api_key"`
+	KeyID            types.String     `tfsdk:"api_key_id"`
+	KeySecret        types.String     `tfsdk:"api_key_secret"`
+	APIUrl           types.String     `tfsdk:"api_url"`
+	Debug            types.Bool       `tfsdk:"debug"`
+	RateLimitRetries types.Int64      `tfsdk:"rate_limit_retries"`
+	Features         []features.Model `tfsdk:"features"`
 }
 
 func New(version string) provider.Provider {
@@ -71,6 +73,12 @@ func (p *HoneycombioProvider) Schema(_ context.Context, _ provider.SchemaRequest
 			"debug": schema.BoolAttribute{
 				MarkdownDescription: "Enable the API client's debug logs. By default, a `TF_LOG` setting of debug or higher will enable this.",
 				Optional:            true,
+			},
+			"rate_limit_retries": schema.Int64Attribute{
+				MarkdownDescription: "The number of times a rate-limited (`HTTP 429`) request is replayed — waiting out the rate limit window each time — before the error is surfaced. " +
+					"Increase this to ride out heavier rate-limit contention (for example, many concurrent runs against the same team) without failing, at the cost of slower runs. " +
+					"It can also be set via the `HONEYCOMB_RATE_LIMIT_RETRIES` environment variable. Defaults to `10`. Values below `1` use the default.",
+				Optional: true,
 			},
 		},
 		Blocks: map[string]schema.Block{
@@ -170,6 +178,17 @@ func (p *HoneycombioProvider) Configure(ctx context.Context, req provider.Config
 		keySecret = config.KeySecret.ValueString()
 	}
 
+	// 0 leaves the client at its default (limits.DefaultRateLimitRetries).
+	rateLimitRetries := 0
+	if v := os.Getenv("HONEYCOMB_RATE_LIMIT_RETRIES"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			rateLimitRetries = n
+		}
+	}
+	if !config.RateLimitRetries.IsNull() && !config.RateLimitRetries.IsUnknown() {
+		rateLimitRetries = int(config.RateLimitRetries.ValueInt64())
+	}
+
 	initv1Client, initv2Client := false, false
 	if apiKey != "" {
 		initv1Client = true
@@ -220,10 +239,11 @@ func (p *HoneycombioProvider) Configure(ctx context.Context, req provider.Config
 
 	if initv1Client {
 		client, err := client.NewClientWithConfig(&client.Config{
-			APIKey:    apiKey,
-			APIUrl:    config.APIUrl.ValueString(),
-			Debug:     debug,
-			UserAgent: userAgent,
+			APIKey:           apiKey,
+			APIUrl:           config.APIUrl.ValueString(),
+			Debug:            debug,
+			UserAgent:        userAgent,
+			RateLimitRetries: rateLimitRetries,
 		})
 		if helper.AddDiagnosticOnError(&resp.Diagnostics, "Unable to create Honeycomb API V1 Client", err) {
 			return
@@ -233,11 +253,12 @@ func (p *HoneycombioProvider) Configure(ctx context.Context, req provider.Config
 
 	if initv2Client {
 		v2client, err := v2client.NewClientWithConfig(&v2client.Config{
-			APIKeyID:     keyID,
-			APIKeySecret: keySecret,
-			BaseURL:      config.APIUrl.ValueString(),
-			Debug:        debug,
-			UserAgent:    userAgent,
+			APIKeyID:         keyID,
+			APIKeySecret:     keySecret,
+			BaseURL:          config.APIUrl.ValueString(),
+			Debug:            debug,
+			UserAgent:        userAgent,
+			RateLimitRetries: rateLimitRetries,
 		})
 		if helper.AddDiagnosticOnError(&resp.Diagnostics, "Unable to create Honeycomb API V2 Client", err) {
 			return

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -97,6 +97,19 @@ The key pair can be set with the `api_key_id` and `api_key_secret` arguments, or
 
 ~> **Note** Hard-coding API keys in any Terraform configuration is not recommended. Consider using the one of the environment variable options.
 
+## Rate Limiting
+
+The Honeycomb API enforces per-team rate limits, scoped per-resource and per-action (for example, reads of triggers are limited independently of reads of SLOs).
+Each limit is a fixed budget of requests per minute that is replenished at the start of each minute.
+
+The provider paces itself to stay within these limits automatically — no configuration is required.
+It reads the rate limit reported on each API response and, when a resource's budget for the current window is exhausted, briefly pauses requests to that resource until the window resets, then resumes.
+Workloads that fit within the limit are unaffected; large plans, applies, or refreshes are smoothed out rather than failing with `HTTP 429` errors.
+
+Because the limits are enforced **per-team**, all Environments managed under the same team share a budget.
+If you run several `terraform` operations against the same team concurrently, they share that budget and may still encounter rate limiting; reducing `-parallelism` or the number of concurrent runs can help.
+If you consistently hit rate limits, contact Honeycomb Support to discuss raising your team's limits.
+
 ## Argument Reference
 
 Arguments accepted by this provider include:

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -103,12 +103,15 @@ The Honeycomb API enforces per-team rate limits, scoped per-resource and per-act
 Each limit is a fixed budget of requests per minute that is replenished at the start of each minute.
 
 The provider paces itself to stay within these limits automatically — no configuration is required.
-It reads the rate limit reported on each API response and, when a resource's budget for the current window is exhausted, briefly pauses requests to that resource until the window resets, then resumes.
-Workloads that fit within the limit are unaffected; large plans, applies, or refreshes are smoothed out rather than failing with `HTTP 429` errors.
+It reads the rate limit reported on each API response and, when a resource's budget for the current window is exhausted, pauses requests to that resource until the window resets, then resumes.
+Workloads that fit within the limit are unaffected.
+
+If a request is rate limited anyway, the provider treats the `HTTP 429` as "try again when the window resets" rather than as a failure: it waits out the window and replays the request, up to `rate_limit_retries` times (default `10`).
+This means rate limiting slows a run down instead of failing it.
 
 Because the limits are enforced **per-team**, all Environments managed under the same team share a budget.
-If you run several `terraform` operations against the same team concurrently, they share that budget and may still encounter rate limiting; reducing `-parallelism` or the number of concurrent runs can help.
-If you consistently hit rate limits, contact Honeycomb Support to discuss raising your team's limits.
+If you run several `terraform` operations against the same team concurrently, they share that budget — each run paces itself, but collectively they can still exceed the limit and spend longer retrying.
+For that case, raising `rate_limit_retries` keeps runs from failing (at the cost of slower runs); reducing `-parallelism` or the number of concurrent runs reduces the contention; and if you consistently hit limits, contact Honeycomb Support to discuss raising your team's limits.
 
 ## Argument Reference
 
@@ -119,6 +122,7 @@ Arguments accepted by this provider include:
 * `api_key_secret` - (Optional) The secret portion of the Honeycomb Management API key to use. It can also be set via the `HONEYCOMB_KEY_SECRET` environment variable.
 * `api_url` - (Optional) Override the URL of the Honeycomb.io API. It can also be set using `HONEYCOMB_API_ENDPOINT`. Defaults to `https://api.honeycomb.io`.
 * `debug` - (Optional) Enable to log additional debug information. To view the logs, set `TF_LOG` to at least debug.
+* `rate_limit_retries` - (Optional) The number of times a rate-limited (`HTTP 429`) request is replayed — waiting out the rate limit window each time — before the error is surfaced. Increase this to ride out heavier rate-limit contention without failing, at the cost of slower runs. It can also be set using `HONEYCOMB_RATE_LIMIT_RETRIES`. Defaults to `10`.
 * `features` - (Optional) The features block allows customization of the behavior of the Honeycomb Provider. Full details documented below.
 
 At least one of `api_key`, or the `api_key_id` and `api_key_secret` pair must be configured.

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -100,10 +100,10 @@ The key pair can be set with the `api_key_id` and `api_key_secret` arguments, or
 ## Rate Limiting
 
 The Honeycomb API enforces per-team rate limits, scoped per-resource and per-action (for example, reads of triggers are limited independently of reads of SLOs).
-Each limit is a fixed budget of requests per minute that is replenished at the start of each minute.
+Each limit is a fixed budget of requests per window — one minute — refilled in full when the window resets.
 
 The provider paces itself to stay within these limits automatically — no configuration is required.
-It reads the rate limit reported on each API response and, when a resource's budget for the current window is exhausted, pauses requests to that resource until the window resets, then resumes.
+It reads the rate limit headers returned on each API response, and when a resource's budget for the current window is exhausted it pauses requests to that resource until the window resets, then resumes.
 Workloads that fit within the limit are unaffected.
 
 If a request is rate limited anyway, the provider treats the `HTTP 429` as "try again when the window resets" rather than as a failure: it waits out the window and replays the request, up to `rate_limit_retries` times (default `10`).


### PR DESCRIPTION
## Summary

The provider handles rate limiting **reactively**: requests fire as fast as Terraform schedules them, and an `HTTP 429` is retried by `go-retryablehttp` up to a fixed cap. Under load that bursts straight into the server's limit, and once the cap is exhausted the run **fails**. This is acute for teams with many triggers/SLOs/burn alerts: a state refresh issues one read per resource against a single **per-team** budget, and several environments planning concurrently share that budget.

This PR makes the client well-behaved under rate limits in two complementary ways. Both are needed — the first smooths a single run; the second is what actually keeps concurrent runs from failing.

## Background: the server's model

Honeycomb enforces a **fixed-window** rate limit, scoped **per-team, per-resource, per-action** (e.g. reads of triggers are limited independently of reads of SLOs). Each window grants a fixed budget — default 120 reads/min — refilled **in full at the next window boundary**, not trickled back continuously. Every response, including a `429`, advertises `RateLimit: limit=…, remaining=…, reset=…` and `RateLimit-Policy: …;w=…`.

## 1. Proactive pacing (the gate)

Adds `limits.RateLimitingTransport`, an `http.RoundTripper` wired into both the v1 and v2 clients. It tracks `limit`/`remaining`/`reset` per `(method, resource)` bucket from response headers, passes requests through while budget remains, and pauses a resource until its window resets when the budget is spent — mirroring the fixed-window server.

- **Single run:** workloads within the limit are untouched; a large refresh is paced smoothly instead of bursting into a wall of 429s (measured ~2× faster, near-zero 429s).
- A continuous-refill limiter (`golang.org/x/time/rate`) was deliberately avoided: it would over-issue mid-window against a fixed-window server and reintroduce 429s.

## 2. Absorbing 429s (the fix for concurrent runs)

The gate can't help across **separate** `terraform` processes — each runs its own gate, can't see the others, and they collectively overshoot the shared per-team budget. So a 429 is treated as what it is — "come back when the window resets", not a failure: the transport waits out the window and **replays the request** (body buffered, so any verb works) up to `rate_limit_retries` times.

- `RetryHTTPCheck` no longer retries 429 — the transport owns rate limiting; `retryablehttp`'s `RetryMax` governs only transport errors and 5xx.
- Configurable via the provider's **`rate_limit_retries`** attribute (and `HONEYCOMB_RATE_LIMIT_RETRIES`), plumbed through both clients and both the Plugin Framework and SDKv2 provider schemas. **Defaults to `10`**, matching the prior 429 retry budget, so default behaviour is unchanged; raise it to ride out heavier contention without failing (at the cost of slower runs).

The net effect: rate limiting **slows a run down instead of failing it**, even when many runs share a team's budget.

## Notes / limitations

- Limits are **per-team**, so concurrent runs still contend for one budget; `rate_limit_retries` keeps them from failing, but the durable fix for *speed* is a higher team limit and/or less concurrency.
- The cold start of each process issues up to `-parallelism` requests before it has observed the limit; those few may 429 and are absorbed.

## Testing

- Unit tests (virtual clock + fake fixed-window server): no-429-under-load, correct pauses at window boundaries, pass-through within budget, independent per-resource buckets, context cancellation, absorbing a 429 then succeeding, and giving up after `rate_limit_retries`.
- `make lint` (golangci-lint v2.9.0): 0 issues. `go vet` and `go test -race ./client/internal/limits/...` pass. Docs regenerated via `make docs`.
