### PR TITLE
feat: Add configuration key support to the provider

### DIFF
--- a/client/v2/models.go
+++ b/client/v2/models.go
@@ -56,7 +56,7 @@ type APIKeyPermissions struct {
 	RunQueries          bool `json:"run_queries,omitempty" jsonapi:"attr,run_queries,omitempty"`
 	ReadServiceMaps     bool `json:"read_service_maps,omitempty" jsonapi:"attr,read_service_maps,omitempty"`
 	ManagePublicBoards  bool `json:"manage_boards,omitempty" jsonapi:"attr,manage_boards,omitempty"`
-	ManagePrivateBoards bool `json:"manage_private_boards,omitempty" jsonapi:"attr,manage_private_boards,omitempty"`
+	ManagePrivateBoards bool `json:"manage_privateBoards,omitempty" jsonapi:"attr,manage_privateBoards,omitempty"`
 	ManageSLOs          bool `json:"manage_slos,omitempty" jsonapi:"attr,manage_slos,omitempty"`
 	ManageTriggers      bool `json:"manage_triggers,omitempty" jsonapi:"attr,manage_triggers,omitempty"`
 	ManageRecipients    bool `json:"manage_recipients,omitempty" jsonapi:"attr,manage_recipients,omitempty"`

--- a/client/v2/models.go
+++ b/client/v2/models.go
@@ -50,5 +50,16 @@ type APIKey struct {
 }
 
 type APIKeyPermissions struct {
-	CreateDatasets bool `json:"create_datasets" jsonapi:"attr,create_datasets"`
+	SendEvents          bool `json:"send_events,omitempty" jsonapi:"attr,send_events,omitempty"`
+	CreateDatasets      bool `json:"create_datasets,omitempty" jsonapi:"attr,create_datasets,omitempty"`
+	ManageQueries       bool `json:"manage_columns,omitempty" jsonapi:"attr,manage_columns,omitempty"`
+	RunQueries          bool `json:"run_queries,omitempty" jsonapi:"attr,run_queries,omitempty"`
+	ReadServiceMaps     bool `json:"read_service_maps,omitempty" jsonapi:"attr,read_service_maps,omitempty"`
+	ManagePublicBoards  bool `json:"manage_boards,omitempty" jsonapi:"attr,manage_boards,omitempty"`
+	ManagePrivateBoards bool `json:"manage_private_boards,omitempty" jsonapi:"attr,manage_private_boards,omitempty"`
+	ManageSLOs          bool `json:"manage_slos,omitempty" jsonapi:"attr,manage_slos,omitempty"`
+	ManageTriggers      bool `json:"manage_triggers,omitempty" jsonapi:"attr,manage_triggers,omitempty"`
+	ManageRecipients    bool `json:"manage_recipients,omitempty" jsonapi:"attr,manage_recipients,omitempty"`
+	ManageMarkers       bool `json:"manage_markers,omitempty" jsonapi:"attr,manage_markers,omitempty"`
+	VisibleToMembers    bool `json:"visible_team_members,omitempty" jsonapi:"attr,visible_team_members,omitempty"`
 }

--- a/docs/resources/api_key.md
+++ b/docs/resources/api_key.md
@@ -31,12 +31,13 @@ output "ingest_key" {
 
 - `environment_id` (String) The Environment ID the API key is scoped to.
 - `name` (String) The name of the API key.
-- `type` (String) The type of API key. Currently only `ingest` is supported.
+- `type` (String) The type of API key. Currently only `ingest` and `configuration` is supported.
 
 ### Optional
 
 - `disabled` (Boolean) Whether the API key is disabled. Defaults to `false`.
 - `permissions` (Block List) A configuration block setting what actions the API key can perform. (see [below for nested schema](#nestedblock--permissions))
+- `visible_to_members` (Boolean) Whether the key can be viewed by members and read-only users, or only owners.
 
 ### Read-Only
 
@@ -49,7 +50,17 @@ output "ingest_key" {
 
 Optional:
 
-- `create_datasets` (Boolean) Allow this key to create missing datasets when sending telemetry. Defaults to `false`.
+- `create_datasets` (Boolean) Allow this ingest or configuration key to create missing datasets when sending telemetry. Defaults to `false`.
+- `manage_markers` (Boolean) Allow this configuration key to manage Markers. Defaults to `false`.
+- `manage_private_boards` (Boolean) Allow this configuration key to manage public boards. Defaults to `false`.
+- `manage_public_boards` (Boolean) Allow this configuration key to manage public boards. Defaults to `false`.
+- `manage_queries` (Boolean) Allow this configuration key to manage queries and columns. Defaults to `false`.
+- `manage_recipients` (Boolean) Allow this configuration key to manage Recipients. Defaults to `false`.
+- `manage_slos` (Boolean) Allow this configuration key to manage SLOs. Defaults to `false`.
+- `manage_triggers` (Boolean) Allow this configuration key to manage Triggers. Defaults to `false`.
+- `read_service_maps` (Boolean) Allow this configuration key to read service maps. This feature is only for enterprise users. Defaults to `false`.
+- `run_queries` (Boolean) Allow this configuration key run queries. Defaults to `false`.
+- `send_events` (Boolean) Allow this configuration key to send events to Honeycomb. Defaults to `false`.
 
 ## Import
 

--- a/internal/helper/validation/parent_value.go
+++ b/internal/helper/validation/parent_value.go
@@ -1,0 +1,76 @@
+package validation
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type ParentValueValidator struct {
+	Expression path.Expression
+
+	Value types.Dynamic
+}
+
+// Description returns a plaintext string describing the validator.
+func (v ParentValueValidator) Description(_ context.Context) string {
+	return fmt.Sprintf("If configured, be used only if %s is %s", v.Expression.String(), v.Value.String())
+}
+
+// MarkdownDescription returns a Markdown formatted string describing the validator.
+func (v ParentValueValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v ParentValueValidator) ValidateBool(ctx context.Context, req validator.BoolRequest, resp *validator.BoolResponse) {
+	// If the Value is unknown or null, there is nothing to validate.
+	if req.ConfigValue.IsUnknown() || req.ConfigValue.IsNull() {
+		return
+	}
+
+	// Find paths matching the Expression in the configuration data.
+	matchedPaths, diags := req.Config.PathMatches(ctx, v.Expression)
+
+	resp.Diagnostics.Append(diags...)
+
+	// Collect all errors
+	if diags.HasError() {
+		return
+	}
+
+	// For each matched path, get the data and compare.
+	for _, matchedPath := range matchedPaths {
+		// Fetch the generic attr.Value at the given path. This ensures any
+		// potential parent Value of a different type, which can be a null
+		// or unknown Value, can be safely checked without raising a type
+		// conversion error.
+		var matchedPathValue attr.Value
+
+		diags := req.Config.GetAttribute(ctx, matchedPath, &matchedPathValue)
+
+		resp.Diagnostics.Append(diags...)
+
+		// Collect all errors
+		if diags.HasError() {
+			continue
+		}
+
+		// If the matched path Value is null or unknown, we cannot compare
+		// values, so continue to other matched paths.
+		if matchedPathValue.IsNull() || matchedPathValue.IsUnknown() {
+			continue
+		}
+
+		if !v.Value.UnderlyingValue().Equal(matchedPathValue) {
+			resp.Diagnostics.AddAttributeError(
+				matchedPath,
+				"Invalid Attribute Value",
+				fmt.Sprintf("Must equal to %s's Value: %s", req.Path, v.Value.String()),
+			)
+		}
+	}
+}

--- a/internal/helper/validation/parent_value.go
+++ b/internal/helper/validation/parent_value.go
@@ -69,7 +69,7 @@ func (v ParentValueValidator) ValidateBool(ctx context.Context, req validator.Bo
 			resp.Diagnostics.AddAttributeError(
 				matchedPath,
 				"Invalid Attribute Value",
-				fmt.Sprintf("Must equal to %s's Value: %s", req.Path, v.Value.String()),
+				fmt.Sprintf("%s must be equal to Value: %s", req.Path, v.Value.String()),
 			)
 		}
 	}

--- a/internal/models/api_keys.go
+++ b/internal/models/api_keys.go
@@ -6,20 +6,41 @@ import (
 )
 
 type APIKeyResourceModel struct {
-	ID            types.String `tfsdk:"id"`
-	Name          types.String `tfsdk:"name"`
-	Type          types.String `tfsdk:"type"`
-	EnvironmentID types.String `tfsdk:"environment_id"`
-	Disabled      types.Bool   `tfsdk:"disabled"`
-	Permissions   types.List   `tfsdk:"permissions"` // APIKeyPermissionModel
-	Secret        types.String `tfsdk:"secret"`
-	Key           types.String `tfsdk:"key"`
+	ID               types.String `tfsdk:"id"`
+	Name             types.String `tfsdk:"name"`
+	Type             types.String `tfsdk:"type"`
+	EnvironmentID    types.String `tfsdk:"environment_id"`
+	VisibleToMembers types.Bool   `tfsdk:"visible_to_members"`
+	Disabled         types.Bool   `tfsdk:"disabled"`
+	Permissions      types.List   `tfsdk:"permissions"` // APIKeyPermissionModel
+	Secret           types.String `tfsdk:"secret"`
+	Key              types.String `tfsdk:"key"`
 }
 
 type APIKeyPermissionModel struct {
-	CreateDatasets types.Bool `tfsdk:"create_datasets"`
+	SendEvents          types.Bool `tfsdk:"send_events"`
+	CreateDatasets      types.Bool `tfsdk:"create_datasets"`
+	ManageQueries       types.Bool `tfsdk:"manage_queries"`
+	RunQueries          types.Bool `tfsdk:"run_queries"`
+	ReadServiceMaps     types.Bool `tfsdk:"read_service_maps"`
+	ManagePublicBoards  types.Bool `tfsdk:"manage_public_boards"`
+	ManagePrivateBoards types.Bool `tfsdk:"manage_private_boards"`
+	ManageSLOs          types.Bool `tfsdk:"manage_slos"`
+	ManageTriggers      types.Bool `tfsdk:"manage_triggers"`
+	ManageRecipients    types.Bool `tfsdk:"manage_recipients"`
+	ManageMarkers       types.Bool `tfsdk:"manage_markers"`
 }
 
 var APIKeyPermissionsAttrType = map[string]attr.Type{
-	"create_datasets": types.BoolType,
+	"send_events":           types.BoolType,
+	"create_datasets":       types.BoolType,
+	"manage_queries":        types.BoolType,
+	"run_queries":           types.BoolType,
+	"read_service_maps":     types.BoolType,
+	"manage_public_boards":  types.BoolType,
+	"manage_private_boards": types.BoolType,
+	"manage_slos":           types.BoolType,
+	"manage_triggers":       types.BoolType,
+	"manage_recipients":     types.BoolType,
+	"manage_markers":        types.BoolType,
 }

--- a/internal/provider/api_key_resource.go
+++ b/internal/provider/api_key_resource.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"errors"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/boolvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
@@ -21,6 +23,7 @@ import (
 	"github.com/honeycombio/terraform-provider-honeycombio/client"
 	v2client "github.com/honeycombio/terraform-provider-honeycombio/client/v2"
 	"github.com/honeycombio/terraform-provider-honeycombio/internal/helper"
+	"github.com/honeycombio/terraform-provider-honeycombio/internal/helper/validation"
 	"github.com/honeycombio/terraform-provider-honeycombio/internal/models"
 )
 
@@ -82,9 +85,9 @@ func (*apiKeyResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 			},
 			"type": schema.StringAttribute{
 				Required:            true,
-				MarkdownDescription: "The type of API key. Currently only `ingest` is supported.",
+				MarkdownDescription: "The type of API key. Currently only `ingest` and `configuration` is supported.",
 				Validators: []validator.String{
-					stringvalidator.OneOf("ingest"),
+					stringvalidator.OneOf("ingest", "configuration"),
 				},
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
@@ -101,6 +104,12 @@ func (*apiKeyResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 				Optional:            true,
 				Computed:            true,
 				MarkdownDescription: "Whether the API key is disabled. Defaults to `false`.",
+				Default:             booldefault.StaticBool(false),
+			},
+			"visible_to_members": schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "Whether the key can be viewed by members and read-only users, or only owners.",
 				Default:             booldefault.StaticBool(false),
 			},
 			"key": schema.StringAttribute{
@@ -129,13 +138,169 @@ func (*apiKeyResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 				},
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
+						"send_events": schema.BoolAttribute{
+							Optional:            true,
+							Computed:            true,
+							Default:             booldefault.StaticBool(false),
+							MarkdownDescription: "Allow this configuration key to send events to Honeycomb. Defaults to `false`.",
+							PlanModifiers: []planmodifier.Bool{
+								boolplanmodifier.RequiresReplace(),
+							},
+							Validators: []validator.Bool{
+								boolvalidator.Any(
+									validation.ParentValueValidator{
+										Expression: path.MatchRoot("type"),
+										Value:      types.DynamicValue(types.StringValue("configuration")),
+									},
+								),
+							},
+						},
 						"create_datasets": schema.BoolAttribute{
 							Optional:            true,
 							Computed:            true,
 							Default:             booldefault.StaticBool(false),
-							MarkdownDescription: "Allow this key to create missing datasets when sending telemetry. Defaults to `false`.",
+							MarkdownDescription: "Allow this ingest or configuration key to create missing datasets when sending telemetry. Defaults to `false`.",
 							PlanModifiers: []planmodifier.Bool{
 								boolplanmodifier.RequiresReplace(),
+							},
+						},
+						"manage_queries": schema.BoolAttribute{
+							Optional:            true,
+							Computed:            true,
+							Default:             booldefault.StaticBool(false),
+							MarkdownDescription: "Allow this configuration key to manage queries and columns. Defaults to `false`.",
+							PlanModifiers: []planmodifier.Bool{
+								boolplanmodifier.RequiresReplace(),
+							},
+							Validators: []validator.Bool{
+								validation.ParentValueValidator{
+									Expression: path.MatchRoot("type"),
+									Value:      types.DynamicValue(types.StringValue("configuration")),
+								},
+							},
+						},
+						"run_queries": schema.BoolAttribute{
+							Optional:            true,
+							Computed:            true,
+							Default:             booldefault.StaticBool(false),
+							MarkdownDescription: "Allow this configuration key run queries. Defaults to `false`.",
+							PlanModifiers: []planmodifier.Bool{
+								boolplanmodifier.RequiresReplace(),
+							},
+							Validators: []validator.Bool{
+								validation.ParentValueValidator{
+									Expression: path.MatchRoot("type"),
+									Value:      types.DynamicValue(types.StringValue("configuration")),
+								},
+							},
+						},
+						"read_service_maps": schema.BoolAttribute{
+							Optional:            true,
+							Computed:            true,
+							Default:             booldefault.StaticBool(false),
+							MarkdownDescription: "Allow this configuration key to read service maps. This feature is only for enterprise users. Defaults to `false`.",
+							PlanModifiers: []planmodifier.Bool{
+								boolplanmodifier.RequiresReplace(),
+							},
+							Validators: []validator.Bool{
+								validation.ParentValueValidator{
+									Expression: path.MatchRoot("type"),
+									Value:      types.DynamicValue(types.StringValue("configuration")),
+								},
+							},
+						},
+						"manage_public_boards": schema.BoolAttribute{
+							Optional:            true,
+							Computed:            true,
+							Default:             booldefault.StaticBool(false),
+							MarkdownDescription: "Allow this configuration key to manage public boards. Defaults to `false`.",
+							PlanModifiers: []planmodifier.Bool{
+								boolplanmodifier.RequiresReplace(),
+							},
+							Validators: []validator.Bool{
+								validation.ParentValueValidator{
+									Expression: path.MatchRoot("type"),
+									Value:      types.DynamicValue(types.StringValue("configuration")),
+								},
+							},
+						},
+						"manage_private_boards": schema.BoolAttribute{
+							Optional:            true,
+							Computed:            true,
+							Default:             booldefault.StaticBool(false),
+							MarkdownDescription: "Allow this configuration key to manage public boards. Defaults to `false`.",
+							PlanModifiers: []planmodifier.Bool{
+								boolplanmodifier.RequiresReplace(),
+							},
+							Validators: []validator.Bool{
+								validation.ParentValueValidator{
+									Expression: path.MatchRoot("type"),
+									Value:      types.DynamicValue(types.StringValue("configuration")),
+								},
+								validation.ParentValueValidator{
+									Expression: path.MatchRoot("visible_to_members"),
+									Value:      types.DynamicValue(types.BoolValue(false)),
+								},
+							},
+						},
+						"manage_slos": schema.BoolAttribute{
+							Optional:            true,
+							Computed:            true,
+							Default:             booldefault.StaticBool(false),
+							MarkdownDescription: "Allow this configuration key to manage SLOs. Defaults to `false`.",
+							PlanModifiers: []planmodifier.Bool{
+								boolplanmodifier.RequiresReplace(),
+							},
+							Validators: []validator.Bool{
+								validation.ParentValueValidator{
+									Expression: path.MatchRoot("type"),
+									Value:      types.DynamicValue(types.StringValue("configuration")),
+								},
+							},
+						},
+						"manage_triggers": schema.BoolAttribute{
+							Optional:            true,
+							Computed:            true,
+							Default:             booldefault.StaticBool(false),
+							MarkdownDescription: "Allow this configuration key to manage Triggers. Defaults to `false`.",
+							PlanModifiers: []planmodifier.Bool{
+								boolplanmodifier.RequiresReplace(),
+							},
+							Validators: []validator.Bool{
+								validation.ParentValueValidator{
+									Expression: path.MatchRoot("type"),
+									Value:      types.DynamicValue(types.StringValue("configuration")),
+								},
+							},
+						},
+						"manage_recipients": schema.BoolAttribute{
+							Optional:            true,
+							Computed:            true,
+							Default:             booldefault.StaticBool(false),
+							MarkdownDescription: "Allow this configuration key to manage Recipients. Defaults to `false`.",
+							PlanModifiers: []planmodifier.Bool{
+								boolplanmodifier.RequiresReplace(),
+							},
+							Validators: []validator.Bool{
+								validation.ParentValueValidator{
+									Expression: path.MatchRoot("type"),
+									Value:      types.DynamicValue(types.StringValue("configuration")),
+								},
+							},
+						},
+						"manage_markers": schema.BoolAttribute{
+							Optional:            true,
+							Computed:            true,
+							Default:             booldefault.StaticBool(false),
+							MarkdownDescription: "Allow this configuration key to manage Markers. Defaults to `false`.",
+							PlanModifiers: []planmodifier.Bool{
+								boolplanmodifier.RequiresReplace(),
+							},
+							Validators: []validator.Bool{
+								validation.ParentValueValidator{
+									Expression: path.MatchRoot("type"),
+									Value:      types.DynamicValue(types.StringValue("configuration")),
+								},
 							},
 						},
 					},
@@ -152,12 +317,17 @@ func (r *apiKeyResource) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
+	apiPermissions := expandAPIKeyPermissions(ctx, plan.Permissions, &resp.Diagnostics)
+	if apiPermissions != nil {
+		apiPermissions.VisibleToMembers = plan.VisibleToMembers.ValueBool()
+	}
+
 	newKey := &v2client.APIKey{
 		Name:        plan.Name.ValueStringPointer(),
 		KeyType:     plan.Type.ValueString(),
 		Environment: &v2client.Environment{ID: plan.EnvironmentID.ValueString()},
 		Disabled:    plan.Disabled.ValueBoolPointer(),
-		Permissions: expandAPIKeyPermissions(ctx, plan.Permissions, &resp.Diagnostics),
+		Permissions: apiPermissions,
 	}
 
 	key, err := r.client.APIKeys.Create(ctx, newKey)
@@ -172,6 +342,7 @@ func (r *apiKeyResource) Create(ctx context.Context, req resource.CreateRequest,
 	state.EnvironmentID = types.StringValue(key.Environment.ID)
 	state.Disabled = types.BoolValue(*key.Disabled)
 	state.Secret = types.StringValue(key.Secret)
+	state.VisibleToMembers = types.BoolValue(key.Permissions.VisibleToMembers)
 
 	if !plan.Permissions.IsNull() {
 		state.Permissions = flattenAPIKeyPermissions(ctx, key.Permissions, &resp.Diagnostics)
@@ -182,6 +353,8 @@ func (r *apiKeyResource) Create(ctx context.Context, req resource.CreateRequest,
 	switch key.KeyType {
 	case "ingest":
 		state.Key = types.StringValue(key.ID + key.Secret)
+	case "configuration":
+		state.Key = types.StringValue(key.Secret)
 	default:
 		resp.Diagnostics.AddError(
 			"Unknown API Key Type",
@@ -227,6 +400,7 @@ func (r *apiKeyResource) Read(ctx context.Context, req resource.ReadRequest, res
 	state.Type = types.StringValue(key.KeyType)
 	state.Disabled = types.BoolValue(*key.Disabled)
 	state.EnvironmentID = types.StringValue(key.Environment.ID)
+	state.VisibleToMembers = types.BoolValue(key.Permissions.VisibleToMembers)
 
 	if !state.Permissions.IsNull() {
 		state.Permissions = flattenAPIKeyPermissions(ctx, key.Permissions, &resp.Diagnostics)
@@ -266,6 +440,8 @@ func (r *apiKeyResource) Update(ctx context.Context, req resource.UpdateRequest,
 	state.Type = types.StringValue(key.KeyType)
 	state.Disabled = types.BoolValue(*key.Disabled)
 	state.EnvironmentID = types.StringValue(key.Environment.ID)
+	state.VisibleToMembers = types.BoolValue(key.Permissions.VisibleToMembers)
+
 	if !state.Permissions.IsNull() {
 		state.Permissions = flattenAPIKeyPermissions(ctx, key.Permissions, &resp.Diagnostics)
 	} else {
@@ -314,7 +490,17 @@ func expandAPIKeyPermissions(ctx context.Context, list types.List, diags *diag.D
 	}
 
 	return &v2client.APIKeyPermissions{
-		CreateDatasets: permissions[0].CreateDatasets.ValueBool(),
+		SendEvents:          permissions[0].SendEvents.ValueBool(),
+		CreateDatasets:      permissions[0].CreateDatasets.ValueBool(),
+		ManageQueries:       permissions[0].ManageQueries.ValueBool(),
+		RunQueries:          permissions[0].RunQueries.ValueBool(),
+		ReadServiceMaps:     permissions[0].ReadServiceMaps.ValueBool(),
+		ManagePublicBoards:  permissions[0].ManagePublicBoards.ValueBool(),
+		ManagePrivateBoards: permissions[0].ManagePrivateBoards.ValueBool(),
+		ManageSLOs:          permissions[0].ManageSLOs.ValueBool(),
+		ManageTriggers:      permissions[0].ManageTriggers.ValueBool(),
+		ManageRecipients:    permissions[0].ManageRecipients.ValueBool(),
+		ManageMarkers:       permissions[0].ManageMarkers.ValueBool(),
 	}
 }
 
@@ -324,7 +510,17 @@ func flattenAPIKeyPermissions(ctx context.Context, p *v2client.APIKeyPermissions
 	}
 
 	obj, d := types.ObjectValue(models.APIKeyPermissionsAttrType, map[string]attr.Value{
-		"create_datasets": types.BoolValue(p.CreateDatasets),
+		"send_events":           types.BoolValue(p.SendEvents),
+		"create_datasets":       types.BoolValue(p.CreateDatasets),
+		"manage_queries":        types.BoolValue(p.ManageQueries),
+		"run_queries":           types.BoolValue(p.RunQueries),
+		"read_service_maps":     types.BoolValue(p.ReadServiceMaps),
+		"manage_public_boards":  types.BoolValue(p.ManagePublicBoards),
+		"manage_private_boards": types.BoolValue(p.ManagePrivateBoards),
+		"manage_slos":           types.BoolValue(p.ManageSLOs),
+		"manage_triggers":       types.BoolValue(p.ManageTriggers),
+		"manage_recipients":     types.BoolValue(p.ManageRecipients),
+		"manage_markers":        types.BoolValue(p.ManageMarkers),
 	})
 	diags.Append(d...)
 

--- a/internal/provider/api_key_resource.go
+++ b/internal/provider/api_key_resource.go
@@ -237,10 +237,13 @@ func (*apiKeyResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 									Expression: path.MatchRoot("type"),
 									Value:      types.DynamicValue(types.StringValue("configuration")),
 								},
-								validation.ParentValueValidator{
-									Expression: path.MatchRoot("visible_to_members"),
-									Value:      types.DynamicValue(types.BoolValue(false)),
-								},
+								boolvalidator.Any(
+									boolvalidator.Equals(false),
+									validation.ParentValueValidator{
+										Expression: path.MatchRoot("visible_to_members"),
+										Value:      types.DynamicValue(types.BoolValue(false)),
+									},
+								),
 							},
 						},
 						"manage_slos": schema.BoolAttribute{

--- a/internal/provider/api_key_resource_test.go
+++ b/internal/provider/api_key_resource_test.go
@@ -14,13 +14,13 @@ func TestAcc_APIKeyResource(t *testing.T) {
 	c := testAccV2Client(t)
 	env := testAccEnvironment(ctx, t, c)
 
-	t.Run("happy path", func(t *testing.T) {
+	t.Run("happy path for ingest key", func(t *testing.T) {
 		resource.Test(t, resource.TestCase{
 			PreCheck:                 testAccPreCheckV2API(t),
 			ProtoV6ProviderFactories: testAccProtoV6MuxServerFactory,
 			Steps: []resource.TestStep{
 				{
-					Config: testAccConfigBasicAPIKeyTest("test key", "false", env.ID),
+					Config: testAccConfigIngestAPIKeyTest("test key", "false", env.ID),
 					Check: resource.ComposeAggregateTestCheckFunc(
 						testAccEnsureAPIKeyExists(t, "honeycombio_api_key.test"),
 						resource.TestCheckResourceAttrSet("honeycombio_api_key.test", "id"),
@@ -34,7 +34,7 @@ func TestAcc_APIKeyResource(t *testing.T) {
 					),
 				},
 				{ // now update the name and disabled state
-					Config: testAccConfigBasicAPIKeyTest("updated test key", "true", env.ID),
+					Config: testAccConfigIngestAPIKeyTest("updated test key", "true", env.ID),
 					Check: resource.ComposeAggregateTestCheckFunc(
 						testAccEnsureAPIKeyExists(t, "honeycombio_api_key.test"),
 						resource.TestCheckResourceAttrSet("honeycombio_api_key.test", "id"),
@@ -51,6 +51,67 @@ func TestAcc_APIKeyResource(t *testing.T) {
 		})
 	})
 
+	t.Run("happy path for configuration key", func(t *testing.T) {
+		resource.Test(t, resource.TestCase{
+			PreCheck:                 testAccPreCheckV2API(t),
+			ProtoV6ProviderFactories: testAccProtoV6MuxServerFactory,
+			Steps: []resource.TestStep{
+				{
+					Config: testAccConfigConfigurationAPIKeyTest("test key", "false", "false", env.ID),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						testAccEnsureAPIKeyExists(t, "honeycombio_api_key.test"),
+						resource.TestCheckResourceAttrSet("honeycombio_api_key.test", "id"),
+						resource.TestCheckResourceAttrSet("honeycombio_api_key.test", "secret"),
+						resource.TestCheckResourceAttrSet("honeycombio_api_key.test", "key"),
+						resource.TestCheckResourceAttr("honeycombio_api_key.test", "name", "test key"),
+						resource.TestCheckResourceAttr("honeycombio_api_key.test", "type", "configuration"),
+						resource.TestCheckResourceAttr("honeycombio_api_key.test", "environment_id", env.ID),
+						resource.TestCheckResourceAttr("honeycombio_api_key.test", "visible_to_members", "false"),
+						resource.TestCheckResourceAttr("honeycombio_api_key.test", "disabled", "false"),
+						// Check all the permissions to make sure they match
+						resource.TestCheckResourceAttr("honeycombio_api_key.test", "permissions.0.send_events", "true"),
+						resource.TestCheckResourceAttr("honeycombio_api_key.test", "permissions.0.create_datasets", "true"),
+						resource.TestCheckResourceAttr("honeycombio_api_key.test", "permissions.0.manage_queries", "true"),
+						resource.TestCheckResourceAttr("honeycombio_api_key.test", "permissions.0.run_queries", "true"),
+						resource.TestCheckResourceAttr("honeycombio_api_key.test", "permissions.0.read_service_maps", "true"),
+						resource.TestCheckResourceAttr("honeycombio_api_key.test", "permissions.0.manage_public_boards", "true"),
+						resource.TestCheckResourceAttr("honeycombio_api_key.test", "permissions.0.manage_private_boards", "false"),
+						resource.TestCheckResourceAttr("honeycombio_api_key.test", "permissions.0.manage_slos", "true"),
+						resource.TestCheckResourceAttr("honeycombio_api_key.test", "permissions.0.manage_triggers", "true"),
+						resource.TestCheckResourceAttr("honeycombio_api_key.test", "permissions.0.manage_recipients", "true"),
+						resource.TestCheckResourceAttr("honeycombio_api_key.test", "permissions.0.manage_markers", "true"),
+					),
+				},
+				{ // now update the name and disabled state
+					Config: testAccConfigConfigurationAPIKeyTest("updated test key", "true", "false", env.ID),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						testAccEnsureAPIKeyExists(t, "honeycombio_api_key.test"),
+						resource.TestCheckResourceAttrSet("honeycombio_api_key.test", "id"),
+						resource.TestCheckResourceAttrSet("honeycombio_api_key.test", "secret"),
+						resource.TestCheckResourceAttrSet("honeycombio_api_key.test", "key"),
+						resource.TestCheckResourceAttr("honeycombio_api_key.test", "name", "updated test key"),
+						resource.TestCheckResourceAttr("honeycombio_api_key.test", "type", "configuration"),
+						resource.TestCheckResourceAttr("honeycombio_api_key.test", "environment_id", env.ID),
+						resource.TestCheckResourceAttr("honeycombio_api_key.test", "visible_to_members", "false"),
+						resource.TestCheckResourceAttr("honeycombio_api_key.test", "disabled", "true"),
+						// Check all the permissions to make sure they match
+						resource.TestCheckResourceAttr("honeycombio_api_key.test", "permissions.0.send_events", "true"),
+						resource.TestCheckResourceAttr("honeycombio_api_key.test", "permissions.0.create_datasets", "true"),
+						resource.TestCheckResourceAttr("honeycombio_api_key.test", "permissions.0.manage_queries", "true"),
+						resource.TestCheckResourceAttr("honeycombio_api_key.test", "permissions.0.run_queries", "true"),
+						resource.TestCheckResourceAttr("honeycombio_api_key.test", "permissions.0.read_service_maps", "true"),
+						resource.TestCheckResourceAttr("honeycombio_api_key.test", "permissions.0.manage_public_boards", "true"),
+						resource.TestCheckResourceAttr("honeycombio_api_key.test", "permissions.0.manage_private_boards", "false"),
+						resource.TestCheckResourceAttr("honeycombio_api_key.test", "permissions.0.manage_slos", "true"),
+						resource.TestCheckResourceAttr("honeycombio_api_key.test", "permissions.0.manage_triggers", "true"),
+						resource.TestCheckResourceAttr("honeycombio_api_key.test", "permissions.0.manage_recipients", "true"),
+						resource.TestCheckResourceAttr("honeycombio_api_key.test", "permissions.0.manage_markers", "true"),
+					),
+				},
+			},
+		})
+	})
+
 	t.Run("default values", func(t *testing.T) {
 		resource.Test(t, resource.TestCase{
 			PreCheck:                 testAccPreCheckV2API(t),
@@ -58,20 +119,54 @@ func TestAcc_APIKeyResource(t *testing.T) {
 			Steps: []resource.TestStep{
 				{
 					Config: fmt.Sprintf(`
-resource "honeycombio_api_key" "test" {
+resource "honeycombio_api_key" "test_ingest" {
   name = "test key"
   type = "ingest"
 
   environment_id = "%s"
 }`, env.ID),
 					Check: resource.ComposeAggregateTestCheckFunc(
-						testAccEnsureAPIKeyExists(t, "honeycombio_api_key.test"),
-						resource.TestCheckResourceAttrSet("honeycombio_api_key.test", "id"),
-						resource.TestCheckResourceAttrSet("honeycombio_api_key.test", "secret"),
-						resource.TestCheckResourceAttr("honeycombio_api_key.test", "name", "test key"),
-						resource.TestCheckResourceAttr("honeycombio_api_key.test", "type", "ingest"),
-						resource.TestCheckResourceAttr("honeycombio_api_key.test", "environment_id", env.ID),
-						resource.TestCheckResourceAttr("honeycombio_api_key.test", "disabled", "false"),
+						testAccEnsureAPIKeyExists(t, "honeycombio_api_key.test_ingest"),
+						resource.TestCheckResourceAttrSet("honeycombio_api_key.test_ingest", "id"),
+						resource.TestCheckResourceAttrSet("honeycombio_api_key.test_ingest", "secret"),
+						resource.TestCheckResourceAttr("honeycombio_api_key.test_ingest", "name", "test key"),
+						resource.TestCheckResourceAttr("honeycombio_api_key.test_ingest", "type", "ingest"),
+						resource.TestCheckResourceAttr("honeycombio_api_key.test_ingest", "environment_id", env.ID),
+						resource.TestCheckResourceAttr("honeycombio_api_key.test_ingest", "disabled", "false"),
+					),
+				},
+				{
+					Config: fmt.Sprintf(`
+resource "honeycombio_api_key" "test_configuration" {
+  name = "test key"
+  type = "configuration"
+
+  environment_id = "%s"
+
+  permissions {}
+}`, env.ID),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						testAccEnsureAPIKeyExists(t, "honeycombio_api_key.test_configuration"),
+						resource.TestCheckResourceAttrSet("honeycombio_api_key.test_configuration", "id"),
+						resource.TestCheckResourceAttrSet("honeycombio_api_key.test_configuration", "secret"),
+						resource.TestCheckResourceAttrSet("honeycombio_api_key.test_configuration", "key"),
+						resource.TestCheckResourceAttr("honeycombio_api_key.test_configuration", "name", "test key"),
+						resource.TestCheckResourceAttr("honeycombio_api_key.test_configuration", "type", "configuration"),
+						resource.TestCheckResourceAttr("honeycombio_api_key.test_configuration", "environment_id", env.ID),
+						resource.TestCheckResourceAttr("honeycombio_api_key.test_configuration", "visible_to_members", "false"),
+						resource.TestCheckResourceAttr("honeycombio_api_key.test_configuration", "disabled", "false"),
+						// Check all the permissions to make sure they match
+						resource.TestCheckResourceAttr("honeycombio_api_key.test_configuration", "permissions.0.send_events", "false"),
+						resource.TestCheckResourceAttr("honeycombio_api_key.test_configuration", "permissions.0.create_datasets", "false"),
+						resource.TestCheckResourceAttr("honeycombio_api_key.test_configuration", "permissions.0.manage_queries", "false"),
+						resource.TestCheckResourceAttr("honeycombio_api_key.test_configuration", "permissions.0.run_queries", "false"),
+						resource.TestCheckResourceAttr("honeycombio_api_key.test_configuration", "permissions.0.read_service_maps", "false"),
+						resource.TestCheckResourceAttr("honeycombio_api_key.test_configuration", "permissions.0.manage_public_boards", "false"),
+						resource.TestCheckResourceAttr("honeycombio_api_key.test_configuration", "permissions.0.manage_private_boards", "false"),
+						resource.TestCheckResourceAttr("honeycombio_api_key.test_configuration", "permissions.0.manage_slos", "false"),
+						resource.TestCheckResourceAttr("honeycombio_api_key.test_configuration", "permissions.0.manage_triggers", "false"),
+						resource.TestCheckResourceAttr("honeycombio_api_key.test_configuration", "permissions.0.manage_recipients", "false"),
+						resource.TestCheckResourceAttr("honeycombio_api_key.test_configuration", "permissions.0.manage_markers", "false"),
 					),
 				},
 			},
@@ -79,7 +174,7 @@ resource "honeycombio_api_key" "test" {
 	})
 }
 
-func testAccConfigBasicAPIKeyTest(name, disabled, envID string) string {
+func testAccConfigIngestAPIKeyTest(name, disabled, envID string) string {
 	return fmt.Sprintf(`
 resource "honeycombio_api_key" "test" {
   name     = "%s"
@@ -92,6 +187,31 @@ resource "honeycombio_api_key" "test" {
     create_datasets = true
   }
 }`, name, disabled, envID)
+}
+
+func testAccConfigConfigurationAPIKeyTest(name, disabled, visibleToMembers, envID string) string {
+	return fmt.Sprintf(`
+resource "honeycombio_api_key" "test" {
+  name               = "%s"
+  type               = "configuration"
+  disabled           = %s
+  visible_to_members = %s
+
+  environment_id = "%s"
+
+  permissions {
+    send_events           = true
+	create_datasets       = true
+	manage_queries        = true
+	run_queries           = true
+	read_service_maps     = true
+	manage_public_boards  = true
+	manage_slos           = true
+	manage_triggers       = true
+	manage_recipients     = true
+	manage_markers        = true
+  }
+}`, name, disabled, visibleToMembers, envID)
 }
 
 func testAccEnsureAPIKeyExists(t *testing.T, name string) resource.TestCheckFunc {


### PR DESCRIPTION


<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

While our API client does support creating and managing configuration keys, the provider didn't support that functionality. 

## Short description of the changes

This adds the feature plus tests to validate that it works. The feature updates the existing provider framework API key resource, which means this should be fully backwards compatible.

The added validation rule is there to avoid misconfiguration where configuration keys permissions are used with ingest keys, and vice versa. Unfortunately, there are no available packages to create a custom schema for unit testing, so this needs to be tested as acceptance tests.
