### PR TITLE
feat: add provider-level default_tags

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -107,6 +107,7 @@ Arguments accepted by this provider include:
 * `api_url` - (Optional) Override the URL of the Honeycomb.io API. It can also be set using `HONEYCOMB_API_ENDPOINT`. Defaults to `https://api.honeycomb.io`.
 * `debug` - (Optional) Enable to log additional debug information. To view the logs, set `TF_LOG` to at least debug.
 * `features` - (Optional) The features block allows customization of the behavior of the Honeycomb Provider. Full details documented below.
+* `default_tags` - (Optional) A `default_tags` block as defined below. Applies a common set of tags to all supported resources.
 
 At least one of `api_key`, or the `api_key_id` and `api_key_secret` pair must be configured.
 
@@ -160,3 +161,28 @@ The `intelligence` block supports the following:
 * `enabled` - (Optional) Set to `true` to enable intelligence features such as `auto_investigate` on triggers and burn alerts. Defaults to `false`.
 
 ~> **Note** [Honeycomb Intelligence](https://docs.honeycomb.io/security-compliance/honeycomb-intelligence) must first be enabled for your team in the Honeycomb UI before using this block. The `intelligence` feature block in the provider tells Terraform that your team has Honeycomb Intelligence enabled and unlocks related attributes like `auto_investigate`.
+
+## Default Tags
+
+The `default_tags` block applies a common set of tags to every resource that supports tags (`honeycombio_slo`, `honeycombio_flexible_board`, and `honeycombio_trigger`).
+A tag set directly on a resource takes precedence over a default tag with the same key.
+Each resource exposes a computed `tags_all` attribute showing the effective set of tags after the defaults are merged in.
+
+### Example Usage
+
+```hcl
+provider "honeycombio" {
+  default_tags {
+    tags = {
+      team = "sre"
+      env  = "prod"
+    }
+  }
+}
+```
+
+### Arguments Reference
+
+The `default_tags` block supports the following:
+
+* `tags` - (Optional) A map of tags to apply to all supported resources.

--- a/docs/resources/flexible_board.md
+++ b/docs/resources/flexible_board.md
@@ -160,6 +160,7 @@ EOF
 
 - `board_url` (String) The URL of the Board in the Honeycomb UI.
 - `id` (String) The ID of the Board.
+- `tags_all` (Map of String) The effective tags on the resource: the provider's `default_tags` merged with the resource's `tags` (resource tags win on a key collision).
 
 <a id="nestedblock--panel"></a>
 ### Nested Schema for `panel`

--- a/docs/resources/slo.md
+++ b/docs/resources/slo.md
@@ -90,6 +90,7 @@ the column evaluation should consistently return nil, true, or false, as these a
 ### Read-Only
 
 - `id` (String) The ID of the SLO.
+- `tags_all` (Map of String) The effective tags on the resource: the provider's `default_tags` merged with the resource's `tags` (resource tags win on a key collision).
 
 ~> **Note** `dataset` will be deprecated in a future release. One of `dataset` or `datasets` is required. In the meantime, you can swap `dataset` with a single value array for `datasets` to effectively evaluate to the same configuration.
 

--- a/docs/resources/trigger.md
+++ b/docs/resources/trigger.md
@@ -540,6 +540,7 @@ resource "honeycombio_trigger" "metrics" {
 ### Read-Only
 
 - `id` (String) The unique identifier for this Trigger.
+- `tags_all` (Map of String) The effective tags on the resource: the provider's `default_tags` merged with the resource's `tags` (resource tags win on a key collision).
 
 <a id="nestedblock--baseline_details"></a>
 ### Nested Schema for `baseline_details`

--- a/honeycombio/provider.go
+++ b/honeycombio/provider.go
@@ -51,6 +51,22 @@ func Provider(version string) *schema.Provider {
 				Description: "Enable the API client's debug logs. By default, a `TF_LOG` setting of debug or higher will enable this.",
 			},
 			"features": features.GetPluginSDKFeaturesSchema(),
+			"default_tags": { // unused in this provider but required to match the Framework provider for the MuxServer
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Description: "Default tags to apply to all supported resources. A tag set on an individual resource takes precedence over a default tag with the same key.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"tags": {
+							Type:        schema.TypeMap,
+							Optional:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: "A map of tags to apply to all supported resources.",
+						},
+					},
+				},
+			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"honeycombio_column":            dataSourceHoneycombioColumn(),

