### PR TITLE
fix: track notification variables in resource state

### DIFF
--- a/internal/provider/burn_alert_resource_test.go
+++ b/internal/provider/burn_alert_resource_test.go
@@ -151,6 +151,26 @@ func TestAcc_BurnAlertResource_exhaustionTimeBasicWebhookRecipient(t *testing.T)
 				Config: testAccConfigBurnAlertExhaustionTime_basicWebhookRecipient(exhaustionMinutes, dataset, sloID, rcptName, rcptURL, "warning"),
 				Check:  testAccEnsureSuccessExhaustionTimeAlertWithWebhookRecip(t, burnAlert, exhaustionMinutes, sloID, "warning"),
 			},
+			// Refresh - detect a notification variable changed outside of Terraform
+			{
+				PreConfig: func() {
+					require.Len(t, burnAlert.Recipients, 1)
+					require.NotNil(t, burnAlert.Recipients[0].Details)
+					require.Len(t, burnAlert.Recipients[0].Details.Variables, 1)
+
+					burnAlert.Recipients[0].Details.Variables[0].Value = "critical"
+					_, err := testAccClient(t).BurnAlerts.Update(context.Background(), dataset, burnAlert)
+					require.NoError(t, err, "failed to update notification variable outside Terraform")
+				},
+				Config:             testAccConfigBurnAlertExhaustionTime_basicWebhookRecipient(exhaustionMinutes, dataset, sloID, rcptName, rcptURL, "warning"),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+			// Apply - restore the configured notification variable
+			{
+				Config: testAccConfigBurnAlertExhaustionTime_basicWebhookRecipient(exhaustionMinutes, dataset, sloID, rcptName, rcptURL, "warning"),
+				Check:  testAccEnsureSuccessExhaustionTimeAlertWithWebhookRecip(t, burnAlert, exhaustionMinutes, sloID, "warning"),
+			},
 			// Update - change variable value
 			{
 				Config: testAccConfigBurnAlertExhaustionTime_basicWebhookRecipient(exhaustionMinutes, dataset, sloID, rcptName, rcptURL, "info"),
@@ -161,6 +181,11 @@ func TestAcc_BurnAlertResource_exhaustionTimeBasicWebhookRecipient(t *testing.T)
 				Config: testAccConfigBurnAlertExhaustionTime_basicWebhookRecipient(exhaustionMinutes, dataset, sloID, rcptName, rcptURL, ""),
 				Check:  testAccEnsureSuccessExhaustionTimeAlertWithWebhookRecip(t, burnAlert, exhaustionMinutes, sloID, ""),
 			},
+			// Update - restore variables so import can verify notification details
+			{
+				Config: testAccConfigBurnAlertExhaustionTime_basicWebhookRecipient(exhaustionMinutes, dataset, sloID, rcptName, rcptURL, "warning"),
+				Check:  testAccEnsureSuccessExhaustionTimeAlertWithWebhookRecip(t, burnAlert, exhaustionMinutes, sloID, "warning"),
+			},
 			// Import
 			{
 				ResourceName:            "honeycombio_burn_alert.test",
@@ -168,6 +193,29 @@ func TestAcc_BurnAlertResource_exhaustionTimeBasicWebhookRecipient(t *testing.T)
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"recipient"},
+				ImportStateCheck: func(states []*terraform.InstanceState) error {
+					if len(states) != 1 {
+						return fmt.Errorf("expected 1 imported state, got %d", len(states))
+					}
+
+					expected := map[string]string{
+						"recipient.0.notification_details.#":                  "1",
+						"recipient.0.notification_details.0.variable.#":       "1",
+						"recipient.0.notification_details.0.variable.0.name":  "severity",
+						"recipient.0.notification_details.0.variable.0.value": "warning",
+					}
+					for attribute, want := range expected {
+						got, ok := states[0].Attributes[attribute]
+						if !ok {
+							return fmt.Errorf("expected imported state to contain %q", attribute)
+						}
+						if got != want {
+							return fmt.Errorf("expected imported %s to be %q, got %q", attribute, want, got)
+						}
+					}
+
+					return nil
+				},
 			},
 		},
 	})

--- a/internal/provider/notification_recipients.go
+++ b/internal/provider/notification_recipients.go
@@ -150,8 +150,11 @@ func mapNotificationRecipientToState(ctx context.Context, remote []client.Notifi
 			// if we didn't find a match, use the recipient as specified in remote
 			recipients[i] = notificationRecipientToModel(ctx, r, diags)
 		} else {
-			// if we found a match, use the stored recipient
+			// Preserve whether the recipient was authored using id or type+target,
+			// but refresh notification details so changes to live variables and
+			// PagerDuty severity are visible as drift.
 			recipients[i] = state[idx]
+			recipients[i].Details = notificationRecipientDetailsToList(ctx, r.Details, diags)
 		}
 	}
 	return recipients
@@ -171,7 +174,7 @@ func reconcileReadNotificationRecipientState(ctx context.Context, remote []clien
 				"id":                   types.StringValue(r.ID),
 				"type":                 types.StringNull(),
 				"target":               types.StringNull(),
-				"notification_details": types.ListNull(types.ObjectType{AttrTypes: models.NotificationRecipientDetailsAttrType}),
+				"notification_details": notificationRecipientDetailsToList(ctx, r.Details, diags),
 			})
 			diags.Append(d...)
 
