### PR TITLE
fix(r/burn_alerts): Enforce single recipient requirement

### DIFF
--- a/docs/resources/burn_alert.md
+++ b/docs/resources/burn_alert.md
@@ -161,7 +161,7 @@ resource "honeycombio_burn_alert" "example_alert" {
 - `dataset` (String) The dataset this Burn Alert is associated with. Will be deprecated in a future release.
 - `description` (String) A description for this Burn Alert.
 - `exhaustion_minutes` (Number) The amount of time, in minutes, remaining before the SLO's error budget will be exhausted and the alert will fire.
-- `recipient` (Block Set) Zero or more recipients to notify when the resource fires. (see [below for nested schema](#nestedblock--recipient))
+- `recipient` (Block Set) One or more recipients to notify when the resource fires. (see [below for nested schema](#nestedblock--recipient))
 
 ### Read-Only
 

--- a/internal/provider/burn_alert_resource.go
+++ b/internal/provider/burn_alert_resource.go
@@ -146,7 +146,8 @@ func (*burnAlertResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 			},
 		},
 		Blocks: map[string]schema.Block{
-			"recipient": notificationRecipientSchema(client.RecipientTypes()),
+			// Burn Alerts require at least one recipient
+			"recipient": notificationRecipientSchema(client.RecipientTypes(), 1),
 		},
 	}
 }

--- a/internal/provider/burn_alert_resource.go
+++ b/internal/provider/burn_alert_resource.go
@@ -146,8 +146,8 @@ func (*burnAlertResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 			},
 		},
 		Blocks: map[string]schema.Block{
-			// Burn Alerts require at least one recipient
-			"recipient": notificationRecipientSchema(client.RecipientTypes(), 1),
+			// Burn Alerts require at least one recipient (enforced in ValidateConfig)
+			"recipient": notificationRecipientSchema(client.RecipientTypes(), true),
 		},
 	}
 }
@@ -223,6 +223,16 @@ func (r *burnAlertResource) ValidateConfig(ctx context.Context, req resource.Val
 
 	if resp.Diagnostics.HasError() {
 		return
+	}
+
+	// A burn alert requires at least one recipient; we need additional validation from
+	// the schema set validation to ensure the set is actually provided.
+	if !data.Recipients.IsUnknown() && len(data.Recipients.Elements()) == 0 {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("recipient"),
+			"Missing required argument",
+			`At least one "recipient" block is required for a burn alert.`,
+		)
 	}
 
 	// When alert_type is exhaustion_time, check that exhaustion_minutes

--- a/internal/provider/burn_alert_resource_test.go
+++ b/internal/provider/burn_alert_resource_test.go
@@ -450,6 +450,25 @@ func TestAcc_BurnAlertResource_validateBudgetRate(t *testing.T) {
 	})
 }
 
