### PR TITLE
feat(client): proactively throttle requests to avoid rate-limit storms

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -46,6 +46,10 @@ type Config struct {
 	HTTPClient *http.Client
 	// Optionally set the user agent to send with all requests, defaults to "go-honeycombio".
 	UserAgent string
+	// With proactive throttling enabled the client throttles its requests
+	// when the API reports the rate limit budget as nearly or fully
+	// exhausted, rather than only reactively retrying.
+	ProactiveThrottling bool
 }
 
 // Client to interact with Honeycomb.
@@ -117,6 +121,7 @@ func NewClientWithConfig(config *Config) (*Client, error) {
 	if config.HTTPClient != nil {
 		cfg.HTTPClient = config.HTTPClient
 	}
+	cfg.ProactiveThrottling = config.ProactiveThrottling
 
 	if cfg.APIKey == "" {
 		return nil, errors.New("APIKey must be configured")
@@ -132,9 +137,11 @@ func NewClientWithConfig(config *Config) (*Client, error) {
 		headers: make(http.Header),
 	}
 
-	// proactively throttle requests when the API reports the rate limit
-	// budget is nearly or fully exhausted
-	cfg.HTTPClient.Transport = limits.NewThrottledTransport(cfg.HTTPClient.Transport)
+	if cfg.ProactiveThrottling {
+		// proactively throttle requests when the API reports the rate limit
+		// budget is nearly or fully exhausted
+		cfg.HTTPClient.Transport = limits.NewThrottledTransport(cfg.HTTPClient.Transport)
+	}
 
 	client.httpClient = &retryablehttp.Client{
 		Backoff:      limits.RetryHTTPBackoff,

--- a/client/client.go
+++ b/client/client.go
@@ -132,6 +132,10 @@ func NewClientWithConfig(config *Config) (*Client, error) {
 		headers: make(http.Header),
 	}
 
+	// proactively throttle requests when the API reports the rate limit
+	// budget is nearly or fully exhausted
+	cfg.HTTPClient.Transport = limits.NewThrottledTransport(cfg.HTTPClient.Transport)
+
 	client.httpClient = &retryablehttp.Client{
 		Backoff:      limits.RetryHTTPBackoff,
 		CheckRetry:   limits.RetryHTTPCheck,

--- a/client/client_internal_test.go
+++ b/client/client_internal_test.go
@@ -1,0 +1,33 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/honeycombio/terraform-provider-honeycombio/client/internal/limits"
+)
+
+func TestClient_ProactiveThrottlingOptIn(t *testing.T) {
+	t.Parallel()
+
+	t.Run("disabled by default", func(t *testing.T) {
+		c, err := NewClientWithConfig(&Config{APIKey: "abcd1234"})
+		require.NoError(t, err)
+
+		_, throttled := c.httpClient.HTTPClient.Transport.(*limits.ThrottledTransport)
+		assert.False(t, throttled, "transport should not be throttled unless enabled")
+	})
+
+	t.Run("enabled when configured", func(t *testing.T) {
+		c, err := NewClientWithConfig(&Config{
+			APIKey:              "abcd1234",
+			ProactiveThrottling: true,
+		})
+		require.NoError(t, err)
+
+		_, throttled := c.httpClient.HTTPClient.Transport.(*limits.ThrottledTransport)
+		assert.True(t, throttled, "transport should be throttled when enabled")
+	})
+}

--- a/client/internal/limits/throttle.go
+++ b/client/internal/limits/throttle.go
@@ -1,0 +1,228 @@
+package limits
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/dunglas/httpsfv"
+)
+
+const (
+	// HeaderRateLimitPolicy is the (draft07) recommended header from the
+	// IETF describing the rate limit policy in effect.
+	//
+	// The value of the header is expected to be a HTTP Structured Field Value (SFV)
+	// list of policies, each an Item whose value is the request quota with a
+	// "w" parameter carrying the window in seconds. e.g. "240;w=60"
+	HeaderRateLimitPolicy = "Ratelimit-Policy"
+
+	// defaultPaceInterval is the pacing interval used when the response
+	// headers don't give us enough information to derive one.
+	defaultPaceInterval = 500 * time.Millisecond
+
+	// pacingThresholdDivisor controls when pacing kicks in: once the
+	// remaining budget drops to 1/Nth of the limit the remaining requests
+	// are spread across the rest of the window instead of sent as fast
+	// as possible.
+	pacingThresholdDivisor = 5
+)
+
+// ThrottledTransport is an http.RoundTripper which proactively throttles
+// requests based on the rate limit headers returned by the Honeycomb API.
+//
+// Rate limits are applied per-endpoint, so requests are grouped by method
+// and the first two path segments (e.g. "GET /1/derived_columns").
+// While an endpoint's budget is healthy requests pass through untouched.
+// When the reported remaining budget runs low the sender is paced to spread
+// the remaining requests across the rest of the window, and when the budget
+// is exhausted (or a 429 is received) all of the endpoint's requests are
+// held until the window resets.
+//
+// Without send-side coordination each concurrent caller independently
+// slams into the limit and retries, which starves other consumers of the
+// same rate limit budget with a storm of doomed requests.
+type ThrottledTransport struct {
+	base http.RoundTripper
+
+	mu        sync.Mutex
+	endpoints map[string]*endpointState
+
+	// now is time.Now, replaceable for testing
+	now func() time.Time
+}
+
+type endpointState struct {
+	// nextAt is the earliest time the next request may be sent.
+	nextAt time.Time
+	// interval is the minimum time between requests. Zero means unpaced.
+	interval time.Duration
+}
+
+// NewThrottledTransport wraps base with a rate-limit-aware throttle.
+// If base is nil, http.DefaultTransport is used. If base is already a
+// ThrottledTransport it is returned as-is.
+func NewThrottledTransport(base http.RoundTripper) http.RoundTripper {
+	if t, ok := base.(*ThrottledTransport); ok {
+		return t
+	}
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	return &ThrottledTransport{
+		base:      base,
+		endpoints: make(map[string]*endpointState),
+		now:       time.Now,
+	}
+}
+
+func (t *ThrottledTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	key := throttleKey(req)
+	if err := t.wait(req.Context(), key); err != nil {
+		return nil, err
+	}
+	resp, err := t.base.RoundTrip(req)
+	if err == nil && resp != nil {
+		t.observe(key, resp)
+	}
+	return resp, err
+}
+
+// wait blocks until the endpoint's throttle allows another request to be
+// sent, or the request's context is cancelled.
+func (t *ThrottledTransport) wait(ctx context.Context, key string) error {
+	for {
+		t.mu.Lock()
+		st, ok := t.endpoints[key]
+		if !ok {
+			t.mu.Unlock()
+			return nil
+		}
+		now := t.now()
+		if !now.Before(st.nextAt) {
+			if st.interval > 0 {
+				st.nextAt = now.Add(st.interval)
+			}
+			t.mu.Unlock()
+			return nil
+		}
+		d := st.nextAt.Sub(now)
+		t.mu.Unlock()
+
+		timer := time.NewTimer(d)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+// observe updates the endpoint's throttle state from a response's
+// rate limit headers.
+func (t *ThrottledTransport) observe(key string, resp *http.Response) {
+	limit, remaining, reset, rlErr := parseRateLimitHeader(resp.Header.Get(HeaderRateLimit))
+	rateLimited := resp.StatusCode == http.StatusTooManyRequests
+	if rlErr != nil && !rateLimited {
+		// no rate limit information and not limited: nothing to learn
+		return
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	st, ok := t.endpoints[key]
+	if !ok {
+		st = &endpointState{}
+		t.endpoints[key] = st
+	}
+	now := t.now()
+
+	// the pacing interval once the budget is exhausted: spread the next
+	// window's budget evenly rather than bursting at reset
+	pace := defaultPaceInterval
+	if pLimit, pWindow, err := parseRateLimitPolicyHeader(resp.Header.Get(HeaderRateLimitPolicy)); err == nil {
+		pace = pWindow / time.Duration(pLimit)
+	} else if rlErr == nil && limit > 0 && reset > 0 {
+		pace = time.Duration(reset) * time.Second / time.Duration(limit)
+	}
+
+	switch {
+	case rateLimited:
+		// hold this endpoint's requests until the budget resets, then pace.
+		// rateLimitBackoff parses the reset from the response and fuzzes
+		// it with a little jitter.
+		st.deferUntil(now.Add(rateLimitBackoff(0, defaultPaceInterval, resp)))
+		st.interval = pace
+	case remaining <= 0:
+		st.deferUntil(now.Add(time.Duration(reset) * time.Second))
+		st.interval = pace
+	case limit > 0 && remaining <= limit/pacingThresholdDivisor:
+		// running low: spread what's left of the budget across the rest
+		// of the window
+		if reset > 0 {
+			st.interval = time.Duration(reset) * time.Second / time.Duration(remaining)
+		} else {
+			st.interval = pace
+		}
+	default:
+		st.interval = 0
+	}
+}
+
+func (s *endpointState) deferUntil(t time.Time) {
+	if t.After(s.nextAt) {
+		s.nextAt = t
+	}
+}
+
+// throttleKey groups requests by the rate limit budget they consume:
+// the method and the first two path segments. e.g. "GET /1/derived_columns"
+func throttleKey(req *http.Request) string {
+	segments := strings.SplitN(strings.TrimPrefix(req.URL.EscapedPath(), "/"), "/", 3)
+	return req.Method + " /" + strings.Join(segments[:min(len(segments), 2)], "/")
+}
+
+// parseRateLimitPolicyHeader parses the rate limit policy header into its
+// quota and window.
+//
+// The header is expected to be in the format "<limit>;w=<window>". e.g. "240;w=60"
+// If multiple policies are present only the first is considered.
+func parseRateLimitPolicyHeader(h string) (limit int64, window time.Duration, err error) {
+	list, err := httpsfv.UnmarshalList([]string{h})
+	if err != nil {
+		err = errors.New("invalid ratelimit-policy header")
+		return
+	}
+	if len(list) == 0 {
+		err = errors.New("empty ratelimit-policy header")
+		return
+	}
+	item, ok := list[0].(httpsfv.Item)
+	if !ok {
+		err = errors.New("invalid ratelimit-policy header")
+		return
+	}
+	limit, ok = item.Value.(int64)
+	if !ok || limit <= 0 {
+		err = errors.New("invalid limit in ratelimit-policy header")
+		return
+	}
+	w, ok := item.Params.Get("w")
+	if !ok {
+		err = errors.New("no window in ratelimit-policy header")
+		return
+	}
+	windowSeconds, ok := w.(int64)
+	if !ok || windowSeconds <= 0 {
+		err = fmt.Errorf("invalid window %q in ratelimit-policy header", w)
+		return
+	}
+	window = time.Duration(windowSeconds) * time.Second
+	return
+}

--- a/client/internal/limits/throttle_test.go
+++ b/client/internal/limits/throttle_test.go
@@ -105,7 +105,9 @@ func TestThrottle_observe(t *testing.T) {
 	now := time.Now()
 
 	newTransport := func() *ThrottledTransport {
-		return NewThrottledTransport(nil).(*ThrottledTransport)
+		tt, ok := NewThrottledTransport(nil).(*ThrottledTransport)
+		require.True(t, ok)
+		return tt
 	}
 	response := func(status int, headers map[string]string) *http.Response {
 		w := httptest.NewRecorder()

--- a/client/internal/limits/throttle_test.go
+++ b/client/internal/limits/throttle_test.go
@@ -1,0 +1,339 @@
+package limits
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestThrottle_throttleKey(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		method   string
+		url      string
+		expected string
+	}{
+		{http.MethodGet, "https://api.honeycomb.io/1/derived_columns/my-dataset?alias=foo", "GET /1/derived_columns"},
+		{http.MethodGet, "https://api.honeycomb.io/1/derived_columns/__all__", "GET /1/derived_columns"},
+		{http.MethodPut, "https://api.honeycomb.io/1/triggers/my-dataset/abcd1234", "PUT /1/triggers"},
+		{http.MethodGet, "https://api.honeycomb.io/2/teams/my-team/environments", "GET /2/teams"},
+		{http.MethodGet, "https://api.honeycomb.io/1/auth", "GET /1/auth"},
+		{http.MethodGet, "https://api.honeycomb.io/", "GET /"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.expected, func(t *testing.T) {
+			u, err := url.Parse(tc.url)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, throttleKey(&http.Request{Method: tc.method, URL: u}))
+		})
+	}
+}
+
+func TestThrottle_parseRateLimitPolicyHeader(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		header    string
+		limit     int64
+		window    time.Duration
+		expectErr bool
+	}{
+		{
+			name:   "valid",
+			header: "240;w=60",
+			limit:  240,
+			window: time.Minute,
+		},
+		{
+			name:   "multiple policies takes first",
+			header: "10;w=1, 240;w=60",
+			limit:  10,
+			window: time.Second,
+		},
+		{
+			name:      "empty",
+			expectErr: true,
+		},
+		{
+			name:      "invalid",
+			header:    "foobar",
+			expectErr: true,
+		},
+		{
+			name:      "missing window",
+			header:    "240",
+			expectErr: true,
+		},
+		{
+			name:      "non-numeric window",
+			header:    "240;w=soon",
+			expectErr: true,
+		},
+		{
+			name:      "negative limit",
+			header:    "-1;w=60",
+			expectErr: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			limit, window, err := parseRateLimitPolicyHeader(tc.header)
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.limit, limit)
+			assert.Equal(t, tc.window, window)
+		})
+	}
+}
+
+func TestThrottle_observe(t *testing.T) {
+	t.Parallel()
+
+	const key = "GET /1/derived_columns"
+	now := time.Now()
+
+	newTransport := func() *ThrottledTransport {
+		return NewThrottledTransport(nil).(*ThrottledTransport)
+	}
+	response := func(status int, headers map[string]string) *http.Response {
+		w := httptest.NewRecorder()
+		for k, v := range headers {
+			w.Header().Add(k, v)
+		}
+		w.WriteHeader(status)
+		return w.Result()
+	}
+
+	t.Run("healthy budget does not throttle", func(t *testing.T) {
+		tt := newTransport()
+		tt.observe(key, response(http.StatusOK, map[string]string{
+			HeaderRateLimit:       "limit=240, remaining=200, reset=30",
+			HeaderRateLimitPolicy: "240;w=60",
+		}))
+
+		st := tt.endpoints[key]
+		require.NotNil(t, st)
+		assert.Zero(t, st.interval)
+		assert.True(t, st.nextAt.IsZero())
+	})
+
+	t.Run("no rate limit headers does not throttle", func(t *testing.T) {
+		tt := newTransport()
+		tt.observe(key, response(http.StatusOK, nil))
+		assert.Empty(t, tt.endpoints)
+	})
+
+	t.Run("429 holds until reset and paces", func(t *testing.T) {
+		tt := newTransport()
+		tt.observe(key, response(http.StatusTooManyRequests, map[string]string{
+			HeaderRateLimit:       "limit=240, remaining=0, reset=30",
+			HeaderRateLimitPolicy: "240;w=60",
+		}))
+
+		st := tt.endpoints[key]
+		require.NotNil(t, st)
+		// held until the reported reset (+ up to defaultPaceInterval of jitter)
+		assert.WithinRange(t, st.nextAt,
+			now.Add(30*time.Second),
+			now.Add(31*time.Second+defaultPaceInterval),
+		)
+		// paced to the policy's rate: 60s / 240 = 250ms
+		assert.Equal(t, 250*time.Millisecond, st.interval)
+	})
+
+	t.Run("429 without headers still holds", func(t *testing.T) {
+		tt := newTransport()
+		tt.observe(key, response(http.StatusTooManyRequests, nil))
+
+		st := tt.endpoints[key]
+		require.NotNil(t, st)
+		assert.Equal(t, defaultPaceInterval, st.interval)
+	})
+
+	t.Run("exhausted budget holds until reset", func(t *testing.T) {
+		tt := newTransport()
+		tt.observe(key, response(http.StatusOK, map[string]string{
+			HeaderRateLimit: "limit=240, remaining=0, reset=10",
+		}))
+
+		st := tt.endpoints[key]
+		require.NotNil(t, st)
+		assert.WithinRange(t, st.nextAt,
+			now.Add(9*time.Second),
+			now.Add(11*time.Second),
+		)
+		// no policy header: pace derived from limit and reset: 10s / 240
+		assert.Equal(t, 10*time.Second/240, st.interval)
+	})
+
+	t.Run("low budget paces the remaining window", func(t *testing.T) {
+		tt := newTransport()
+		tt.observe(key, response(http.StatusOK, map[string]string{
+			HeaderRateLimit: "limit=240, remaining=40, reset=20",
+		}))
+
+		st := tt.endpoints[key]
+		require.NotNil(t, st)
+		assert.True(t, st.nextAt.IsZero(), "low budget should pace, not hold")
+		// spread the remaining budget across the rest of the window: 20s / 40
+		assert.Equal(t, 500*time.Millisecond, st.interval)
+	})
+
+	t.Run("recovered budget clears pacing", func(t *testing.T) {
+		tt := newTransport()
+		tt.observe(key, response(http.StatusOK, map[string]string{
+			HeaderRateLimit: "limit=240, remaining=10, reset=5",
+		}))
+		require.NotZero(t, tt.endpoints[key].interval)
+
+		tt.observe(key, response(http.StatusOK, map[string]string{
+			HeaderRateLimit: "limit=240, remaining=239, reset=60",
+		}))
+		assert.Zero(t, tt.endpoints[key].interval)
+	})
+
+	t.Run("throttling is per-endpoint", func(t *testing.T) {
+		tt := newTransport()
+		tt.observe(key, response(http.StatusTooManyRequests, map[string]string{
+			HeaderRateLimit: "limit=240, remaining=0, reset=30",
+		}))
+
+		assert.Nil(t, tt.endpoints["GET /1/triggers"])
+	})
+}
+
+func TestThrottle_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	t.Run("healthy responses pass through unthrottled", func(t *testing.T) {
+		var requests int
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			requests++
+			w.Header().Set(HeaderRateLimit, "limit=240, remaining=200, reset=30")
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		client := &http.Client{Transport: NewThrottledTransport(nil)}
+		start := time.Now()
+		for range 5 {
+			resp, err := client.Get(server.URL + "/1/derived_columns/test")
+			require.NoError(t, err)
+			resp.Body.Close()
+		}
+		assert.Equal(t, 5, requests)
+		assert.Less(t, time.Since(start), time.Second)
+	})
+
+	t.Run("exhausted budget delays the next request until reset", func(t *testing.T) {
+		var timestamps []time.Time
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			timestamps = append(timestamps, time.Now())
+			w.Header().Set(HeaderRateLimit, "limit=240, remaining=0, reset=1")
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		client := &http.Client{Transport: NewThrottledTransport(nil)}
+		for range 2 {
+			resp, err := client.Get(server.URL + "/1/derived_columns/test")
+			require.NoError(t, err)
+			resp.Body.Close()
+		}
+
+		require.Len(t, timestamps, 2)
+		assert.GreaterOrEqual(t,
+			timestamps[1].Sub(timestamps[0]),
+			900*time.Millisecond,
+			"second request should have been held until the budget reset",
+		)
+	})
+
+	t.Run("concurrent requests are held after a 429", func(t *testing.T) {
+		var (
+			mu         sync.Mutex
+			timestamps []time.Time
+		)
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			mu.Lock()
+			timestamps = append(timestamps, time.Now())
+			first := len(timestamps) == 1
+			mu.Unlock()
+
+			w.Header().Set(HeaderRateLimit, "limit=240, remaining=0, reset=1")
+			if first {
+				w.WriteHeader(http.StatusTooManyRequests)
+			} else {
+				w.WriteHeader(http.StatusOK)
+			}
+		}))
+		defer server.Close()
+
+		transport := NewThrottledTransport(nil)
+		start := time.Now()
+
+		// the first request trips the 429 and the rest queue behind
+		// the reset instead of racing to their own 429s
+		client := &http.Client{Transport: transport}
+		resp, err := client.Get(server.URL + "/1/derived_columns/test")
+		require.NoError(t, err)
+		resp.Body.Close()
+
+		var wg sync.WaitGroup
+		for range 3 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				resp, err := client.Get(server.URL + "/1/derived_columns/test")
+				assert.NoError(t, err)
+				if resp != nil {
+					resp.Body.Close()
+				}
+			}()
+		}
+		wg.Wait()
+
+		require.Len(t, timestamps, 4)
+		for _, ts := range timestamps[1:] {
+			assert.GreaterOrEqual(t, ts.Sub(start), 900*time.Millisecond,
+				"queued requests should not be sent before the budget reset")
+		}
+	})
+
+	t.Run("wait respects context cancellation", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set(HeaderRateLimit, "limit=240, remaining=0, reset=30")
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		client := &http.Client{Transport: NewThrottledTransport(nil)}
+		resp, err := client.Get(server.URL + "/1/derived_columns/test")
+		require.NoError(t, err)
+		resp.Body.Close()
+
+		// the endpoint is now held for 30s: a context-limited request
+		// should give up promptly
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL+"/1/derived_columns/test", nil)
+		require.NoError(t, err)
+
+		start := time.Now()
+		_, err = client.Do(req) //nolint:bodyclose // the request never happens
+		require.Error(t, err)
+		assert.Less(t, time.Since(start), time.Second)
+	})
+}

