### PR TITLE
fix: avoid perpetual granularity diff on metrics queries/triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+## Bugfixes
+
+- fix: avoid perpetual diff when `granularity` is omitted on metrics queries/triggers (#896)
+
 # 0.51.0 (June 11, 2026)
 
 ## Enhancements

--- a/client/query_spec.go
+++ b/client/query_spec.go
@@ -193,8 +193,11 @@ func (qs *QuerySpec) EquivalentTo(other QuerySpec) bool {
 	if !reflect.DeepEqual(qs.StartTime, other.StartTime) || !reflect.DeepEqual(qs.EndTime, other.EndTime) {
 		return false
 	}
-	// Granularity may be exported out of the Query Builder as '0' when not provided
-	if PtrValueOrDefault(qs.Granularity, 0) != PtrValueOrDefault(other.Granularity, 0) {
+	// Granularity: if the config doesn't specify a granularity, accept whatever value
+	// the API has settled on (e.g. metrics datasets default to a non-zero granularity,
+	// while other datasets default to 0/auto, and the Query Builder may export it as
+	// literal '0' when not provided). Only compare when config sets one explicitly.
+	if other.Granularity != nil && PtrValueOrDefault(qs.Granularity, 0) != *other.Granularity {
 		return false
 	}
 	if !reflect.DeepEqual(qs.CompareTimeOffsetSeconds, other.CompareTimeOffsetSeconds) {

--- a/client/query_spec_test.go
+++ b/client/query_spec_test.go
@@ -116,6 +116,27 @@ func TestQuerySpec_EquivalentTo(t *testing.T) {
 			true,
 		},
 		{
+			// Metrics datasets have the API compute and persist a non-zero default
+			// granularity when the config doesn't specify one. Config omitting
+			// granularity should be considered equivalent to any state value.
+			"omitted granularity is equivalent to API-defaulted state value",
+			client.QuerySpec{
+				Granularity: client.ToPtr(30),
+			},
+			client.QuerySpec{},
+			true,
+		},
+		{
+			"explicit granularity mismatch is not equivalent",
+			client.QuerySpec{
+				Granularity: client.ToPtr(60),
+			},
+			client.QuerySpec{
+				Granularity: client.ToPtr(300),
+			},
+			false,
+		},
+		{
 			"default w/ column is not equivalent to empty",
 			client.QuerySpec{
 				Calculations: []client.CalculationSpec{

--- a/internal/provider/trigger_resource_test.go
+++ b/internal/provider/trigger_resource_test.go
@@ -2397,6 +2397,67 @@ func TestAcc_TriggerResourceWithMetrics(t *testing.T) {
 	})
 }
 
+// TestAcc_TriggerResourceWithMetricsOmittedGranularity is a regression test for
+// https://github.com/honeycombio/terraform-provider-honeycombio/issues/896: when a
+// metrics trigger's query spec omits granularity, the API fills in its own non-zero
+// default, which used to cause a perpetual diff on every subsequent plan.
+func TestAcc_TriggerResourceWithMetricsOmittedGranularity(t *testing.T) {
+	dataset := testAccMetricsDataset(t)
+	name := test.RandomStringWithPrefix("test.", 20)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 testAccPreCheck(t),
+		ProtoV6ProviderFactories: testAccProtoV6MuxServerFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfigTriggerMetricsOmittedGranularity(dataset, name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccEnsureTriggerExists(t, "honeycombio_trigger.test"),
+					resource.TestCheckResourceAttr("honeycombio_trigger.test", "name", name),
+				),
+			},
+			{
+				// re-applying the same config that omits granularity should never show a diff,
+				// even though the API has filled in its own default granularity in state.
+				Config:             testAccConfigTriggerMetricsOmittedGranularity(dataset, name),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+func testAccConfigTriggerMetricsOmittedGranularity(dataset, name string) string {
+	return fmt.Sprintf(`
+data "honeycombio_query_specification" "test" {
+  calculation {
+    op     = "AVG"
+    column = "app.cumulative"
+  }
+
+  time_range = 1800
+}
+
+resource "honeycombio_trigger" "test" {
+  name    = "%[2]s"
+  dataset = "%[1]s"
+
+  query_json = data.honeycombio_query_specification.test.json
+
+  frequency = 900
+
+  threshold {
+    op    = ">"
+    value = 1000
+  }
+
+  recipient {
+    type   = "marker"
+    target = "Metrics trigger fired"
+  }
+}`, dataset, name)
+}
+
 func testAccConfigTriggerMetricsCustom(dataset, name string) string {
 	return fmt.Sprintf(`
 data "honeycombio_query_specification" "test" {


### PR DESCRIPTION
## What

Fixes #896: `terraform plan` on a `honeycombio_trigger` (or `honeycombio_query`) targeting a metrics dataset shows a perpetual `granularity` diff when the query spec omits `granularity`, even immediately after `apply`.

## Why

Metrics datasets have the Honeycomb API compute and persist a non-zero default `granularity` when a query spec omits it. `client.QuerySpec.EquivalentTo` — the semantic-equality check backing the `query_json` plan modifier — hardcoded `0` as the assumed default on *both* sides of the comparison (a fix from an earlier issue, #404, for a different case: the Query Builder exporting a literal `0`). So an API-defaulted value like `30` never matched the config's implicit default, and the diff never resolved.

## Fix

In `client/query_spec.go`, only compare `granularity` when the config explicitly specifies a value. When config omits it, defer to whatever value is already in state — the user expressed no preference, so the API's default (0, or a metrics-specific non-zero default) is accepted either way. This preserves the original `#404` behavior (explicit `granularity: 0` from Query Builder still matches state) and still catches genuine changes (config explicitly sets a different value than state).

`honeycombio_query` shares the same plan modifier and `EquivalentTo`, so the fix applies transparently there too.

## Test plan

- [x] `client/query_spec_test.go`: added cases to `TestQuerySpec_EquivalentTo` — omitted config granularity vs. non-zero state value → equivalent; explicit config/state mismatch → not equivalent. Passing.
- [x] `internal/provider/trigger_resource_test.go`: added `TestAcc_TriggerResourceWithMetricsOmittedGranularity`, a regression test that applies a metrics trigger with `granularity` omitted, then re-plans the same config and asserts no diff (`PlanOnly`/`ExpectNonEmptyPlan: false`). Requires live credentials + `HONEYCOMB_METRICS_DATASET` to run; not exercised in this sandbox.
- [x] `go build ./...`, `go vet ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)