+func TestAcc_BurnAlertResource_validateRequiresRecipient(t *testing.T) {
+	dataset, sloID := burnAlertAccTestSetup(t)
+
+	budgetRateWindowMinutes := 60
+	budgetRateDecreasePercent := float64(5)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 testAccPreCheck(t),
+		ProtoV6ProviderFactories: testAccProtoV6MuxServerFactory,
+		CheckDestroy:             testAccEnsureBurnAlertDestroyed(t),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccConfigBurnAlertBudgetRate_noRecipient(budgetRateWindowMinutes, budgetRateDecreasePercent, dataset, sloID),
+				ExpectError: regexp.MustCompile(`set must contain at least 1 element`),
+			},
+		},
+	})
+}
+
 func TestAcc_BurnAlertResource_validateUnknownOrVariableAttributesExhaustionTime(t *testing.T) {
 	dataset, sloID := burnAlertAccTestSetup(t)
 	burnAlert := &client.BurnAlert{}
@@ -1103,7 +1122,7 @@ resource "honeycombio_burn_alert" "test" {
   dataset            = "%[2]s"
   slo_id             = "%[3]s"
   description        = "%[5]s"
-  
+
   recipient {
     id = honeycombio_pagerduty_recipient.test.id
 
@@ -1126,7 +1145,7 @@ resource "honeycombio_burn_alert" "test" {
 
   slo_id             = "%[2]s"
   description        = "%[4]s"
-  
+
   recipient {
     id = honeycombio_pagerduty_recipient.test.id
 
@@ -1212,7 +1231,7 @@ resource "honeycombio_burn_alert" "test" {
   recipient {
 	id = honeycombio_webhook_recipient.test.id
 
-	notification_details {	
+	notification_details {
  		variable {
  			name = "severity"
  			value = "%[6]s"
@@ -1262,7 +1281,7 @@ resource "honeycombio_burn_alert" "test" {
   recipient {
 	id = honeycombio_webhook_recipient.test.id
 
-	notification_details {	
+	notification_details {
  		variable {
  			name = "severity"
  			value = "info"
@@ -1359,6 +1378,19 @@ resource "honeycombio_burn_alert" "test" {
     }
   }
 }`, budgetRateWindowMinutes, helper.FloatToPercentString(budgetRateDecreasePercent), dataset, sloID, pdseverity, testBADescription)
+}
+
+func testAccConfigBurnAlertBudgetRate_noRecipient(budgetRateWindowMinutes int, budgetRateDecreasePercent float64, dataset, sloID string) string {
+	return fmt.Sprintf(`
+resource "honeycombio_burn_alert" "test" {
+  alert_type                   = "budget_rate"
+  description                  = "%[5]s"
+  budget_rate_window_minutes   = %[1]d
+  budget_rate_decrease_percent = %[2]s
+
+  dataset = "%[3]s"
+  slo_id  = "%[4]s"
+}`, budgetRateWindowMinutes, helper.FloatToPercentString(budgetRateDecreasePercent), dataset, sloID, testBADescription)
 }
 
 func testAccConfigBurnAlertBudgetRate_basic_dataset_deprecation(budgetRateWindowMinutes int, budgetRateDecreasePercent float64, sloID, pdseverity string) string {
@@ -1489,8 +1521,8 @@ resource "honeycombio_burn_alert" "test" {
 
   recipient {
 	id = honeycombio_webhook_recipient.test.id
-	
-	notification_details {	
+
+	notification_details {
 		variable {
 			name = "severity"
 			value = "%[7]s"
@@ -1541,8 +1573,8 @@ resource "honeycombio_burn_alert" "test" {
 
   recipient {
 	id = honeycombio_webhook_recipient.test.id
-	
-	notification_details {	
+
+	notification_details {
 		variable {
 			name = "severity"
 			value = "info"

--- a/internal/provider/burn_alert_resource_test.go
+++ b/internal/provider/burn_alert_resource_test.go
@@ -461,9 +461,15 @@ func TestAcc_BurnAlertResource_validateRequiresRecipient(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6MuxServerFactory,
 		CheckDestroy:             testAccEnsureBurnAlertDestroyed(t),
 		Steps: []resource.TestStep{
+			// no recipient block at all (null set)
 			{
 				Config:      testAccConfigBurnAlertBudgetRate_noRecipient(budgetRateWindowMinutes, budgetRateDecreasePercent, dataset, sloID),
-				ExpectError: regexp.MustCompile(`set must contain at least 1 element`),
+				ExpectError: regexp.MustCompile(`At least one "recipient" block is required`),
+			},
+			// an explicitly empty set (dynamic block with an empty for_each)
+			{
+				Config:      testAccConfigBurnAlertBudgetRate_emptyRecipientSet(budgetRateWindowMinutes, budgetRateDecreasePercent, dataset, sloID),
+				ExpectError: regexp.MustCompile(`At least one "recipient" block is required`),
 			},
 		},
 	})
@@ -1390,6 +1396,28 @@ resource "honeycombio_burn_alert" "test" {
 
   dataset = "%[3]s"
   slo_id  = "%[4]s"
+}`, budgetRateWindowMinutes, helper.FloatToPercentString(budgetRateDecreasePercent), dataset, sloID, testBADescription)
+}
+
+func testAccConfigBurnAlertBudgetRate_emptyRecipientSet(budgetRateWindowMinutes int, budgetRateDecreasePercent float64, dataset, sloID string) string {
+	return fmt.Sprintf(`
+resource "honeycombio_burn_alert" "test" {
+  alert_type                   = "budget_rate"
+  description                  = "%[5]s"
+  budget_rate_window_minutes   = %[1]d
+  budget_rate_decrease_percent = %[2]s
+
+  dataset = "%[3]s"
+  slo_id  = "%[4]s"
+
+  dynamic "recipient" {
+    for_each = []
+
+    content {
+      type   = recipient.value.type
+      target = recipient.value.target
+    }
+  }
 }`, budgetRateWindowMinutes, helper.FloatToPercentString(budgetRateDecreasePercent), dataset, sloID, testBADescription)
 }
 

--- a/internal/provider/notification_recipients.go
+++ b/internal/provider/notification_recipients.go
@@ -28,10 +28,22 @@ import (
 	"github.com/honeycombio/terraform-provider-honeycombio/internal/models"
 )
 
-func notificationRecipientSchema(allowedTypes []client.RecipientType) schema.SetNestedBlock {
+func notificationRecipientSchema(
+	allowedTypes []client.RecipientType,
+	minRecipients int,
+) schema.SetNestedBlock {
+
+	description := "Zero or more recipients to notify when the resource fires."
+	var validators []validator.Set
+	if minRecipients > 0 {
+		description = "One or more recipients to notify when the resource fires."
+		validators = append(validators, setvalidator.SizeAtLeast(minRecipients))
+	}
+
 	return schema.SetNestedBlock{
-		Description:   "Zero or more recipients to notify when the resource fires.",
+		Description:   description,
 		PlanModifiers: []planmodifier.Set{modifiers.NotificationRecipients()},
+		Validators:    validators,
 		NestedObject: schema.NestedBlockObject{
 			Validators: []validator.Object{
 				objectvalidator.AtLeastOneOf(

--- a/internal/provider/notification_recipients.go
+++ b/internal/provider/notification_recipients.go
@@ -30,20 +30,19 @@ import (
 
 func notificationRecipientSchema(
 	allowedTypes []client.RecipientType,
-	minRecipients int,
+	requireRecipient bool,
 ) schema.SetNestedBlock {
-
+	// The requirement is enforced by each resource's ValidateConfig (a block-level
+	// SizeAtLeast validator does not fire on an omitted/null block); this only sets
+	// the documented description to match.
 	description := "Zero or more recipients to notify when the resource fires."
-	var validators []validator.Set
-	if minRecipients > 0 {
+	if requireRecipient {
 		description = "One or more recipients to notify when the resource fires."
-		validators = append(validators, setvalidator.SizeAtLeast(minRecipients))
 	}
 
 	return schema.SetNestedBlock{
 		Description:   description,
 		PlanModifiers: []planmodifier.Set{modifiers.NotificationRecipients()},
-		Validators:    validators,
 		NestedObject: schema.NestedBlockObject{
 			Validators: []validator.Object{
 				objectvalidator.AtLeastOneOf(

--- a/internal/provider/trigger_resource.go
+++ b/internal/provider/trigger_resource.go
@@ -223,7 +223,7 @@ func (r *triggerResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 					},
 				},
 			},
-			"recipient": notificationRecipientSchema(client.TriggerRecipientTypes(), 0),
+			"recipient": notificationRecipientSchema(client.TriggerRecipientTypes(), false),
 			"baseline_details": schema.ListNestedBlock{
 				Description: "A configuration block that allows you to receive notifications when the delta between values in your data, " +
 					"compared to a previous time period, cross thresholds you configure.",

--- a/internal/provider/trigger_resource.go
+++ b/internal/provider/trigger_resource.go
@@ -223,7 +223,7 @@ func (r *triggerResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 					},
 				},
 			},
-			"recipient": notificationRecipientSchema(client.TriggerRecipientTypes()),
+			"recipient": notificationRecipientSchema(client.TriggerRecipientTypes(), 0),
 			"baseline_details": schema.ListNestedBlock{
 				Description: "A configuration block that allows you to receive notifications when the delta between values in your data, " +
 					"compared to a previous time period, cross thresholds you configure.",


### PR DESCRIPTION
## Which problem is this PR solving?

- Closes #874 
- Fixes: https://linear.app/honeycombio/issue/APPO11Y-4716

## Short description of the changes

Currently, both the web frontend and the API require that every burn alert has at least one recipient. The provider did not check this enforcement.

While it would arguably be better if we didn't have this restriction, it's currently entrenched in the product, and I'd like to follow up separately on lifting this restriction. For now, it isn't safe to just remove the restriction since some application logic breaks.

Thus, I'm doing the minimal thing here of enforcing this behavior at plan-time, rather than an apply-time failure.

Note: The docs currently still list this as optional. I think this is a limitation of the docs generation on SetNestedBlock - there's currently no way for me to mark this as required, other than via the validation.

## How to verify that this has the expected result

1. Test Automation Coverage
2. Run through the repro in the issue - it should fail at plan-time now.