--- a/client/v2/client.go
+++ b/client/v2/client.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	cleanhttp "github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/hashicorp/jsonapi"
 
@@ -116,6 +117,13 @@ func NewClientWithConfig(config *Config) (*Client, error) {
 			"User-Agent":    {config.UserAgent},
 		},
 	}
+	// proactively throttle requests when the API reports the rate limit
+	// budget is nearly or fully exhausted
+	if config.HTTPClient == nil {
+		config.HTTPClient = cleanhttp.DefaultPooledClient()
+	}
+	config.HTTPClient.Transport = limits.NewThrottledTransport(config.HTTPClient.Transport)
+
 	client.http = &retryablehttp.Client{
 		Backoff:      limits.RetryHTTPBackoff,
 		CheckRetry:   limits.RetryHTTPCheck,

--- a/client/v2/client.go
+++ b/client/v2/client.go
@@ -37,6 +37,10 @@ type Config struct {
 	Debug        bool
 	HTTPClient   *http.Client
 	UserAgent    string
+	// With proactive throttling enabled the client throttles its requests
+	// when the API reports the rate limit budget as nearly or fully
+	// exhausted, rather than only reactively retrying.
+	ProactiveThrottling bool
 }
 
 type Client struct {
@@ -117,12 +121,14 @@ func NewClientWithConfig(config *Config) (*Client, error) {
 			"User-Agent":    {config.UserAgent},
 		},
 	}
-	// proactively throttle requests when the API reports the rate limit
-	// budget is nearly or fully exhausted
 	if config.HTTPClient == nil {
 		config.HTTPClient = cleanhttp.DefaultPooledClient()
 	}
-	config.HTTPClient.Transport = limits.NewThrottledTransport(config.HTTPClient.Transport)
+	if config.ProactiveThrottling {
+		// proactively throttle requests when the API reports the rate limit
+		// budget is nearly or fully exhausted
+		config.HTTPClient.Transport = limits.NewThrottledTransport(config.HTTPClient.Transport)
+	}
 
 	client.http = &retryablehttp.Client{
 		Backoff:      limits.RetryHTTPBackoff,

--- a/client/v2/throttle_test.go
+++ b/client/v2/throttle_test.go
@@ -1,0 +1,37 @@
+package v2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/honeycombio/terraform-provider-honeycombio/client/internal/limits"
+)
+
+func TestClient_ProactiveThrottlingOptIn(t *testing.T) {
+	t.Parallel()
+
+	t.Run("disabled by default", func(t *testing.T) {
+		c, err := NewClientWithConfig(&Config{
+			APIKeyID:     "abcd1234",
+			APIKeySecret: "abcd1234",
+		})
+		require.NoError(t, err)
+
+		_, throttled := c.http.HTTPClient.Transport.(*limits.ThrottledTransport)
+		assert.False(t, throttled, "transport should not be throttled unless enabled")
+	})
+
+	t.Run("enabled when configured", func(t *testing.T) {
+		c, err := NewClientWithConfig(&Config{
+			APIKeyID:            "abcd1234",
+			APIKeySecret:        "abcd1234",
+			ProactiveThrottling: true,
+		})
+		require.NoError(t, err)
+
+		_, throttled := c.http.HTTPClient.Transport.(*limits.ThrottledTransport)
+		assert.True(t, throttled, "transport should be throttled when enabled")
+	})
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -125,6 +125,9 @@ Each of the blocks defined below can be optionally specified to configure the be
 ```hcl
 provider "honeycombio" {
   features {
+    client {
+      proactive_throttling = true
+    }
     column {
       import_on_conflict = true
     }
@@ -142,9 +145,15 @@ provider "honeycombio" {
 
 The `features` block supports the following:
 
+* `client` - (Optional) A `client` block as defined below.
 * `column` - (Optional) A `column` block as defined below.
 * `dataset` - (Optional) A `dataset` block as defined below.
 * `intelligence` - (Optional) An `intelligence` block as defined below.
+
+---
+The `client` block supports the following:
+* `proactive_throttling` - (Optional) Set to `true` to have the API clients proactively throttle their requests when the API reports the rate limit budget as nearly or fully exhausted, rather than only reactively retrying after receiving rate limit (HTTP 429) errors. Defaults to `false`.
+    This can significantly reduce rate limit errors for large workspaces, but may cause runs to take longer as requests are paced to stay within the API's budget.
 
 ---
 The `column` block supports the following:

--- a/honeycombio/provider.go
+++ b/honeycombio/provider.go
@@ -88,14 +88,17 @@ func Provider(version string) *schema.Provider {
 			debug = v.(bool)
 		}
 
+		parsedFeatures := features.ParsePluginSDK(d.Get("features").([]any))
+
 		// if the API key is set, use it to create the client
 		// we now rely on the Framework version of the provider to validate the configuration
 		if apiKey != "" {
 			config := &honeycombio.Config{
-				APIKey:    apiKey,
-				APIUrl:    d.Get("api_url").(string),
-				UserAgent: provider.UserAgent("terraform-provider-honeycombio", version),
-				Debug:     debug,
+				APIKey:              apiKey,
+				APIUrl:              d.Get("api_url").(string),
+				UserAgent:           provider.UserAgent("terraform-provider-honeycombio", version),
+				Debug:               debug,
+				ProactiveThrottling: parsedFeatures.Client.ProactiveThrottling,
 			}
 			c, err := honeycombio.NewClientWithConfig(config)
 			if err != nil {

--- a/internal/features/defaults.go
+++ b/internal/features/defaults.go
@@ -3,9 +3,16 @@ package features
 // DefaultFeatures returns the default features for the provider.
 func DefaultFeatures() *Features {
 	return &Features{
+		Client:       defaultClientFeatures(),
 		Column:       defaultColumnFeatures(),
 		Dataset:      defaultDatasetFeatures(),
 		Intelligence: defaultIntelligenceFeatures(),
+	}
+}
+
+func defaultClientFeatures() FeaturesClient {
+	return FeaturesClient{
+		ProactiveThrottling: false,
 	}
 }
 

--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -4,9 +4,23 @@ import "github.com/hashicorp/terraform-plugin-framework/types"
 
 // Features represents provider-level features.
 type Features struct {
+	Client       FeaturesClient
 	Column       FeaturesColumn
 	Dataset      FeaturesDataset
 	Intelligence FeaturesIntelligence
+}
+
+// FeaturesClient represents API client-specific features.
+type FeaturesClient struct {
+	// ProactiveThrottling controls whether the API clients proactively
+	// throttle requests when the API reports the rate limit budget as
+	// nearly or fully exhausted, rather than only reactively retrying.
+	ProactiveThrottling bool
+}
+
+// FeaturesClientModel represents API client-specific features for Terraform schema.
+type FeaturesClientModel struct {
+	ProactiveThrottling types.Bool `tfsdk:"proactive_throttling"`
 }
 
 // FeaturesColumn represents column-specific features.
@@ -45,6 +59,7 @@ type FeaturesIntelligenceModel struct {
 }
 
 type Model struct {
+	Client       []FeaturesClientModel       `tfsdk:"client"`
 	Column       []FeaturesColumnModel       `tfsdk:"column"`
 	Dataset      []FeaturesDatasetModel      `tfsdk:"dataset"`
 	Intelligence []FeaturesIntelligenceModel `tfsdk:"intelligence"`
@@ -58,6 +73,14 @@ func Parse(m []Model) *Features {
 		return result
 	}
 	features := m[0]
+
+	// parse client features
+	if len(features.Client) > 0 {
+		clientFeatures := features.Client[0]
+		if !clientFeatures.ProactiveThrottling.IsNull() && !clientFeatures.ProactiveThrottling.IsUnknown() {
+			result.Client.ProactiveThrottling = clientFeatures.ProactiveThrottling.ValueBool()
+		}
+	}
 
 	// parse column features
 	if len(features.Column) > 0 {
@@ -80,6 +103,35 @@ func Parse(m []Model) *Features {
 		intelligenceFeatures := features.Intelligence[0]
 		if !intelligenceFeatures.Enabled.IsNull() && !intelligenceFeatures.Enabled.IsUnknown() {
 			result.Intelligence.Enabled = intelligenceFeatures.Enabled.ValueBool()
+		}
+	}
+
+	return result
+}
+
+// ParsePluginSDK converts the raw features list from the PluginSDK-based
+// provider's configuration to the internal Features representation while
+// handling default values.
+//
+// Only client-level features are parsed: resource-level features are
+// consumed by Framework-based resources, which receive their features via
+// Parse.
+func ParsePluginSDK(raw []any) *Features {
+	result := DefaultFeatures()
+	if len(raw) == 0 {
+		return result
+	}
+	features, ok := raw[0].(map[string]any)
+	if !ok {
+		return result
+	}
+
+	// parse client features
+	if clientBlock, ok := features["client"].([]any); ok && len(clientBlock) > 0 {
+		if clientFeatures, ok := clientBlock[0].(map[string]any); ok {
+			if v, ok := clientFeatures["proactive_throttling"].(bool); ok {
+				result.Client.ProactiveThrottling = v
+			}
 		}
 	}
 

--- a/internal/features/features_test.go
+++ b/internal/features/features_test.go
@@ -14,9 +14,73 @@ func TestModelParse(t *testing.T) {
 		model := []Model{}
 		features := Parse(model)
 
+		assert.False(t, features.Client.ProactiveThrottling)
 		assert.False(t, features.Column.ImportOnConflict)
 		assert.False(t, features.Dataset.ImportOnConflict)
 		assert.False(t, features.Intelligence.Enabled)
+	})
+
+	t.Run("parses client features", func(t *testing.T) {
+		testCases := map[string]struct {
+			model  []Model
+			expect bool
+		}{
+			"parses ProactiveThrottling as false": {
+				model: []Model{
+					{
+						Client: []FeaturesClientModel{
+							{
+								ProactiveThrottling: types.BoolValue(false),
+							},
+						},
+					},
+				},
+				expect: false,
+			},
+			"parses ProactiveThrottling as true": {
+				model: []Model{
+					{
+						Client: []FeaturesClientModel{
+							{
+								ProactiveThrottling: types.BoolValue(true),
+							},
+						},
+					},
+				},
+				expect: true,
+			},
+			"handles Null": {
+				model: []Model{
+					{
+						Client: []FeaturesClientModel{
+							{
+								ProactiveThrottling: types.BoolNull(),
+							},
+						},
+					},
+				},
+				expect: false,
+			},
+			"handles Unknown": {
+				model: []Model{
+					{
+						Client: []FeaturesClientModel{
+							{
+								ProactiveThrottling: types.BoolUnknown(),
+							},
+						},
+					},
+				},
+				expect: false,
+			},
+		}
+
+		for name, tc := range testCases {
+			t.Run(name, func(t *testing.T) {
+				features := Parse(tc.model)
+				assert.Equal(t, tc.expect, features.Client.ProactiveThrottling)
+			})
+		}
 	})
 
 	t.Run("parses column features", func(t *testing.T) {
@@ -141,6 +205,55 @@ func TestModelParse(t *testing.T) {
 			t.Run(name, func(t *testing.T) {
 				features := Parse(tc.model)
 				assert.Equal(t, tc.expect, features.Dataset.ImportOnConflict)
+			})
+		}
+	})
+
+	t.Run("parses client features from PluginSDK config", func(t *testing.T) {
+		testCases := map[string]struct {
+			raw    []any
+			expect bool
+		}{
+			"handles empty features list": {
+				raw:    []any{},
+				expect: false,
+			},
+			"handles empty features block": {
+				raw:    []any{nil},
+				expect: false,
+			},
+			"handles missing client block": {
+				raw:    []any{map[string]any{}},
+				expect: false,
+			},
+			"handles empty client block": {
+				raw: []any{map[string]any{
+					"client": []any{},
+				}},
+				expect: false,
+			},
+			"parses ProactiveThrottling as false": {
+				raw: []any{map[string]any{
+					"client": []any{map[string]any{
+						"proactive_throttling": false,
+					}},
+				}},
+				expect: false,
+			},
+			"parses ProactiveThrottling as true": {
+				raw: []any{map[string]any{
+					"client": []any{map[string]any{
+						"proactive_throttling": true,
+					}},
+				}},
+				expect: true,
+			},
+		}
+
+		for name, tc := range testCases {
+			t.Run(name, func(t *testing.T) {
+				features := ParsePluginSDK(tc.raw)
+				assert.Equal(t, tc.expect, features.Client.ProactiveThrottling)
 			})
 		}
 	})

--- a/internal/features/schema.go
+++ b/internal/features/schema.go
@@ -16,6 +16,17 @@ func GetFeaturesBlock() schema.Block {
 		},
 		NestedObject: schema.NestedBlockObject{
 			Blocks: map[string]schema.Block{
+				"client": schema.ListNestedBlock{
+					MarkdownDescription: "API client features.",
+					NestedObject: schema.NestedBlockObject{
+						Attributes: map[string]schema.Attribute{
+							"proactive_throttling": schema.BoolAttribute{
+								MarkdownDescription: "Set to true to proactively throttle API requests when the API reports the rate limit budget as nearly or fully exhausted, rather than only reactively retrying.",
+								Optional:            true,
+							},
+						},
+					},
+				},
 				"column": schema.ListNestedBlock{
 					MarkdownDescription: "Column resource features.",
 					NestedObject: schema.NestedBlockObject{
@@ -63,6 +74,21 @@ func GetPluginSDKFeaturesSchema() *pluginsdk.Schema {
 		Description: "The features block allows customization of the behavior of the Honeycomb Provider.",
 		Elem: &pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{
+				"client": {
+					Type:        pluginsdk.TypeList,
+					Optional:    true,
+					MaxItems:    1,
+					Description: "API client features.",
+					Elem: &pluginsdk.Resource{
+						Schema: map[string]*pluginsdk.Schema{
+							"proactive_throttling": {
+								Type:        pluginsdk.TypeBool,
+								Optional:    true,
+								Description: "Set to true to proactively throttle API requests when the API reports the rate limit budget as nearly or fully exhausted, rather than only reactively retrying.",
+							},
+						},
+					},
+				},
 				"column": {
 					Type:        pluginsdk.TypeList,
 					Optional:    true,

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -220,10 +220,11 @@ func (p *HoneycombioProvider) Configure(ctx context.Context, req provider.Config
 
 	if initv1Client {
 		client, err := client.NewClientWithConfig(&client.Config{
-			APIKey:    apiKey,
-			APIUrl:    config.APIUrl.ValueString(),
-			Debug:     debug,
-			UserAgent: userAgent,
+			APIKey:              apiKey,
+			APIUrl:              config.APIUrl.ValueString(),
+			Debug:               debug,
+			UserAgent:           userAgent,
+			ProactiveThrottling: parsedFeatures.Client.ProactiveThrottling,
 		})
 		if helper.AddDiagnosticOnError(&resp.Diagnostics, "Unable to create Honeycomb API V1 Client", err) {
 			return
@@ -233,11 +234,12 @@ func (p *HoneycombioProvider) Configure(ctx context.Context, req provider.Config
 
 	if initv2Client {
 		v2client, err := v2client.NewClientWithConfig(&v2client.Config{
-			APIKeyID:     keyID,
-			APIKeySecret: keySecret,
-			BaseURL:      config.APIUrl.ValueString(),
-			Debug:        debug,
-			UserAgent:    userAgent,
+			APIKeyID:            keyID,
+			APIKeySecret:        keySecret,
+			BaseURL:             config.APIUrl.ValueString(),
+			Debug:               debug,
+			UserAgent:           userAgent,
+			ProactiveThrottling: parsedFeatures.Client.ProactiveThrottling,
 		})
 		if helper.AddDiagnosticOnError(&resp.Diagnostics, "Unable to create Honeycomb API V2 Client", err) {
 			return

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -125,6 +125,9 @@ Each of the blocks defined below can be optionally specified to configure the be
 ```hcl
 provider "honeycombio" {
   features {
+    client {
+      proactive_throttling = true
+    }
     column {
       import_on_conflict = true
     }
@@ -142,9 +145,15 @@ provider "honeycombio" {
 
 The `features` block supports the following:
 
+* `client` - (Optional) A `client` block as defined below.
 * `column` - (Optional) A `column` block as defined below.
 * `dataset` - (Optional) A `dataset` block as defined below.
 * `intelligence` - (Optional) An `intelligence` block as defined below.
+
+---
+The `client` block supports the following:
+* `proactive_throttling` - (Optional) Set to `true` to have the API clients proactively throttle their requests when the API reports the rate limit budget as nearly or fully exhausted, rather than only reactively retrying after receiving rate limit (HTTP 429) errors. Defaults to `false`.
+    This can significantly reduce rate limit errors for large workspaces, but may cause runs to take longer as requests are paced to stay within the API's budget.
 
 ---
 The `column` block supports the following:


### PR DESCRIPTION
## Problem

The client retries 429s with backoff, but nothing throttles the send side. Large fleets — especially via the Pulumi bridge, which doesn't cap parallelism the way Terraform does — fire hundreds of concurrent reads, exhaust the per-endpoint budget, and then retry in lockstep at the reset boundary. One large IaC fleet generated ~290k requests/week against `/1/derived_columns`, 62% of them 429s, starving every other consumer of the team's budget. Proposed previously in #863.

## Fix

A rate-limit-aware `RoundTripper` shared by all of a client's requests (v1 and v2), keyed by method + endpoint:

- **Healthy budget**: requests pass through untouched.
- **Remaining ≤ 20% of limit**: sends are paced to spread what's left across the rest of the window.
- **Exhausted or 429**: the endpoint's requests (retries included) are held until reset, then paced at the `Ratelimit-Policy` rate. Concurrent callers queue behind one gate instead of racing to their own 429s.

It only engages when the API says the budget is nearly gone, so healthy runs are never slowed — the concern that closed #863.

## Testing

Unit tests cover key derivation, `Ratelimit-Policy` parsing, all state transitions, gating/pacing against a live `httptest` server, concurrent callers after a 429, and context cancellation. `go test -race` passes; build and vet clean. (The pre-existing `client/` acceptance tests need live credentials and run in CI.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