@@ -307,7 +310,7 @@ func flattenNotificationVariables(ctx context.Context, vars []client.Notificatio
 	for _, v := range vars {
 		notifVarValues = append(notifVarValues, notificationVariableToObjectValue(v, diags))
 	}
-	notifVarResult, d := types.SetValueFrom(ctx, types.ObjectType{AttrTypes: models.WebhookHeaderAttrType}, notifVarValues)
+	notifVarResult, d := types.SetValueFrom(ctx, types.ObjectType{AttrTypes: models.NotificationVariableAttrType}, notifVarValues)
 	diags.Append(d...)
 
 	return notifVarResult

--- a/internal/provider/notification_recipients_test.go
+++ b/internal/provider/notification_recipients_test.go
@@ -69,6 +69,53 @@ func Test_reconcileReadNotificationRecipientState(t *testing.T) {
 			}),
 		},
 		{
+			name: "remote notification details replace state details",
+			args: args{
+				remote: []client.NotificationRecipient{
+					{
+						ID:   "abcd12345",
+						Type: client.RecipientTypeWebhook,
+						Details: &client.NotificationRecipientDetails{
+							Variables: []client.NotificationVariable{{Name: "severity", Value: "critical"}},
+						},
+					},
+				},
+				state: notificationRecipientModelsToSet([]models.NotificationRecipientModel{
+					{
+						ID:      types.StringValue("abcd12345"),
+						Details: notificationRecipientDetailsWithVariablesToList(client.NotificationVariable{Name: "severity", Value: "warning"}),
+					},
+				}),
+			},
+			want: notificationRecipientModelsToSet([]models.NotificationRecipientModel{
+				{
+					ID:      types.StringValue("abcd12345"),
+					Details: notificationRecipientDetailsWithVariablesToList(client.NotificationVariable{Name: "severity", Value: "critical"}),
+				},
+			}),
+		},
+		{
+			name: "import includes remote notification details",
+			args: args{
+				remote: []client.NotificationRecipient{
+					{
+						ID:   "abcd12345",
+						Type: client.RecipientTypeWebhook,
+						Details: &client.NotificationRecipientDetails{
+							Variables: []client.NotificationVariable{{Name: "severity", Value: "warning"}},
+						},
+					},
+				},
+				state: types.SetNull(elemType),
+			},
+			want: notificationRecipientModelsToSet([]models.NotificationRecipientModel{
+				{
+					ID:      types.StringValue("abcd12345"),
+					Details: notificationRecipientDetailsWithVariablesToList(client.NotificationVariable{Name: "severity", Value: "warning"}),
+				},
+			}),
+		},
+		{
 			name: "remote has additional recipients",
 			args: args{
 				remote: []client.NotificationRecipient{
@@ -136,7 +183,11 @@ func Test_reconcileReadNotificationRecipientState(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, reconcileReadNotificationRecipientState(context.Background(), tt.args.remote, tt.args.state, &diag.Diagnostics{}))
+			var diags diag.Diagnostics
+			got := reconcileReadNotificationRecipientState(context.Background(), tt.args.remote, tt.args.state, &diags)
+
+			assert.Empty(t, diags)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -151,4 +202,22 @@ func notificationRecipientModelsToSet(n []models.NotificationRecipientModel) typ
 
 func notificationRecipientDetailsToValue(s string) []attr.Value {
 	return []attr.Value{types.ObjectValueMust(models.NotificationRecipientDetailsAttrType, map[string]attr.Value{"pagerduty_severity": types.StringValue(s), "variable": types.SetNull(types.ObjectType{AttrTypes: models.NotificationVariableAttrType})})}
+}
+
+func notificationRecipientDetailsWithVariablesToList(variables ...client.NotificationVariable) types.List {
+	variableValues := make([]attr.Value, 0, len(variables))
+	for _, variable := range variables {
+		variableValues = append(variableValues, types.ObjectValueMust(models.NotificationVariableAttrType, map[string]attr.Value{
+			"name":  types.StringValue(variable.Name),
+			"value": types.StringValue(variable.Value),
+		}))
+	}
+
+	variableSet := types.SetValueMust(types.ObjectType{AttrTypes: models.NotificationVariableAttrType}, variableValues)
+	details := types.ObjectValueMust(models.NotificationRecipientDetailsAttrType, map[string]attr.Value{
+		"pagerduty_severity": types.StringValue(""),
+		"variable":           variableSet,
+	})
+
+	return types.ListValueMust(types.ObjectType{AttrTypes: models.NotificationRecipientDetailsAttrType}, []attr.Value{details})
 }


### PR DESCRIPTION
## Which problem is this PR solving?

Burn alert live notification variables returned by Honeycomb were discarded during import and refresh, hiding remote drift from Terraform.

## Short description of the changes

Preserve the configured recipient identity while rebuilding notification details from the API so variables can be imported, tracked, and reconciled.

## How to verify that this has the expected result

See tests, I think? I can't run the tests locally because they seem to require live Honeycomb API keys (!), so I'm not sure how to validate this change.

(This code is Claude-written so I don't feel super confident in it, some pointers would be appreciated.)