### PR TITLE
maint: prepare v0.53.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 0.53.0 (July 30, 2026)
+
+## Enhancements
+
+- feat(r/column): support histogram column type (#891)
+
+## Housekeeping
+
+- maint(deps): bump google.golang.org/grpc from 1.79.3 to 1.82.1 (#892)
+- maint(deps): bump actions/setup-go from 6 to 7 (#890)
+
 # 0.52.0 (July 16, 2026)
 
 ## Notes:

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ terraform {
   required_providers {
     honeycombio = {
       source  = "honeycombio/honeycombio"
-      version = "~> 0.52.0"
+      version = "~> 0.53.0"
     }
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ terraform {
   required_providers {
     honeycombio = {
       source  = "honeycombio/honeycombio"
-      version = "~> 0.52.0"
+      version = "~> 0.53.0"
     }
   }
 }

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -14,7 +14,7 @@ terraform {
   required_providers {
     honeycombio = {
       source  = "honeycombio/honeycombio"
-      version = "~> 0.52.0"
+      version = "~> 0.53.0"
     }
   }
 }


### PR DESCRIPTION
## Summary

Release-commit PR for v0.53.0: adds the CHANGELOG entry for the histogram column type support (#891) and two dependency bumps (#892, #890), and bumps the version references in README.md, docs/index.md, and templates/index.md.tmpl since this is a minor release.

Once merged, next step is tagging `v0.53.0` per the release procedure in CONTRIBUTING.md.