### PR TITLE
test: handle API-populated AutoInvestigate in trigger create tests

### DIFF
--- a/client/trigger_test.go
+++ b/client/trigger_test.go
@@ -74,6 +74,7 @@ func TestTriggers(t *testing.T) {
 		data.ID = trigger.ID
 		data.QueryID = trigger.QueryID
 		data.AlertType = trigger.AlertType
+		data.AutoInvestigate = trigger.AutoInvestigate
 		data.Recipients[0].ID = trigger.Recipients[0].ID
 		// set default time range
 		data.Query.TimeRange = client.ToPtr(300)
@@ -333,6 +334,7 @@ func TestTriggersWithBaselineDetails(t *testing.T) {
 		data.ID = trigger.ID
 		data.QueryID = trigger.QueryID
 		data.AlertType = trigger.AlertType
+		data.AutoInvestigate = trigger.AutoInvestigate
 		data.Recipients[0].ID = trigger.Recipients[0].ID
 		// set default time range
 		data.Query.TimeRange = client.ToPtr(900)


### PR DESCRIPTION
## What

Fixes the failing scheduled **Test US** CI run ([example run](https://github.com/honeycombio/terraform-provider-honeycombio/actions/runs/27730572834)).

Two client acceptance subtests were failing on `assert.Equal(t, data, trigger)`:
- `TestTriggers/Create`
- `TestTriggersWithBaselineDetails/Create - with baseline details`

The only difference between expected and actual was the `AutoInvestigate` field:
```
expected: AutoInvestigate:(*bool)(nil)
actual  : AutoInvestigate:(*bool)(0x...)   // non-nil
```

## Why

The US Honeycomb API has started populating `auto_investigate` on triggers, returning a non-nil `*bool` where the test built an expected struct with `nil`. EU passed because that API change isn't live there yet — so this is a backend behavior change, not a provider regression.

## Fix

Copy the server-assigned `AutoInvestigate` value from the API response before the equality assertion in both subtests, matching how other server-populated fields (`ID`, `QueryID`, `AlertType`, recipient IDs) are already handled. This makes the tests resilient regardless of whether the API returns the field as `nil` or populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)