### PR TITLE
feat: increase maximum retry attempts

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -139,7 +139,7 @@ func NewClientWithConfig(config *Config) (*Client, error) {
 		HTTPClient:   cfg.HTTPClient,
 		RetryWaitMin: 200 * time.Millisecond,
 		RetryWaitMax: time.Minute,
-		RetryMax:     10,
+		RetryMax:     30,
 	}
 
 	if config.Debug {

--- a/client/v2/client.go
+++ b/client/v2/client.go
@@ -123,7 +123,7 @@ func NewClientWithConfig(config *Config) (*Client, error) {
 		HTTPClient:   config.HTTPClient,
 		RetryWaitMin: 200 * time.Millisecond,
 		RetryWaitMax: time.Minute,
-		RetryMax:     10,
+		RetryMax:     30,
 	}
 
 	if config.Debug {


### PR DESCRIPTION
## Which problem is this PR solving?

With a large number of resources and a low rate limit, some TF requests sometimes get rate-limited

## Short description of the changes

The client's maximum retry count was recently changed from 30 to 10. Bumping this back to the original limit