--- a/internal/helper/tags.go
+++ b/internal/helper/tags.go
@@ -2,6 +2,7 @@ package helper
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -33,4 +34,50 @@ func MapToTags(ctx context.Context, tagsMap types.Map) ([]client.Tag, diag.Diagn
 	}
 
 	return tags, nil
+}
+
+// MergeTags overlays the resource's tags onto the provider defaults, with the resource winning on a key collision.
+func MergeTags(ctx context.Context, defaults map[string]string, resourceTags types.Map) (types.Map, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if resourceTags.IsUnknown() {
+		return types.MapUnknown(types.StringType), diags
+	}
+
+	merged := make(map[string]string, len(defaults))
+	for k, v := range defaults {
+		merged[k] = v
+	}
+	if !resourceTags.IsNull() {
+		var rt map[string]string
+		diags.Append(resourceTags.ElementsAs(ctx, &rt, false)...)
+		if diags.HasError() {
+			return types.MapNull(types.StringType), diags
+		}
+		for k, v := range rt {
+			merged[k] = v
+		}
+	}
+
+	if len(merged) > client.MaxTagsPerResource {
+		diags.AddError(
+			"Too many tags",
+			fmt.Sprintf("Merging default_tags with the resource's tags results in %d tags, which exceeds the maximum of %d per resource.",
+				len(merged), client.MaxTagsPerResource),
+		)
+		return types.MapNull(types.StringType), diags
+	}
+
+	return types.MapValueFrom(ctx, types.StringType, merged)
+}
+
+// RemoveDefaultTags drops any tag whose key and value match a provider default.
+func RemoveDefaultTags(ctx context.Context, tags []client.Tag, defaults map[string]string) (types.Map, diag.Diagnostics) {
+	owned := make(map[string]string, len(tags))
+	for _, tag := range tags {
+		if v, ok := defaults[tag.Key]; ok && v == tag.Value {
+			continue
+		}
+		owned[tag.Key] = tag.Value
+	}
+	return types.MapValueFrom(ctx, types.StringType, owned)
 }

