### PR TITLE
feat(client): make proactive throttling opt-in via the features block

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -46,6 +46,10 @@ type Config struct {
 	HTTPClient *http.Client
 	// Optionally set the user agent to send with all requests, defaults to "go-honeycombio".
 	UserAgent string
+	// With proactive throttling enabled the client throttles its requests
+	// when the API reports the rate limit budget as nearly or fully
+	// exhausted, rather than only reactively retrying.
+	ProactiveThrottling bool
 }
 
 // Client to interact with Honeycomb.
@@ -117,6 +121,7 @@ func NewClientWithConfig(config *Config) (*Client, error) {
 	if config.HTTPClient != nil {
 		cfg.HTTPClient = config.HTTPClient
 	}
+	cfg.ProactiveThrottling = config.ProactiveThrottling
 
 	if cfg.APIKey == "" {
 		return nil, errors.New("APIKey must be configured")
@@ -132,9 +137,11 @@ func NewClientWithConfig(config *Config) (*Client, error) {
 		headers: make(http.Header),
 	}
 
-	// proactively throttle requests when the API reports the rate limit
-	// budget is nearly or fully exhausted
-	cfg.HTTPClient.Transport = limits.NewThrottledTransport(cfg.HTTPClient.Transport)
+	if cfg.ProactiveThrottling {
+		// proactively throttle requests when the API reports the rate limit
+		// budget is nearly or fully exhausted
+		cfg.HTTPClient.Transport = limits.NewThrottledTransport(cfg.HTTPClient.Transport)
+	}
 
 	client.httpClient = &retryablehttp.Client{
 		Backoff:      limits.RetryHTTPBackoff,

--- a/client/client_internal_test.go
+++ b/client/client_internal_test.go
@@ -1,0 +1,33 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/honeycombio/terraform-provider-honeycombio/client/internal/limits"
+)
+
+func TestClient_ProactiveThrottlingOptIn(t *testing.T) {
+	t.Parallel()
+
+	t.Run("disabled by default", func(t *testing.T) {
+		c, err := NewClientWithConfig(&Config{APIKey: "abcd1234"})
+		require.NoError(t, err)
+
+		_, throttled := c.httpClient.HTTPClient.Transport.(*limits.ThrottledTransport)
+		assert.False(t, throttled, "transport should not be throttled unless enabled")
+	})
+
+	t.Run("enabled when configured", func(t *testing.T) {
+		c, err := NewClientWithConfig(&Config{
+			APIKey:              "abcd1234",
+			ProactiveThrottling: true,
+		})
+		require.NoError(t, err)
+
+		_, throttled := c.httpClient.HTTPClient.Transport.(*limits.ThrottledTransport)
+		assert.True(t, throttled, "transport should be throttled when enabled")
+	})
+}

--- a/client/v2/client.go
+++ b/client/v2/client.go
@@ -37,6 +37,10 @@ type Config struct {
 	Debug        bool
 	HTTPClient   *http.Client
 	UserAgent    string
+	// With proactive throttling enabled the client throttles its requests
+	// when the API reports the rate limit budget as nearly or fully
+	// exhausted, rather than only reactively retrying.
+	ProactiveThrottling bool
 }
 
 type Client struct {
@@ -117,12 +121,14 @@ func NewClientWithConfig(config *Config) (*Client, error) {
 			"User-Agent":    {config.UserAgent},
 		},
 	}
-	// proactively throttle requests when the API reports the rate limit
-	// budget is nearly or fully exhausted
 	if config.HTTPClient == nil {
 		config.HTTPClient = cleanhttp.DefaultPooledClient()
 	}
-	config.HTTPClient.Transport = limits.NewThrottledTransport(config.HTTPClient.Transport)
+	if config.ProactiveThrottling {
+		// proactively throttle requests when the API reports the rate limit
+		// budget is nearly or fully exhausted
+		config.HTTPClient.Transport = limits.NewThrottledTransport(config.HTTPClient.Transport)
+	}
 
 	client.http = &retryablehttp.Client{
 		Backoff:      limits.RetryHTTPBackoff,

--- a/client/v2/throttle_test.go
+++ b/client/v2/throttle_test.go
@@ -1,0 +1,37 @@
+package v2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/honeycombio/terraform-provider-honeycombio/client/internal/limits"
+)
+
+func TestClient_ProactiveThrottlingOptIn(t *testing.T) {
+	t.Parallel()
+
+	t.Run("disabled by default", func(t *testing.T) {
+		c, err := NewClientWithConfig(&Config{
+			APIKeyID:     "abcd1234",
+			APIKeySecret: "abcd1234",
+		})
+		require.NoError(t, err)
+
+		_, throttled := c.http.HTTPClient.Transport.(*limits.ThrottledTransport)
+		assert.False(t, throttled, "transport should not be throttled unless enabled")
+	})
+
+	t.Run("enabled when configured", func(t *testing.T) {
+		c, err := NewClientWithConfig(&Config{
+			APIKeyID:            "abcd1234",
+			APIKeySecret:        "abcd1234",
+			ProactiveThrottling: true,
+		})
+		require.NoError(t, err)
+
+		_, throttled := c.http.HTTPClient.Transport.(*limits.ThrottledTransport)
+		assert.True(t, throttled, "transport should be throttled when enabled")
+	})
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -125,6 +125,9 @@ Each of the blocks defined below can be optionally specified to configure the be
 ```hcl
 provider "honeycombio" {
   features {
+    client {
+      proactive_throttling = true
+    }
     column {
       import_on_conflict = true
     }
@@ -142,9 +145,15 @@ provider "honeycombio" {
 
 The `features` block supports the following:
 
+* `client` - (Optional) A `client` block as defined below.
 * `column` - (Optional) A `column` block as defined below.
 * `dataset` - (Optional) A `dataset` block as defined below.
 * `intelligence` - (Optional) An `intelligence` block as defined below.
+
+---
+The `client` block supports the following:
+* `proactive_throttling` - (Optional) Set to `true` to have the API clients proactively throttle their requests when the API reports the rate limit budget as nearly or fully exhausted, rather than only reactively retrying after receiving rate limit (HTTP 429) errors. Defaults to `false`.
+    This can significantly reduce rate limit errors for large workspaces, but may cause runs to take longer as requests are paced to stay within the API's budget.
 
 ---
 The `column` block supports the following:

--- a/honeycombio/provider.go
+++ b/honeycombio/provider.go
@@ -88,14 +88,17 @@ func Provider(version string) *schema.Provider {
 			debug = v.(bool)
 		}
 
+		parsedFeatures := features.ParsePluginSDK(d.Get("features").([]any))
+
 		// if the API key is set, use it to create the client
 		// we now rely on the Framework version of the provider to validate the configuration
 		if apiKey != "" {
 			config := &honeycombio.Config{
-				APIKey:    apiKey,
-				APIUrl:    d.Get("api_url").(string),
-				UserAgent: provider.UserAgent("terraform-provider-honeycombio", version),
-				Debug:     debug,
+				APIKey:              apiKey,
+				APIUrl:              d.Get("api_url").(string),
+				UserAgent:           provider.UserAgent("terraform-provider-honeycombio", version),
+				Debug:               debug,
+				ProactiveThrottling: parsedFeatures.Client.ProactiveThrottling,
 			}
 			c, err := honeycombio.NewClientWithConfig(config)
 			if err != nil {

--- a/internal/features/defaults.go
+++ b/internal/features/defaults.go
@@ -3,9 +3,16 @@ package features
 // DefaultFeatures returns the default features for the provider.
 func DefaultFeatures() *Features {
 	return &Features{
+		Client:       defaultClientFeatures(),
 		Column:       defaultColumnFeatures(),
 		Dataset:      defaultDatasetFeatures(),
 		Intelligence: defaultIntelligenceFeatures(),
+	}
+}
+
+func defaultClientFeatures() FeaturesClient {
+	return FeaturesClient{
+		ProactiveThrottling: false,
 	}
 }
 

--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -4,9 +4,23 @@ import "github.com/hashicorp/terraform-plugin-framework/types"
 
 // Features represents provider-level features.
 type Features struct {
+	Client       FeaturesClient
 	Column       FeaturesColumn
 	Dataset      FeaturesDataset
 	Intelligence FeaturesIntelligence
+}
+
+// FeaturesClient represents API client-specific features.
+type FeaturesClient struct {
+	// ProactiveThrottling controls whether the API clients proactively
+	// throttle requests when the API reports the rate limit budget as
+	// nearly or fully exhausted, rather than only reactively retrying.
+	ProactiveThrottling bool
+}
+
+// FeaturesClientModel represents API client-specific features for Terraform schema.
+type FeaturesClientModel struct {
+	ProactiveThrottling types.Bool `tfsdk:"proactive_throttling"`
 }
 
 // FeaturesColumn represents column-specific features.
@@ -45,6 +59,7 @@ type FeaturesIntelligenceModel struct {
 }
 
 type Model struct {
+	Client       []FeaturesClientModel       `tfsdk:"client"`
 	Column       []FeaturesColumnModel       `tfsdk:"column"`
 	Dataset      []FeaturesDatasetModel      `tfsdk:"dataset"`
 	Intelligence []FeaturesIntelligenceModel `tfsdk:"intelligence"`
@@ -58,6 +73,14 @@ func Parse(m []Model) *Features {
 		return result
 	}
 	features := m[0]
+
+	// parse client features
+	if len(features.Client) > 0 {
+		clientFeatures := features.Client[0]
+		if !clientFeatures.ProactiveThrottling.IsNull() && !clientFeatures.ProactiveThrottling.IsUnknown() {
+			result.Client.ProactiveThrottling = clientFeatures.ProactiveThrottling.ValueBool()
+		}
+	}
 
 	// parse column features
 	if len(features.Column) > 0 {
@@ -80,6 +103,35 @@ func Parse(m []Model) *Features {
 		intelligenceFeatures := features.Intelligence[0]
 		if !intelligenceFeatures.Enabled.IsNull() && !intelligenceFeatures.Enabled.IsUnknown() {
 			result.Intelligence.Enabled = intelligenceFeatures.Enabled.ValueBool()
+		}
+	}
+
+	return result
+}
+
+// ParsePluginSDK converts the raw features list from the PluginSDK-based
+// provider's configuration to the internal Features representation while
+// handling default values.
+//
+// Only client-level features are parsed: resource-level features are
+// consumed by Framework-based resources, which receive their features via
+// Parse.
+func ParsePluginSDK(raw []any) *Features {
+	result := DefaultFeatures()
+	if len(raw) == 0 {
+		return result
+	}
+	features, ok := raw[0].(map[string]any)
+	if !ok {
+		return result
+	}
+
+	// parse client features
+	if clientBlock, ok := features["client"].([]any); ok && len(clientBlock) > 0 {
+		if clientFeatures, ok := clientBlock[0].(map[string]any); ok {
+			if v, ok := clientFeatures["proactive_throttling"].(bool); ok {
+				result.Client.ProactiveThrottling = v
+			}
 		}
 	}
 

--- a/internal/features/features_test.go
+++ b/internal/features/features_test.go
@@ -14,9 +14,73 @@ func TestModelParse(t *testing.T) {
 		model := []Model{}
 		features := Parse(model)
 
+		assert.False(t, features.Client.ProactiveThrottling)
 		assert.False(t, features.Column.ImportOnConflict)
 		assert.False(t, features.Dataset.ImportOnConflict)
 		assert.False(t, features.Intelligence.Enabled)
+	})
+
+	t.Run("parses client features", func(t *testing.T) {
+		testCases := map[string]struct {
+			model  []Model
+			expect bool
+		}{
+			"parses ProactiveThrottling as false": {
+				model: []Model{
+					{
+						Client: []FeaturesClientModel{
+							{
+								ProactiveThrottling: types.BoolValue(false),
+							},
+						},
+					},
+				},
+				expect: false,
+			},
+			"parses ProactiveThrottling as true": {
+				model: []Model{
+					{
+						Client: []FeaturesClientModel{
+							{
+								ProactiveThrottling: types.BoolValue(true),
+							},
+						},
+					},
+				},
+				expect: true,
+			},
+			"handles Null": {
+				model: []Model{
+					{
+						Client: []FeaturesClientModel{
+							{
+								ProactiveThrottling: types.BoolNull(),
+							},
+						},
+					},
+				},
+				expect: false,
+			},
+			"handles Unknown": {
+				model: []Model{
+					{
+						Client: []FeaturesClientModel{
+							{
+								ProactiveThrottling: types.BoolUnknown(),
+							},
+						},
+					},
+				},
+				expect: false,
+			},
+		}
+
+		for name, tc := range testCases {
+			t.Run(name, func(t *testing.T) {
+				features := Parse(tc.model)
+				assert.Equal(t, tc.expect, features.Client.ProactiveThrottling)
+			})
+		}
 	})
 
 	t.Run("parses column features", func(t *testing.T) {
@@ -141,6 +205,55 @@ func TestModelParse(t *testing.T) {
 			t.Run(name, func(t *testing.T) {
 				features := Parse(tc.model)
 				assert.Equal(t, tc.expect, features.Dataset.ImportOnConflict)
+			})
+		}
+	})
+
+	t.Run("parses client features from PluginSDK config", func(t *testing.T) {
+		testCases := map[string]struct {
+			raw    []any
+			expect bool
+		}{
+			"handles empty features list": {
+				raw:    []any{},
+				expect: false,
+			},
+			"handles empty features block": {
+				raw:    []any{nil},
+				expect: false,
+			},
+			"handles missing client block": {
+				raw:    []any{map[string]any{}},
+				expect: false,
+			},
+			"handles empty client block": {
+				raw: []any{map[string]any{
+					"client": []any{},
+				}},
+				expect: false,
+			},
+			"parses ProactiveThrottling as false": {
+				raw: []any{map[string]any{
+					"client": []any{map[string]any{
+						"proactive_throttling": false,
+					}},
+				}},
+				expect: false,
+			},
+			"parses ProactiveThrottling as true": {
+				raw: []any{map[string]any{
+					"client": []any{map[string]any{
+						"proactive_throttling": true,
+					}},
+				}},
+				expect: true,
+			},
+		}
+
+		for name, tc := range testCases {
+			t.Run(name, func(t *testing.T) {
+				features := ParsePluginSDK(tc.raw)
+				assert.Equal(t, tc.expect, features.Client.ProactiveThrottling)
 			})
 		}
 	})

--- a/internal/features/schema.go
+++ b/internal/features/schema.go
@@ -16,6 +16,17 @@ func GetFeaturesBlock() schema.Block {
 		},
 		NestedObject: schema.NestedBlockObject{
 			Blocks: map[string]schema.Block{
+				"client": schema.ListNestedBlock{
+					MarkdownDescription: "API client features.",
+					NestedObject: schema.NestedBlockObject{
+						Attributes: map[string]schema.Attribute{
+							"proactive_throttling": schema.BoolAttribute{
+								MarkdownDescription: "Set to true to proactively throttle API requests when the API reports the rate limit budget as nearly or fully exhausted, rather than only reactively retrying.",
+								Optional:            true,
+							},
+						},
+					},
+				},
 				"column": schema.ListNestedBlock{
 					MarkdownDescription: "Column resource features.",
 					NestedObject: schema.NestedBlockObject{
@@ -63,6 +74,21 @@ func GetPluginSDKFeaturesSchema() *pluginsdk.Schema {
 		Description: "The features block allows customization of the behavior of the Honeycomb Provider.",
 		Elem: &pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{
+				"client": {
+					Type:        pluginsdk.TypeList,
+					Optional:    true,
+					MaxItems:    1,
+					Description: "API client features.",
+					Elem: &pluginsdk.Resource{
+						Schema: map[string]*pluginsdk.Schema{
+							"proactive_throttling": {
+								Type:        pluginsdk.TypeBool,
+								Optional:    true,
+								Description: "Set to true to proactively throttle API requests when the API reports the rate limit budget as nearly or fully exhausted, rather than only reactively retrying.",
+							},
+						},
+					},
+				},
 				"column": {
 					Type:        pluginsdk.TypeList,
 					Optional:    true,

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -220,10 +220,11 @@ func (p *HoneycombioProvider) Configure(ctx context.Context, req provider.Config
 
 	if initv1Client {
 		client, err := client.NewClientWithConfig(&client.Config{
-			APIKey:    apiKey,
-			APIUrl:    config.APIUrl.ValueString(),
-			Debug:     debug,
-			UserAgent: userAgent,
+			APIKey:              apiKey,
+			APIUrl:              config.APIUrl.ValueString(),
+			Debug:               debug,
+			UserAgent:           userAgent,
+			ProactiveThrottling: parsedFeatures.Client.ProactiveThrottling,
 		})
 		if helper.AddDiagnosticOnError(&resp.Diagnostics, "Unable to create Honeycomb API V1 Client", err) {
 			return
@@ -233,11 +234,12 @@ func (p *HoneycombioProvider) Configure(ctx context.Context, req provider.Config
 
 	if initv2Client {
 		v2client, err := v2client.NewClientWithConfig(&v2client.Config{
-			APIKeyID:     keyID,
-			APIKeySecret: keySecret,
-			BaseURL:      config.APIUrl.ValueString(),
-			Debug:        debug,
-			UserAgent:    userAgent,
+			APIKeyID:            keyID,
+			APIKeySecret:        keySecret,
+			BaseURL:             config.APIUrl.ValueString(),
+			Debug:               debug,
+			UserAgent:           userAgent,
+			ProactiveThrottling: parsedFeatures.Client.ProactiveThrottling,
 		})
 		if helper.AddDiagnosticOnError(&resp.Diagnostics, "Unable to create Honeycomb API V2 Client", err) {
 			return

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -125,6 +125,9 @@ Each of the blocks defined below can be optionally specified to configure the be
 ```hcl
 provider "honeycombio" {
   features {
+    client {
+      proactive_throttling = true
+    }
     column {
       import_on_conflict = true
     }
@@ -142,9 +145,15 @@ provider "honeycombio" {
 
 The `features` block supports the following:
 
+* `client` - (Optional) A `client` block as defined below.
 * `column` - (Optional) A `column` block as defined below.
 * `dataset` - (Optional) A `dataset` block as defined below.
 * `intelligence` - (Optional) An `intelligence` block as defined below.
+
+---
+The `client` block supports the following:
+* `proactive_throttling` - (Optional) Set to `true` to have the API clients proactively throttle their requests when the API reports the rate limit budget as nearly or fully exhausted, rather than only reactively retrying after receiving rate limit (HTTP 429) errors. Defaults to `false`.
+    This can significantly reduce rate limit errors for large workspaces, but may cause runs to take longer as requests are paced to stay within the API's budget.
 
 ---
 The `column` block supports the following:


### PR DESCRIPTION
## Problem

#885 wires the rate-limit-aware throttle into every client unconditionally. While it only engages when the API reports the budget as nearly gone, it's still a behavior change for all users of the provider (and the client packages) with no way to turn it off and no way to roll back short of pinning to an older release if pacing interacts badly with a workload we didn't anticipate.

## Fix

Proactive throttling is now opt-in via the provider's existing `features` block, following the same pattern as `column.import_on_conflict`:

```hcl
provider "honeycombio" {
  features {
    client {
      proactive_throttling = true
    }
  }
}
```