### PR TITLE
feat(client): serve column reads from a cached list

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -50,7 +50,7 @@ type Config struct {
 	// With read caching enabled, reads of supported resource types are
 	// served from a short-lived cache of the containing collection, so
 	// large fleets don't issue one API request per resource read.
-	// Currently supported: derived columns.
+	// Currently supported: columns, derived columns.
 	ReadCaching bool
 }
 
@@ -164,7 +164,11 @@ func NewClientWithConfig(config *Config) (*Client, error) {
 	client.Auth = &auth{client: client}
 	client.Boards = &boards{client: client}
 	client.BoardViews = &boardViews{client: client}
-	client.Columns = &columns{client: client}
+	columns := &columns{client: client}
+	if cfg.ReadCaching {
+		columns.cache = cache.New[Column](columnCacheTTL)
+	}
+	client.Columns = columns
 	client.Datasets = &datasets{client: client}
 	client.DatasetDefinitions = &datasetDefinitions{client: client}
 	derivedColumns := &derivedColumns{client: client}

--- a/client/column.go
+++ b/client/column.go
@@ -5,7 +5,15 @@ import (
 	"fmt"
 	"net/url"
 	"time"
+
+	"github.com/honeycombio/terraform-provider-honeycombio/client/internal/cache"
 )
+
+// columnCacheTTL is how long a dataset's cached column list is served
+// before being refetched. Kept short: the cache exists to collapse the
+// burst of per-resource reads within a single Terraform or Pulumi
+// operation, not to avoid refetching across operations.
+const columnCacheTTL = time.Minute
 
 // Columns describe all the columns-related methods that the Honeycomb API
 // supports.
@@ -33,8 +41,15 @@ type Columns interface {
 }
 
 // columns implements Columns.
+//
+// When read caching is enabled (Config.ReadCaching) reads are served
+// from a short-lived per-dataset cache of the full column list so that
+// large plans, refreshes, and applies don't issue one API request per
+// managed column. Writes invalidate the dataset's cached list.
 type columns struct {
 	client *Client
+	// cache is nil unless read caching is enabled.
+	cache *cache.Cache[Column]
 }
 
 // Compile-time proof of interface implementation by type columns.
@@ -88,9 +103,15 @@ func ColumnTypes() []ColumnType {
 }
 
 func (s *columns) List(ctx context.Context, dataset string) ([]Column, error) {
-	var c []Column
-	err := s.client.Do(ctx, "GET", "/1/columns/"+urlEncodeDataset(dataset), nil, &c)
-	return c, err
+	fetch := func(ctx context.Context) ([]Column, error) {
+		var c []Column
+		err := s.client.Do(ctx, "GET", "/1/columns/"+urlEncodeDataset(dataset), nil, &c)
+		return c, err
+	}
+	if s.cache == nil {
+		return fetch(ctx)
+	}
+	return s.cache.Get(ctx, urlEncodeDataset(dataset), fetch)
 }
 
 func (s *columns) Get(ctx context.Context, dataset string, id string) (*Column, error) {
@@ -100,23 +121,57 @@ func (s *columns) Get(ctx context.Context, dataset string, id string) (*Column, 
 }
 
 func (s *columns) GetByKeyName(ctx context.Context, dataset string, keyName string) (*Column, error) {
+	if s.cache != nil {
+		columns, err := s.List(ctx, dataset)
+		if err == nil {
+			for i := range columns {
+				if columns[i].KeyName == keyName {
+					return &columns[i], nil
+				}
+			}
+		}
+	}
+
+	// direct lookup: the only path when read caching is disabled, and
+	// the fallback for a cache miss — this preserves the API's error
+	// responses (e.g. a 404 for a column which truly doesn't exist)
+	// exactly as they were
 	var c Column
 	err := s.client.Do(ctx, "GET", fmt.Sprintf("/1/columns/%s?key_name=%s", urlEncodeDataset(dataset), url.QueryEscape(keyName)), nil, &c)
-	return &c, err
+	if err != nil {
+		return nil, err
+	}
+	return &c, nil
 }
 
 func (s *columns) Create(ctx context.Context, dataset string, data *Column) (*Column, error) {
 	var c Column
 	err := s.client.Do(ctx, "POST", "/1/columns/"+urlEncodeDataset(dataset), data, &c)
+	s.invalidateCache(dataset)
 	return &c, err
 }
 
 func (s *columns) Update(ctx context.Context, dataset string, data *Column) (*Column, error) {
 	var c Column
 	err := s.client.Do(ctx, "PUT", fmt.Sprintf("/1/columns/%s/%s", urlEncodeDataset(dataset), data.ID), data, &c)
+	s.invalidateCache(dataset)
 	return &c, err
 }
 
 func (s *columns) Delete(ctx context.Context, dataset string, id string) error {
-	return s.client.Do(ctx, "DELETE", fmt.Sprintf("/1/columns/%s/%s", urlEncodeDataset(dataset), id), nil, nil)
+	err := s.client.Do(ctx, "DELETE", fmt.Sprintf("/1/columns/%s/%s", urlEncodeDataset(dataset), id), nil, nil)
+	s.invalidateCache(dataset)
+	return err
+}
+
+// invalidateCache drops the cached column list a write may have made
+// stale; the next read fetches a fresh list.
+//
+// Columns are always dataset-scoped -- there is no environment-wide
+// column -- so a write can only affect its own dataset's list.
+func (s *columns) invalidateCache(dataset string) {
+	if s.cache == nil {
+		return
+	}
+	s.cache.Invalidate(urlEncodeDataset(dataset))
 }

--- a/client/column_cache_test.go
+++ b/client/column_cache_test.go
@@ -1,0 +1,259 @@
+package client_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/honeycombio/terraform-provider-honeycombio/client"
+)
+
+// columnTestAPI is a fake of the columns API which counts the list and
+// key-name-lookup requests it serves.
+type columnTestAPI struct {
+	mu      sync.Mutex
+	columns map[string][]client.Column // keyed by dataset
+
+	listRequests    atomic.Int64
+	keyNameRequests atomic.Int64
+	writeRequests   atomic.Int64
+
+	nextID int
+}
+
+func (a *columnTestAPI) handler(w http.ResponseWriter, r *http.Request) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	// path is "{dataset}" for the collection, "{dataset}/{id}" for an item
+	rest := strings.TrimPrefix(r.URL.Path, "/1/columns/")
+	dataset, id, _ := strings.Cut(rest, "/")
+
+	switch {
+	case r.Method == http.MethodGet && r.URL.Query().Has("key_name"):
+		a.keyNameRequests.Add(1)
+		for _, c := range a.columns[dataset] {
+			if c.KeyName == r.URL.Query().Get("key_name") {
+				_ = json.NewEncoder(w).Encode(c)
+				return
+			}
+		}
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"column not found"}`))
+
+	case r.Method == http.MethodGet && id == "":
+		a.listRequests.Add(1)
+		_ = json.NewEncoder(w).Encode(a.columns[dataset])
+
+	case r.Method == http.MethodPost:
+		a.writeRequests.Add(1)
+		var c client.Column
+		_ = json.NewDecoder(r.Body).Decode(&c)
+		a.nextID++
+		c.ID = fmt.Sprintf("id-%d", a.nextID)
+		a.columns[dataset] = append(a.columns[dataset], c)
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(c)
+
+	case r.Method == http.MethodPut:
+		a.writeRequests.Add(1)
+		var c client.Column
+		_ = json.NewDecoder(r.Body).Decode(&c)
+		c.ID = id
+		for i := range a.columns[dataset] {
+			if a.columns[dataset][i].ID == id {
+				a.columns[dataset][i] = c
+				_ = json.NewEncoder(w).Encode(c)
+				return
+			}
+		}
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"column not found"}`))
+
+	case r.Method == http.MethodDelete:
+		a.writeRequests.Add(1)
+		for i, c := range a.columns[dataset] {
+			if c.ID == id {
+				a.columns[dataset] = append(a.columns[dataset][:i:i], a.columns[dataset][i+1:]...)
+				w.WriteHeader(http.StatusNoContent)
+				return
+			}
+		}
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"column not found"}`))
+
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}
+}
+
+func newColumnTestClient(t *testing.T, api *columnTestAPI, opts ...testClientOption) *client.Client {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(api.handler))
+	t.Cleanup(server.Close)
+
+	cfg := &client.Config{APIKey: "test-key", APIUrl: server.URL}
+	for _, o := range opts {
+		o(cfg)
+	}
+	c, err := client.NewClientWithConfig(cfg)
+	require.NoError(t, err)
+	return c
+}
+
+func TestColumns_ReadsAreServedFromCache(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	api := &columnTestAPI{
+		columns: map[string][]client.Column{
+			"test-dataset": {
+				{ID: "id-1", KeyName: "column_1"},
+				{ID: "id-2", KeyName: "column_2"},
+			},
+		},
+	}
+	c := newColumnTestClient(t, api, withReadCaching)
+
+	// a burst of concurrent key-name reads -- as a refresh of many
+	// honeycombio_column resources produces -- collapses into a single
+	// list request
+	var wg sync.WaitGroup
+	for range 25 {
+		for _, keyName := range []string{"column_1", "column_2"} {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				col, err := c.Columns.GetByKeyName(ctx, "test-dataset", keyName)
+				assert.NoError(t, err)
+				if assert.NotNil(t, col) {
+					assert.Equal(t, keyName, col.KeyName)
+				}
+			}()
+		}
+	}
+	wg.Wait()
+
+	assert.Equal(t, int64(1), api.listRequests.Load(), "expected a single list request")
+	assert.Zero(t, api.keyNameRequests.Load(), "expected no per-key-name requests")
+
+	// List is served from the same cache
+	columns, err := c.Columns.List(ctx, "test-dataset")
+	require.NoError(t, err)
+	assert.Len(t, columns, 2)
+	assert.Equal(t, int64(1), api.listRequests.Load())
+}
+
+func TestColumns_CachingIsDisabledByDefault(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	api := &columnTestAPI{
+		columns: map[string][]client.Column{
+			"test-dataset": {{ID: "id-1", KeyName: "column_1"}},
+		},
+	}
+	// no withReadCaching: the default must preserve today's behaviour
+	c := newColumnTestClient(t, api)
+
+	for range 3 {
+		_, err := c.Columns.GetByKeyName(ctx, "test-dataset", "column_1")
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, int64(3), api.keyNameRequests.Load(), "expected one direct lookup per read")
+	assert.Zero(t, api.listRequests.Load(), "expected no list requests when caching is off")
+}
+
+func TestColumns_MissingKeyNameFallsBackToDirectLookup(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	api := &columnTestAPI{columns: map[string][]client.Column{"test-dataset": {}}}
+	c := newColumnTestClient(t, api, withReadCaching)
+
+	_, err := c.Columns.GetByKeyName(ctx, "test-dataset", "column_gone")
+
+	var detailedErr client.DetailedError
+	require.ErrorAs(t, err, &detailedErr)
+	assert.True(t, detailedErr.IsNotFound(), "expected NotFound to propagate through the cache")
+	assert.Equal(t, int64(1), api.keyNameRequests.Load(), "expected the miss to be confirmed with a direct lookup")
+}
+
+func TestColumns_WritesInvalidateTheCache(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	api := &columnTestAPI{columns: map[string][]client.Column{"test-dataset": {}}}
+	c := newColumnTestClient(t, api, withReadCaching)
+
+	// prime the cache with the empty dataset
+	columns, err := c.Columns.List(ctx, "test-dataset")
+	require.NoError(t, err)
+	assert.Empty(t, columns)
+
+	created, err := c.Columns.Create(ctx, "test-dataset", &client.Column{KeyName: "column_new"})
+	require.NoError(t, err)
+
+	// the create invalidated the cached list, so the new column is
+	// visible without a per-key-name lookup
+	col, err := c.Columns.GetByKeyName(ctx, "test-dataset", "column_new")
+	require.NoError(t, err)
+	assert.Equal(t, "column_new", col.KeyName)
+	assert.Equal(t, int64(2), api.listRequests.Load(), "expected the list to be refetched after the write")
+	assert.Zero(t, api.keyNameRequests.Load())
+
+	// so does an update
+	created.Description = "updated"
+	_, err = c.Columns.Update(ctx, "test-dataset", created)
+	require.NoError(t, err)
+	col, err = c.Columns.GetByKeyName(ctx, "test-dataset", "column_new")
+	require.NoError(t, err)
+	assert.Equal(t, "updated", col.Description)
+	assert.Equal(t, int64(3), api.listRequests.Load())
+
+	// and a delete
+	require.NoError(t, c.Columns.Delete(ctx, "test-dataset", created.ID))
+	_, err = c.Columns.GetByKeyName(ctx, "test-dataset", "column_new")
+	require.Error(t, err, "expected the deleted column to be gone from the cache")
+	assert.Equal(t, int64(4), api.listRequests.Load())
+}
+
+func TestColumns_CacheIsPerDataset(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	api := &columnTestAPI{
+		columns: map[string][]client.Column{
+			"dataset-a": {{ID: "id-1", KeyName: "column_1"}},
+			"dataset-b": {{ID: "id-2", KeyName: "column_1"}},
+		},
+	}
+	c := newColumnTestClient(t, api, withReadCaching)
+
+	a, err := c.Columns.GetByKeyName(ctx, "dataset-a", "column_1")
+	require.NoError(t, err)
+	b, err := c.Columns.GetByKeyName(ctx, "dataset-b", "column_1")
+	require.NoError(t, err)
+
+	assert.Equal(t, "id-1", a.ID)
+	assert.Equal(t, "id-2", b.ID, "each dataset must be cached under its own key")
+	assert.Equal(t, int64(2), api.listRequests.Load())
+
+	// a write to one dataset does not invalidate the other
+	_, err = c.Columns.Create(ctx, "dataset-a", &client.Column{KeyName: "column_2"})
+	require.NoError(t, err)
+	_, err = c.Columns.GetByKeyName(ctx, "dataset-b", "column_1")
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), api.listRequests.Load(), "dataset-b's cache should be untouched")
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -154,7 +154,8 @@ The `features` block supports the following:
 The `client` block supports the following:
 * `read_caching` - (Optional) Set to `true` to serve reads of supported resource types from a short-lived (60 second) cache of the containing collection, so configurations managing many resources of the same type don't issue one API request per resource read. Defaults to `false`.
     Reads confirm not-found results directly against the API, so drift is still detected. The trade-off is that a resource changed outside of Terraform within the cache window may be read stale for up to 60 seconds.
-    Currently supported resource types: derived columns.
+    Currently supported resource types: columns and derived columns (both resources and their data sources).
+    Note for columns: `last_written_at` is served from the same cache, so it may lag actual write activity by up to 60 seconds. Leave `read_caching` disabled if you depend on that attribute being current.
 
 ---
 The `column` block supports the following:

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -154,7 +154,8 @@ The `features` block supports the following:
 The `client` block supports the following:
 * `read_caching` - (Optional) Set to `true` to serve reads of supported resource types from a short-lived (60 second) cache of the containing collection, so configurations managing many resources of the same type don't issue one API request per resource read. Defaults to `false`.
     Reads confirm not-found results directly against the API, so drift is still detected. The trade-off is that a resource changed outside of Terraform within the cache window may be read stale for up to 60 seconds.
-    Currently supported resource types: derived columns.
+    Currently supported resource types: columns and derived columns (both resources and their data sources).
+    Note for columns: `last_written_at` is served from the same cache, so it may lag actual write activity by up to 60 seconds. Leave `read_caching` disabled if you depend on that attribute being current.
 
 ---
 The `column` block supports the following:


### PR DESCRIPTION
## Problem

Every column read is its own request — `GET /1/columns/{dataset}?key_name=…` — so a plan or refresh over N managed columns issues N requests in a burst against the collection route's rate limit budget.

For one large IaC fleet this is now **the worst endpoint on the API**, and it is accelerating:

| | requests (7d) | 429s | 429 share |
|---|---|---|---|
| week ending Aug 25 | 234,676 | 97,108 | 41% |
| **week ending Sep 1** | **673,505** | **537,234** | **80%** |

That is 2.9× the volume and 5.5× the rate-limited responses week over week, and it is 60% of that fleet's total API traffic. The shape is unambiguous — 99.99% of it is key-name lookups:

| count | method | status | has `key_name` |
|---|---|---|---|
| 537,234 | GET | **429** | yes |
| 133,208 | GET | 200 | yes |
| 2,973 | GET | 404 | yes |
| 49 | POST | 201/404 | no |

Forty-nine writes against 673k reads. Because the client retries 429s, a large share of those reads are retries of the *same* logical lookup.

## Fix

Extend the read cache added for derived columns in #886 to columns. The generic `cache.Cache[T]` does the work already: the first read fetches the dataset's full column list once, concurrent readers share that single fetch, and subsequent reads are answered from memory. **N per-resource reads collapse into 1 list request.**

- Writes (`Create`/`Update`/`Delete`) invalidate the dataset's cached list.
- A key name absent from the cache falls back to the direct `?key_name=` lookup, so 404/drift semantics are unchanged and a failed list degrades to exactly today's behaviour.
- Columns are always dataset-scoped — there is no environment-wide column — so unlike derived columns there is no `InvalidateAll` case.
- `Get` (by ID) is left uncached; it isn't on the hot path.

### Opt-in

This reuses the **existing** `features { client { read_caching = true } }` flag rather than adding a new one. Nothing changes for anyone who hasn't explicitly asked for it, and operators who have already opted in for derived columns get columns on the same decision.

The one behaviour worth calling out, now documented in the provider docs: `last_written_at` is served from the same cache, so it can lag actual write activity by up to the 60s TTL. It is a `Computed` attribute in both the resource and the data source, so this produces no plan churn — but anyone depending on that timestamp being current should leave `read_caching` off.

## Testing

New tests cover the collapse (50 concurrent `GetByKeyName` calls → exactly 1 list request, 0 key-name requests), that caching is **off by default** (3 reads → 3 direct lookups, 0 lists), miss-fallback propagating `IsNotFound()`, invalidation on create/update/delete, and per-dataset isolation including that a write to one dataset doesn't invalidate another. Passes with `-race`. Existing derived-column, cache, and features suites still pass; `go build`, `go vet`, and `gofmt` clean; docs and template kept in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