--- a/internal/helper/tags_test.go
+++ b/internal/helper/tags_test.go
@@ -1,0 +1,103 @@
+package helper
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/honeycombio/terraform-provider-honeycombio/client"
+)
+
+func tagsMap(t *testing.T, m map[string]string) types.Map {
+	t.Helper()
+	v, diags := types.MapValueFrom(context.Background(), types.StringType, m)
+	require.False(t, diags.HasError())
+	return v
+}
+
+func TestMergeTags(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("resource tags win over defaults", func(t *testing.T) {
+		got, diags := MergeTags(ctx,
+			map[string]string{"team": "sre", "env": "prod"},
+			tagsMap(t, map[string]string{"team": "platform"}),
+		)
+		require.False(t, diags.HasError())
+
+		var out map[string]string
+		got.ElementsAs(ctx, &out, false)
+		assert.Equal(t, map[string]string{"team": "platform", "env": "prod"}, out)
+	})
+
+	t.Run("no defaults returns the resource tags", func(t *testing.T) {
+		got, diags := MergeTags(ctx, nil, tagsMap(t, map[string]string{"team": "platform"}))
+		require.False(t, diags.HasError())
+
+		var out map[string]string
+		got.ElementsAs(ctx, &out, false)
+		assert.Equal(t, map[string]string{"team": "platform"}, out)
+	})
+
+	t.Run("null resource tags returns the defaults", func(t *testing.T) {
+		got, diags := MergeTags(ctx, map[string]string{"team": "sre"}, types.MapNull(types.StringType))
+		require.False(t, diags.HasError())
+
+		var out map[string]string
+		got.ElementsAs(ctx, &out, false)
+		assert.Equal(t, map[string]string{"team": "sre"}, out)
+	})
+
+	t.Run("unknown resource tags returns unknown", func(t *testing.T) {
+		got, diags := MergeTags(ctx, map[string]string{"team": "sre"}, types.MapUnknown(types.StringType))
+		require.False(t, diags.HasError())
+		assert.True(t, got.IsUnknown())
+	})
+
+	t.Run("errors when the merged set exceeds the limit", func(t *testing.T) {
+		defaults := make(map[string]string, client.MaxTagsPerResource)
+		for i := 0; i < client.MaxTagsPerResource; i++ {
+			defaults[fmt.Sprintf("d%d", i)] = "v"
+		}
+		_, diags := MergeTags(ctx, defaults, tagsMap(t, map[string]string{"extra": "v"}))
+		assert.True(t, diags.HasError())
+	})
+}
+
+func TestRemoveDefaultTags(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("drops tags matching a default key and value", func(t *testing.T) {
+		all := []client.Tag{{Key: "team", Value: "platform"}, {Key: "env", Value: "prod"}}
+		got, diags := RemoveDefaultTags(ctx, all, map[string]string{"team": "sre", "env": "prod"})
+		require.False(t, diags.HasError())
+
+		var out map[string]string
+		got.ElementsAs(ctx, &out, false)
+		assert.Equal(t, map[string]string{"team": "platform"}, out)
+	})
+
+	t.Run("keeps a tag whose value differs from the default", func(t *testing.T) {
+		all := []client.Tag{{Key: "team", Value: "platform"}}
+		got, diags := RemoveDefaultTags(ctx, all, map[string]string{"team": "sre"})
+		require.False(t, diags.HasError())
+
+		var out map[string]string
+		got.ElementsAs(ctx, &out, false)
+		assert.Equal(t, map[string]string{"team": "platform"}, out)
+	})
+
+	t.Run("no defaults returns all tags", func(t *testing.T) {
+		all := []client.Tag{{Key: "team", Value: "platform"}}
+		got, diags := RemoveDefaultTags(ctx, all, nil)
+		require.False(t, diags.HasError())
+
+		var out map[string]string
+		got.ElementsAs(ctx, &out, false)
+		assert.Equal(t, map[string]string{"team": "platform"}, out)
+	})
+}

--- a/internal/models/flexible_board.go
+++ b/internal/models/flexible_board.go
@@ -12,6 +12,7 @@ type FlexibleBoardResourceModel struct {
 	URL           types.String `tfsdk:"board_url"`
 	Panels        types.List   `tfsdk:"panel"`
 	Tags          types.Map    `tfsdk:"tags"`
+	TagsAll       types.Map    `tfsdk:"tags_all"`
 	PresetFilters types.List   `tfsdk:"preset_filter"`
 }
 

