### PR TITLE
maint(slos): remove dataset restriction

### DIFF
--- a/internal/provider/slo_resource.go
+++ b/internal/provider/slo_resource.go
@@ -103,7 +103,6 @@ func (*sloResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *re
 				},
 				Validators: []validator.Set{
 					setvalidator.SizeAtLeast(1),
-					setvalidator.SizeAtMost(10),
 					setvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("dataset")),
 					setvalidator.ExactlyOneOf(path.MatchRelative().AtParent().AtName("dataset"), path.MatchRelative().AtParent().AtName("datasets")),
 				},


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes: https://linear.app/honeycombio/issue/APPO11Y-4612

## Short description of the changes

Remove the 10 dataset restriction - this is dynamic and controlled via API validation.

## How to verify that this has the expected result

No automated tests for this - I did manually verify that we are able to make these SLOs now for a team that has upped their internal restriction

The ticket also includes a parallel PR to verify the API already enforces the admin limit, so we're not opening things up more than we intend to.