--- a/internal/models/slo.go
+++ b/internal/models/slo.go
@@ -16,6 +16,7 @@ type SLOResourceModel struct {
 	TargetPercentage types.Float64 `tfsdk:"target_percentage"`
 	TimePeriod       types.Int64   `tfsdk:"time_period"`
 	Tags             types.Map     `tfsdk:"tags"`
+	TagsAll          types.Map     `tfsdk:"tags_all"`
 }
 
 type SLOsDataSourceModel struct {

--- a/internal/models/triggers.go
+++ b/internal/models/triggers.go
@@ -21,6 +21,7 @@ type TriggerResourceModel struct {
 	EvaluationSchedule types.List   `tfsdk:"evaluation_schedule"` // TriggerEvaluationScheduleModel
 	BaselineDetails    types.List   `tfsdk:"baseline_details"`
 	Tags               types.Map    `tfsdk:"tags"`
+	TagsAll            types.Map    `tfsdk:"tags_all"`
 }
 
 type TriggerBaselineDetailsModel struct {

--- a/internal/provider/flexible_board_resource.go
+++ b/internal/provider/flexible_board_resource.go
@@ -31,11 +31,13 @@ var (
 	_ resource.Resource                 = &flexibleBoardResource{}
 	_ resource.ResourceWithConfigure    = &flexibleBoardResource{}
 	_ resource.ResourceWithImportState  = &flexibleBoardResource{}
+	_ resource.ResourceWithModifyPlan   = &flexibleBoardResource{}
 	_ resource.ResourceWithUpgradeState = &flexibleBoardResource{}
 )
 
 type flexibleBoardResource struct {
-	client *client.Client
+	client      *client.Client
+	defaultTags map[string]string
 }
 
 func NewFlexibleBoardResource() resource.Resource {
@@ -58,6 +60,11 @@ func (r *flexibleBoardResource) Configure(_ context.Context, req resource.Config
 		return
 	}
 	r.client = c
+	r.defaultTags = w.DefaultTags()
+}
+
+func (r *flexibleBoardResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	modifyPlanForDefaultTags(ctx, r.defaultTags, req, resp)
 }
 
 func (*flexibleBoardResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
@@ -99,7 +106,8 @@ func (*flexibleBoardResource) Schema(_ context.Context, _ resource.SchemaRequest
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
-			"tags": tagsSchema(),
+			"tags":     tagsSchema(),
+			"tags_all": tagsAllSchema(),
 		},
 		Blocks: map[string]schema.Block{
 			"panel": schema.ListNestedBlock{
@@ -619,6 +627,7 @@ func (*flexibleBoardResource) UpgradeState(ctx context.Context) map[int64]resour
 					URL:           oldState.URL,
 					Panels:        finalPanels,
 					Tags:          oldState.Tags,
+					TagsAll:       oldState.Tags,
 					PresetFilters: types.ListNull(types.ObjectType{AttrTypes: models.PresetFilterModelAttrType}),
 				}
 				resp.Diagnostics.Append(resp.State.Set(ctx, newState)...)
@@ -635,7 +644,7 @@ func (r *flexibleBoardResource) Create(ctx context.Context, req resource.CreateR
 		return
 	}
 
-	planTags, diags := helper.MapToTags(ctx, plan.Tags)
+	planTags, diags := helper.MapToTags(ctx, plan.TagsAll)
 	if diags.HasError() {
 		return
 	}
@@ -692,12 +701,13 @@ func (r *flexibleBoardResource) Create(ctx context.Context, req resource.CreateR
 		state.Panels = panels
 	}
 
-	tags, diags := helper.TagsToMap(ctx, board.Tags)
+	tagsAll, diags := helper.TagsToMap(ctx, board.Tags)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	state.Tags = tags
+	state.Tags = plan.Tags
+	state.TagsAll = tagsAll
 
 	state.PresetFilters = flattenPresetFilters(ctx, board.PresetFilters, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
@@ -779,12 +789,19 @@ func (r *flexibleBoardResource) Read(ctx context.Context, req resource.ReadReque
 		resp.Diagnostics.Append(diag...)
 		state.Panels = panels
 	}
-	tags, diags := helper.TagsToMap(ctx, board.Tags)
+	tagsAll, diags := helper.TagsToMap(ctx, board.Tags)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	state.Tags = tags
+	state.TagsAll = tagsAll
+
+	ownedTags, diags := helper.RemoveDefaultTags(ctx, board.Tags, r.defaultTags)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	state.Tags = ownedTags
 
 	state.PresetFilters = flattenPresetFilters(ctx, board.PresetFilters, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
@@ -803,7 +820,7 @@ func (r *flexibleBoardResource) Update(ctx context.Context, req resource.UpdateR
 		return
 	}
 
-	planTags, diags := helper.MapToTags(ctx, plan.Tags)
+	planTags, diags := helper.MapToTags(ctx, plan.TagsAll)
 	if diags.HasError() {
 		return
 	}
@@ -866,12 +883,13 @@ func (r *flexibleBoardResource) Update(ctx context.Context, req resource.UpdateR
 		state.Panels = panels
 	}
 
-	tags, diags := helper.TagsToMap(ctx, board.Tags)
+	tagsAll, diags := helper.TagsToMap(ctx, board.Tags)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	state.Tags = tags
+	state.Tags = plan.Tags
+	state.TagsAll = tagsAll
 
 	state.PresetFilters = flattenPresetFilters(ctx, board.PresetFilters, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -6,11 +6,15 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/honeycombio/terraform-provider-honeycombio/client"
@@ -32,12 +36,17 @@ type HoneycombioProvider struct {
 
 // HoneycombioProviderModel describes the provider data model.
 type HoneycombioProviderModel struct {
-	APIKey    types.String     `tfsdk:"api_key"`
-	KeyID     types.String     `tfsdk:"api_key_id"`
-	KeySecret types.String     `tfsdk:"api_key_secret"`
-	APIUrl    types.String     `tfsdk:"api_url"`
-	Debug     types.Bool       `tfsdk:"debug"`
-	Features  []features.Model `tfsdk:"features"`
+	APIKey      types.String       `tfsdk:"api_key"`
+	KeyID       types.String       `tfsdk:"api_key_id"`
+	KeySecret   types.String       `tfsdk:"api_key_secret"`
+	APIUrl      types.String       `tfsdk:"api_url"`
+	Debug       types.Bool         `tfsdk:"debug"`
+	Features    []features.Model   `tfsdk:"features"`
+	DefaultTags []defaultTagsModel `tfsdk:"default_tags"`
+}
+
+type defaultTagsModel struct {
+	Tags types.Map `tfsdk:"tags"`
 }
 
 func New(version string) provider.Provider {
@@ -75,6 +84,36 @@ func (p *HoneycombioProvider) Schema(_ context.Context, _ provider.SchemaRequest
 		},
 		Blocks: map[string]schema.Block{
 			"features": features.GetFeaturesBlock(),
+			"default_tags": schema.ListNestedBlock{
+				MarkdownDescription: "Default tags to apply to all supported resources. A tag set on an individual resource takes precedence over a default tag with the same key.",
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"tags": schema.MapAttribute{
+							MarkdownDescription: "A map of tags to apply to all supported resources.",
+							Optional:            true,
+							ElementType:         types.StringType,
+							Validators: []validator.Map{
+								mapvalidator.SizeAtMost(client.MaxTagsPerResource),
+								mapvalidator.KeysAre(
+									stringvalidator.RegexMatches(
+										client.TagKeyValidationRegex,
+										"must only contain lowercase letters, and be 1-32 characters long",
+									),
+								),
+								mapvalidator.ValueStringsAre(
+									stringvalidator.RegexMatches(
+										client.TagValueValidationRegex,
+										"must begin with a lowercase letter, be between 1-128 characters long, and only contain lowercase alphanumeric characters, -, or /",
+									),
+								),
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -208,6 +247,15 @@ func (p *HoneycombioProvider) Configure(ctx context.Context, req provider.Config
 		features: parsedFeatures,
 	}
 
+	defaultTags := map[string]string{}
+	if len(config.DefaultTags) > 0 && !config.DefaultTags[0].Tags.IsNull() && !config.DefaultTags[0].Tags.IsUnknown() {
+		resp.Diagnostics.Append(config.DefaultTags[0].Tags.ElementsAs(ctx, &defaultTags, false)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+	cc.defaultTags = defaultTags
+
 	debug := log.IsDebugOrHigher()
 	if !config.Debug.IsNull() {
 		debug = config.Debug.ValueBool()
@@ -251,9 +299,14 @@ func (p *HoneycombioProvider) Configure(ctx context.Context, req provider.Config
 
 // ConfiguredClient is a wrapper around the configured Honeycomb API clients.
 type ConfiguredClient struct {
-	v1client *client.Client
-	v2client *v2client.Client
-	features *features.Features
+	v1client    *client.Client
+	v2client    *v2client.Client
+	features    *features.Features
+	defaultTags map[string]string
+}
+
+func (c *ConfiguredClient) DefaultTags() map[string]string {
+	return c.defaultTags
 }
 
 func (c *ConfiguredClient) V1Client() (*client.Client, error) {

--- a/internal/provider/slo_resource.go
+++ b/internal/provider/slo_resource.go
@@ -29,10 +29,12 @@ var (
 	_ resource.Resource                = &sloResource{}
 	_ resource.ResourceWithConfigure   = &sloResource{}
 	_ resource.ResourceWithImportState = &sloResource{}
+	_ resource.ResourceWithModifyPlan  = &sloResource{}
 )
 
 type sloResource struct {
-	client *client.Client
+	client      *client.Client
+	defaultTags map[string]string
 }
 
 func NewSLOResource() resource.Resource {
@@ -55,6 +57,7 @@ func (r *sloResource) Configure(_ context.Context, req resource.ConfigureRequest
 		return
 	}
 	r.client = c
+	r.defaultTags = w.DefaultTags()
 }
 
 func (*sloResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
@@ -127,9 +130,14 @@ the column evaluation should consistently return nil, true, or false, as these a
 					int64validator.AtLeast(1),
 				},
 			},
-			"tags": tagsSchema(),
+			"tags":     tagsSchema(),
+			"tags_all": tagsAllSchema(),
 		},
 	}
+}
+
+func (r *sloResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	modifyPlanForDefaultTags(ctx, r.defaultTags, req, resp)
 }
 
 func (r *sloResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
@@ -150,6 +158,7 @@ func (r *sloResource) ImportState(ctx context.Context, req resource.ImportStateR
 		Dataset:  dsValue,
 		Datasets: types.SetUnknown(types.StringType),
 		Tags:     types.MapUnknown(types.StringType),
+		TagsAll:  types.MapUnknown(types.StringType),
 	})...)
 }
 
@@ -194,12 +203,13 @@ func (r *sloResource) Create(ctx context.Context, req resource.CreateRequest, re
 	}
 	state.Datasets = datasetsSet
 
-	tags, diags := helper.TagsToMap(ctx, slo.Tags)
+	tagsAll, diags := helper.TagsToMap(ctx, slo.Tags)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	state.Tags = tags
+	state.Tags = plan.Tags
+	state.TagsAll = tagsAll
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 	if resp.Diagnostics.HasError() {
@@ -255,12 +265,19 @@ func (r *sloResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 	}
 	state.Datasets = datasetsSet
 
-	tags, diags := helper.TagsToMap(ctx, slo.Tags)
+	tagsAll, diags := helper.TagsToMap(ctx, slo.Tags)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	state.Tags = tags
+	state.TagsAll = tagsAll
+
+	ownedTags, diags := helper.RemoveDefaultTags(ctx, slo.Tags, r.defaultTags)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	state.Tags = ownedTags
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 	if resp.Diagnostics.HasError() {
@@ -309,12 +326,13 @@ func (r *sloResource) Update(ctx context.Context, req resource.UpdateRequest, re
 	}
 	state.Datasets = datasetsSet
 
-	tags, diags := helper.TagsToMap(ctx, slo.Tags)
+	tagsAll, diags := helper.TagsToMap(ctx, slo.Tags)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	state.Tags = tags
+	state.Tags = plan.Tags
+	state.TagsAll = tagsAll
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 	if resp.Diagnostics.HasError() {
@@ -367,7 +385,7 @@ func expandSLO(ctx context.Context, plan models.SLOResourceModel) (*client.SLO, 
 		}
 	}
 
-	tags, diags := helper.MapToTags(ctx, plan.Tags)
+	tags, diags := helper.MapToTags(ctx, plan.TagsAll)
 	if diags.HasError() {
 		return nil, fmt.Errorf("error extracting tags: %v", diags)
 	}

--- a/internal/provider/slo_resource_test.go
+++ b/internal/provider/slo_resource_test.go
@@ -113,6 +113,59 @@ resource "honeycombio_slo" "test" {
 	})
 }
 
+func TestAccHoneycombioSLO_defaultTags(t *testing.T) {
+	dataset, sliAlias := sloAccTestSetup(t)
+
+	config := fmt.Sprintf(`
+provider "honeycombio" {
+  default_tags {
+    tags = {
+      team = "sre"
+      env  = "prod"
+    }
+  }
+}
+
+resource "honeycombio_slo" "test" {
+  name              = "TestAcc SLO default_tags"
+  dataset           = "%s"
+  sli               = "%s"
+  target_percentage = 99.9
+  time_period       = 30
+
+  tags = {
+    team = "platform"
+  }
+}`, dataset, sliAlias)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 testAccPreCheck(t),
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					// tags holds only the resource-owned tags
+					resource.TestCheckResourceAttr("honeycombio_slo.test", "tags.%", "1"),
+					resource.TestCheckResourceAttr("honeycombio_slo.test", "tags.team", "platform"),
+					// tags_all is the effective set, with the resource winning on `team`
+					resource.TestCheckResourceAttr("honeycombio_slo.test", "tags_all.%", "2"),
+					resource.TestCheckResourceAttr("honeycombio_slo.test", "tags_all.team", "platform"),
+					resource.TestCheckResourceAttr("honeycombio_slo.test", "tags_all.env", "prod"),
+				),
+			},
+			{ // re-applying the same config must produce no diff
+				Config: config,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
 // Checks to ensure that if an SLO was removed from Honeycomb outside of Terraform (UI or API)
 // that it is detected and planned for recreation.
 func TestAccHoneycombioSLO_RecreateOnNotFound(t *testing.T) {

--- a/internal/provider/tags.go
+++ b/internal/provider/tags.go
@@ -1,16 +1,22 @@
 package provider
 
 import (
+	"context"
+
 	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/honeycombio/terraform-provider-honeycombio/client"
+	"github.com/honeycombio/terraform-provider-honeycombio/internal/helper"
 	"github.com/honeycombio/terraform-provider-honeycombio/internal/helper/modifiers"
 )
 
@@ -46,4 +52,35 @@ func tagsSchema() schema.MapAttribute {
 			),
 		},
 	}
+}
+
+func tagsAllSchema() schema.MapAttribute {
+	return schema.MapAttribute{
+		Description: "The effective tags on the resource: the provider's `default_tags` merged with the resource's `tags` (resource tags win on a key collision).",
+		Computed:    true,
+		ElementType: types.StringType,
+		PlanModifiers: []planmodifier.Map{
+			mapplanmodifier.UseStateForUnknown(),
+		},
+	}
+}
+
+func modifyPlanForDefaultTags(ctx context.Context, defaults map[string]string, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	if req.Plan.Raw.IsNull() {
+		return
+	}
+
+	var tags types.Map
+	resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, path.Root("tags"), &tags)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tagsAll, diags := helper.MergeTags(ctx, defaults, tags)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root("tags_all"), tagsAll)...)
 }

--- a/internal/provider/trigger_resource.go
+++ b/internal/provider/trigger_resource.go
@@ -38,6 +38,7 @@ var (
 	_ resource.Resource                   = &triggerResource{}
 	_ resource.ResourceWithConfigure      = &triggerResource{}
 	_ resource.ResourceWithImportState    = &triggerResource{}
+	_ resource.ResourceWithModifyPlan     = &triggerResource{}
 	_ resource.ResourceWithValidateConfig = &triggerResource{}
 )
 
@@ -46,8 +47,9 @@ func NewTriggerResource() resource.Resource {
 }
 
 type triggerResource struct {
-	client  *client.Client
-	feature features.FeaturesIntelligence
+	client      *client.Client
+	feature     features.FeaturesIntelligence
+	defaultTags map[string]string
 }
 
 // matches HH:mm timestamps with optional leading 0
@@ -152,7 +154,8 @@ func (r *triggerResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 					),
 				},
 			},
-			"tags": tagsSchema(),
+			"tags":     tagsSchema(),
+			"tags_all": tagsAllSchema(),
 		},
 		Blocks: map[string]schema.Block{
 			"threshold": schema.ListNestedBlock{
@@ -272,6 +275,11 @@ func (r *triggerResource) Configure(_ context.Context, req resource.ConfigureReq
 		return
 	}
 	r.feature = f.Intelligence
+	r.defaultTags = w.DefaultTags()
+}
+
+func (r *triggerResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	modifyPlanForDefaultTags(ctx, r.defaultTags, req, resp)
 }
 
 func (r *triggerResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
@@ -292,7 +300,7 @@ func (r *triggerResource) Create(ctx context.Context, req resource.CreateRequest
 		return
 	}
 
-	planTags, diags := helper.MapToTags(ctx, plan.Tags)
+	planTags, diags := helper.MapToTags(ctx, plan.TagsAll)
 	if diags.HasError() {
 		return
 	}
@@ -379,7 +387,8 @@ func (r *triggerResource) Create(ctx context.Context, req resource.CreateRequest
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	state.Tags = stateTags
+	state.Tags = plan.Tags
+	state.TagsAll = stateTags
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }
@@ -451,12 +460,19 @@ func (r *triggerResource) Read(ctx context.Context, req resource.ReadRequest, re
 		}
 	}
 
-	tags, diags := helper.TagsToMap(ctx, trigger.Tags)
+	tagsAll, diags := helper.TagsToMap(ctx, trigger.Tags)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	state.Tags = tags
+	state.TagsAll = tagsAll
+
+	ownedTags, diags := helper.RemoveDefaultTags(ctx, trigger.Tags, r.defaultTags)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	state.Tags = ownedTags
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }
@@ -479,7 +495,7 @@ func (r *triggerResource) Update(ctx context.Context, req resource.UpdateRequest
 		return
 	}
 
-	planTags, diags := helper.MapToTags(ctx, plan.Tags)
+	planTags, diags := helper.MapToTags(ctx, plan.TagsAll)
 	if diags.HasError() {
 		return
 	}
@@ -574,7 +590,8 @@ func (r *triggerResource) Update(ctx context.Context, req resource.UpdateRequest
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	state.Tags = stateTags
+	state.Tags = plan.Tags
+	state.TagsAll = stateTags
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -107,6 +107,7 @@ Arguments accepted by this provider include:
 * `api_url` - (Optional) Override the URL of the Honeycomb.io API. It can also be set using `HONEYCOMB_API_ENDPOINT`. Defaults to `https://api.honeycomb.io`.
 * `debug` - (Optional) Enable to log additional debug information. To view the logs, set `TF_LOG` to at least debug.
 * `features` - (Optional) The features block allows customization of the behavior of the Honeycomb Provider. Full details documented below.
+* `default_tags` - (Optional) A `default_tags` block as defined below. Applies a common set of tags to all supported resources.
 
 At least one of `api_key`, or the `api_key_id` and `api_key_secret` pair must be configured.
 
@@ -160,3 +161,28 @@ The `intelligence` block supports the following:
 * `enabled` - (Optional) Set to `true` to enable intelligence features such as `auto_investigate` on triggers and burn alerts. Defaults to `false`.
 
 ~> **Note** [Honeycomb Intelligence](https://docs.honeycomb.io/security-compliance/honeycomb-intelligence) must first be enabled for your team in the Honeycomb UI before using this block. The `intelligence` feature block in the provider tells Terraform that your team has Honeycomb Intelligence enabled and unlocks related attributes like `auto_investigate`.
+
+## Default Tags
+
+The `default_tags` block applies a common set of tags to every resource that supports tags (`honeycombio_slo`, `honeycombio_flexible_board`, and `honeycombio_trigger`).
+A tag set directly on a resource takes precedence over a default tag with the same key.
+Each resource exposes a computed `tags_all` attribute showing the effective set of tags after the defaults are merged in.
+
+### Example Usage
+
+```hcl
+provider "honeycombio" {
+  default_tags {
+    tags = {
+      team = "sre"
+      env  = "prod"
+    }
+  }
+}
+```
+
+### Arguments Reference
+
+The `default_tags` block supports the following:
+
+* `tags` - (Optional) A map of tags to apply to all supported resources.


### PR DESCRIPTION
Adds a provider-level `default_tags` block that applies a common set of tags to all tag-supporting resources (`honeycombio_slo`, `honeycombio_flexible_board`, `honeycombio_trigger`), following the standard `default_tags`/`tags_all` pattern.

```hcl
provider "honeycombio" {
  default_tags {
    tags = {
      team = "sre"
      env  = "prod"
    }
  }
}
```

- New `default_tags { tags = {...} }` block on the provider (added to both the Framework and SDKv2 providers so the muxed schemas match).
- Resources keep their `tags` argument (as configured) and gain a computed `tags_all`: the defaults merged with resource tags, where resource tags win on a key collision.
- The merge runs at plan time, so there is no perpetual diff. `tags_all` is the set sent to the API.

Note: as with the AWS provider's `default_tags`, a resource tag whose key and value both equal a default is absorbed on read and can show a one-time diff.

Tested with `go build` / `go vet` / `golangci-lint` (clean), unit tests for the merge helpers, and an SLO acceptance test covering merge, precedence, and no-perpetual-diff.